### PR TITLE
Minor changes to the galilean documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ algorithm, its advantages and limitations, see the section :doc:`overview`.
 
 FBPIC can run either on CPU or GPU. For large
 simulations, running the code on GPU can be up to **40 times faster**
-than on CPU. 
+than on CPU.
 
 .. note::
 
@@ -30,16 +30,10 @@ than on CPU.
 
    - For **multi**-CPU and **multi**-GPU runs (using MPI), the code is not yet
      production-ready.
-     
+
    - Only linear shape factors (a.k.a. first-order shape factors) are implemented for the
      macroparticles. Third-order shape factors will be implemented in a
      future release
-
-   - The code supports **boosted-frame simulations**. However, no
-     specific mechanism against the Numerical Cherenkov Instability is
-     included in this release. In future releases, the `Galilean scheme
-     <https://arxiv.org/abs/1608.00215>`_ will be included.
-
 
 
 Contents of the documentation
@@ -76,7 +70,7 @@ Attribution
 ---------------
 
 FBPIC was originally developed by Remi Lehe at `Berkeley Lab <http://www.lbl.gov/>`_,
-and Manuel Kirchen at 
+and Manuel Kirchen at
 `CFEL, Hamburg University <http://lux.cfel.de/>`_. The code also
 benefitted from the contributions of Soeren Jalas, Kevin Peters and
 Irene Dornmair (CFEL).

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -30,7 +30,7 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
     """
     def __init__(self, zmin_lab, zmax_lab, v_lab, dt_snapshots_lab,
                  Ntot_snapshots_lab, gamma_boost, period, fldobject,
-                 comm=None, fieldtypes=["rho", "E", "B", "J"],
+                 comm=None, fieldtypes=["E", "B"],
                  write_dir=None ) :
         """
         Initialize diagnostics that retrieve the data in the lab frame,
@@ -62,6 +62,15 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
         period: int
             Number of iterations for which the data is accumulated in memory,
             before finally writing it to the disk.
+
+        fieldtypes : a list of strings, optional
+            The strings are either "rho", "E", "B" or "J"
+            and indicate which field should be written.
+            Default : only "E" and "B" are written. This is because the
+            backward Lorentz transform is not as precise for "rho" and "J" as
+            for "E" and "B" (because "rho" and "J" are staggered in time).
+            The user can still output "rho" and "J" by changing `fieldtypes`,
+            but has to be aware that there may errors in the backward transform.
         """
         # Do not leave write_dir as None, as this may conflict with
         # the default directory ('./diags') in which diagnostics in the
@@ -663,7 +672,7 @@ if cuda_installed:
             # There is a factor 2 here so as to comply with the convention in
             # Lifschitz et al., which is also the convention of Warp
             # For better performance, this factor is included in the shape
-            # factors ('t' stands for 'twice' below) 
+            # factors ('t' stands for 'twice' below)
             tSz = 2*Sz
             tSzp = 2*Szp
 


### PR DESCRIPTION
This includes two small changes:
- Remove the note in the documentation that said that the Galilean scheme is not implemented.
- By default, do not output rho and J in the boosted field diagnostic.

The second change is not ideal, but it is motivated by the fact that I often observed rho and J to be quite noisy and hard to interpret in the backward-transformed diagnostics (whereas they are fine in the untransformed diagnostics, i.e. the diagnostics within the boosted frame). This is clearly an artifact of the backward transformation for the staggered field rho and J. 
So the current default is a safe-guard for new users, so that they do not get those weird fields and wonder what happens.  Of course, they can always override this default, but in this case they will (hopefully) read the corresponding documentation/docstring and be aware of the potential issues.

@MKirchen : do you agree with this?