### PR TITLE
Avoid importing matplotlib in production runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ install:
   - python setup.py install
 before_script:
   - python -m pyflakes .
-script: 
+  - pip install matplotlib openPMD-viewer
+script:
   - "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,9 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numba matplotlib scipy h5py
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numba scipy h5py
   - conda install --yes -c conda-forge python=$TRAVIS_PYTHON_VERSION pyfftw mpi4py
   - conda install --yes pyflakes
-  - pip install openpmd_viewer
   - python setup.py install
 before_script:
   - python -m pyflakes .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ git pull git@github.com:fbpic/fbpic.git dev
   - Make sure that the tests pass (please install `openPMD-viewer` first)
   ```
   python setup.py install
-  pip install openPMD-viewer
+  pip install matplotlib openPMD-viewer
   python setup.py test
   ```
   (Be patient: the tests can take approx. 5 min.)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ it from [here](https://www.continuum.io/downloads).
 
 - Install the dependencies of FBPIC. This can be done in two lines:
 ```
-conda install numba matplotlib scipy h5py
+conda install numba scipy h5py
 conda install -c conda-forge mpi4py pyfftw
 ```
 - Download and install FBPIC:

--- a/docs/source/install/install_jureca.rst
+++ b/docs/source/install/install_jureca.rst
@@ -41,7 +41,7 @@ In order to download and install `Anaconda <https://www.continuum.io/downloads>`
 Then install the dependencies of FBPIC:
 ::
    
-   conda install numba accelerate accelerate_cudalib matplotlib
+   conda install numba accelerate accelerate_cudalib
    conda install -c conda-forge pyfftw
 
 It is important that the following packages are **NOT** installed

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -14,7 +14,7 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
   ::
 
-     conda install numba matplotlib scipy h5py
+     conda install numba scipy h5py
      conda install -c conda-forge mpi4py pyfftw
 
 -  Install ``fbpic``

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -555,7 +555,12 @@ class InterpolationGrid(object) :
             Options to be passed to matplotlib's imshow
         """
         # matplotlib only needs to be imported if this function is called
-        import matplotlib.pyplot as plt
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            raise ImportError(
+        'The package `matplotlib` is required to show the fields.'
+        '\nPlease install it: `conda install matplotlib`')
         
         # Select the field to plot
         plotted_field = getattr( self, fieldtype)
@@ -940,7 +945,12 @@ class SpectralGrid(object) :
             Options to be passed to matplotlib's imshow
         """
         # matplotlib only needs to be imported if this function is called
-        import matplotlib.pyplot as plt
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            raise ImportError(
+        'The package `matplotlib` is required to show the fields.'
+        '\nPlease install it: `conda install matplotlib`')
 
         # Select the field to plot
         plotted_field = getattr( self, fieldtype)

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -6,7 +6,6 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the structure and methods associated with the fields.
 """
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy.constants import c, mu_0, epsilon_0
 from .spectral_transform import SpectralTransformer, cuda_installed
 
@@ -555,6 +554,9 @@ class InterpolationGrid(object) :
         kw : dictionary
             Options to be passed to matplotlib's imshow
         """
+        # matplotlib only needs to be imported if this function is called
+        import matplotlib.pyplot as plt
+        
         # Select the field to plot
         plotted_field = getattr( self, fieldtype)
         # Show the field also below the axis for a more realistic picture
@@ -937,6 +939,9 @@ class SpectralGrid(object) :
         kw : dictionary
             Options to be passed to matplotlib's imshow
         """
+        # matplotlib only needs to be imported if this function is called
+        import matplotlib.pyplot as plt
+
         # Select the field to plot
         plotted_field = getattr( self, fieldtype)
         # Fold it so as to center the 0 frequency

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 scipy
-matplotlib
 numba
 h5py
 mpi4py

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     maintainer_email='remi.lehe@normalesup.org',
     license='BSD-3-Clause-LBNL',
     packages=find_packages('./'),
-    tests_require=['pytest'],
+    tests_require=['pytest', 'matplotlib', 'openpmd_viewer'],
     cmdclass={'test': PyTest},
     install_requires=install_requires,
     platforms='any',


### PR DESCRIPTION
Before this PR, matplotlib was imported by default by fbpic (in `fields.py`). However, it is only used for some plots of the fields, which were used when developing the code, but are never used in production.

Since the latest version of matplotlib take quite some time to be imported, this PR stops importing matplotlib by default (so as not to slow down production runs). matplotlib is now only imported when using the above-mentioned plotting functions.

As a consequence, matplotlib was also removed from the dependencies of fbpic (and from the corresponding documentation). It is now only installed for running the tests (since the tests do still use matplotlib)

PS: Either of the three of you can merge this PR.

