### PR TITLE
Prevent particles from getting too far out of the box, in the periodic case

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -394,10 +394,6 @@ class BoundaryCommunicator(object):
             from a density profile: in the case the time is used in
             order to infer how much the plasma has moved)
         """
-        # Do not exchange particles for 0 guard cells (periodic, single-proc)
-        if self.n_guard == 0:
-            return
-
         # Remove out-of-domain particles from particle arrays (either on
         # CPU or GPU) and store them in sending buffers on the CPU
         send_left, send_right = remove_outside_particles( species,


### PR DESCRIPTION
For single-proc, periodic simulations, we used to skip the particle exchange, using:

``` python
# Do not exchange particles for 0 guard cells (periodic, single-proc)
if self.n_guard == 0:
       return
```

However, that also means that we were skipping these instructions, which make sure that 
particles are brought back inside the box.

``` python
         # Periodic boundary conditions for exchanging particles
         # Particles received at the right (resp. left) end of the simulation
         # box are shifted by Ltot (zmax-zmin) to the right (resp. left).
         if self.right_proc == 0:
             # The index 2 corresponds to z
             recv_right[2,:] = recv_right[2,:] + self.Ltot
         if self.left_proc == self.size-1:
             # The index 2 corresponds to z
             recv_left[2,:] = recv_left[2,:] - self.Ltot
```

This can cause problems in periodic simulations with a flowing plasma: the particles continuously move, and their positions are never brought back inside the box. This can then cause errors (which I observed) in the charge deposition, due to out-of-bound access.
(Note: the charge deposition can handle particles that are moderately far outside the box, thanks to:

``` python
        # periodic boundaries in z                                              
        # lower z boundaries                                                    
        if iz_lower < 0:
            iz_lower += Nz
        if iz_upper < 0:
            iz_upper += Nz
        # upper z boundaries                                                    
        if iz_lower > Nz-1:
            iz_lower -= Nz
        if iz_upper > Nz-1:
            iz_upper -= Nz
```

but if the particles are really too far, i.e. more than `2 Nz`, than this causes out-of-bounds)

In order to prevent the above issue, I imposed that the particle exchange is still done, in the case of periodic boundary and single-proc. 

This is somewhat inefficient for single-GPU simulations, since particles are still passed to the CPU in order to perform the exchange. However, periodic simulations are rather rare for production runs, and even in this case, the `exchange_period` can still be set to a relatively high value so as to minimize the impact of passing the particles to the CPU.
