### PR TITLE
Close #12 and #14: Build numba function for field push and keep the ones for standard PSATD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 install:
   - conda install --yes numba scipy h5py
   - conda install --yes -c conda-forge pyfftw mpi4py
-  - conda install --yes pyflakes
+  - pip install pyflakes
   - python setup.py install
 before_script:
   - python -m pyflakes .

--- a/fbpic/fields/cuda_methods.py
+++ b/fbpic/fields/cuda_methods.py
@@ -137,29 +137,41 @@ def cuda_divide_vector_by_volume( mode0r, mode1r, mode0t, mode1t,
 # Methods of the SpectralGrid object
 # -----------------------------------
 
+@cuda.jit('void(complex128[:,:], complex128[:,:], \
+           complex128[:,:], complex128[:,:], complex128[:,:], \
+           float64[:,:], float64[:,:], float64[:,:], \
+           float64, int32, int32)')
+def cuda_correct_currents_standard( rho_prev, rho_next, Jp, Jm, Jz,
+                            kz, kr, inv_k2, inv_dt, Nz, Nr ):
+    """
+    Correct the currents in spectral space, using the standard pstad
+    """
+    # Cuda 2D grid
+    iz, ir = cuda.grid(2)
+
+    # Perform the current correction
+    if (iz < Nz) and (ir < Nr) :
+
+        # Calculate the intermediate variable F
+        F = - inv_k2[iz, ir] * (
+            (rho_next[iz, ir] - rho_prev[iz, ir])*inv_dt \
+            + 1.j*kz[iz, ir]*Jz[iz, ir] \
+            + kr[iz, ir]*( Jp[iz, ir] - Jm[iz, ir] ) )
+
+        # Correct the currents accordingly
+        Jp[iz, ir] +=  0.5 * kr[iz, ir] * F
+        Jm[iz, ir] += -0.5 * kr[iz, ir] * F
+        Jz[iz, ir] += -1.j * kz[iz, ir] * F
+
 @cuda.jit
-def cuda_correct_currents( rho_prev, rho_next, Jp, Jm, Jz,
+def cuda_correct_currents_comoving( rho_prev, rho_next, Jp, Jm, Jz,
                             kz, kr, inv_k2,
                             j_corr_coef, T_eb, T_cc,
                             inv_dt, Nz, Nr ) :
     """
-    Correct the currents in spectral space
-
-    Parameters :
-    ------------
-    rho_prev, rho_next, Jp, Jm, Jz : 2darrays of complex
-        Fields in spectral space.
-
-    kz, kr, inv_k2, j_corr_coef : 2darrays of reals
-        Constant coefficients that depend on the spectral grid
-
-    inv_dt : float
-        Inverse of the timestep
-
-    Nz, Nr : ints
-        The dimensions of the arrays
+    Correct the currents in spectral space, using the assumption
+    of comoving currents
     """
-
     # Cuda 2D grid
     iz, ir = cuda.grid(2)
 
@@ -177,19 +189,23 @@ def cuda_correct_currents( rho_prev, rho_next, Jp, Jm, Jz,
         Jm[iz, ir] += -0.5 * kr[iz, ir] * F
         Jz[iz, ir] += -1.j * kz[iz, ir] * F
 
-
-@cuda.jit
-def cuda_push_eb_with( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
+@cuda.jit('void(complex128[:,:], complex128[:,:], complex128[:,:], \
+           complex128[:,:], complex128[:,:], complex128[:,:], \
+           complex128[:,:], complex128[:,:], complex128[:,:], \
+           complex128[:,:], complex128[:,:], \
+           float64[:,:], float64[:,:], float64[:,:], \
+           float64[:,:], float64[:,:], float64[:,:], float64[:,:], float64, \
+           int8, int32, int32)')
+def cuda_push_eb_standard( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                        rho_prev, rho_next,
                        rho_prev_coef, rho_next_coef, j_coef,
-                       C, S_w, T_eb, T_cc, T_rho,
-                       kr, kz, dt, V, use_true_rho, Nz, Nr) :
+                       C, S_w, kr, kz, dt,
+                       use_true_rho, Nz, Nr) :
     """
-    Push the fields over one timestep, using the psatd algorithm
+    Push the fields over one timestep, using the standard psatd algorithm
 
     See the documentation of SpectralGrid.push_eb_with
     """
-
     # Cuda 2D grid
     iz, ir = cuda.grid(2)
 
@@ -202,11 +218,83 @@ def cuda_push_eb_with( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
         Ez_old = Ez[iz, ir]
 
         # Calculate useful auxiliary arrays
-        if use_true_rho :
+        if use_true_rho:
             # Evaluation using the rho projected on the grid
             rho_diff = rho_next_coef[iz, ir] * rho_next[iz, ir] \
                     - rho_prev_coef[iz, ir] * rho_prev[iz, ir]
-        else :
+        else:
+            # Evaluation using div(E) and div(J)
+            divE = kr[iz, ir]*( Ep[iz, ir] - Em[iz, ir] ) \
+                + 1.j*kz[iz, ir]*Ez[iz, ir]
+            divJ = kr[iz, ir]*( Jp[iz, ir] - Jm[iz, ir] ) \
+                + 1.j*kz[iz, ir]*Jz[iz, ir]
+
+            rho_diff = (rho_next_coef[iz, ir] - rho_prev_coef[iz, ir]) \
+              * epsilon_0 * divE - rho_next_coef[iz, ir] * dt * divJ
+
+        # Push the E field
+        Ep[iz, ir] = C[iz, ir]*Ep[iz, ir] + 0.5*kr[iz, ir]*rho_diff \
+            + c2*S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Bz[iz, ir] \
+            + kz[iz, ir]*Bp[iz, ir] - mu_0*Jp[iz, ir] )
+
+        Em[iz, ir] = C[iz, ir]*Em[iz, ir] - 0.5*kr[iz, ir]*rho_diff \
+            + c2*S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Bz[iz, ir] \
+            - kz[iz, ir]*Bm[iz, ir] - mu_0*Jm[iz, ir] )
+
+        Ez[iz, ir] = C[iz, ir]*Ez[iz, ir] - 1.j*kz[iz, ir]*rho_diff \
+            + c2*S_w[iz, ir]*( 1.j*kr[iz, ir]*Bp[iz, ir] \
+            + 1.j*kr[iz, ir]*Bm[iz, ir] - mu_0*Jz[iz, ir] )
+
+        # Push the B field
+        Bp[iz, ir] = C[iz, ir]*Bp[iz, ir] \
+            - S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Ez_old \
+                        + kz[iz, ir]*Ep_old ) \
+            + j_coef[iz, ir]*( -1.j*0.5*kr[iz, ir]*Jz[iz, ir] \
+                        + kz[iz, ir]*Jp[iz, ir] )
+
+        Bm[iz, ir] = C[iz, ir]*Bm[iz, ir] \
+            - S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Ez_old \
+                        - kz[iz, ir]*Em_old ) \
+            + j_coef[iz, ir]*( -1.j*0.5*kr[iz, ir]*Jz[iz, ir] \
+                        - kz[iz, ir]*Jm[iz, ir] )
+
+        Bz[iz, ir] = C[iz, ir]*Bz[iz, ir] \
+            - S_w[iz, ir]*( 1.j*kr[iz, ir]*Ep_old \
+                        + 1.j*kr[iz, ir]*Em_old ) \
+            + j_coef[iz, ir]*( 1.j*kr[iz, ir]*Jp[iz, ir] \
+                        + 1.j*kr[iz, ir]*Jm[iz, ir] )
+
+@cuda.jit
+def cuda_push_eb_comoving( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
+                       rho_prev, rho_next,
+                       rho_prev_coef, rho_next_coef, j_coef,
+                       C, S_w, T_eb, T_cc, T_rho,
+                       kr, kz, dt, V, use_true_rho, Nz, Nr) :
+    """
+    Push the fields over one timestep, using the psatd algorithm,
+    with the assumptions of comoving currents
+    (either with the galilean scheme or comoving scheme, depending on
+    the values of the coefficients that are passed)
+
+    See the documentation of SpectralGrid.push_eb_with
+    """
+    # Cuda 2D grid
+    iz, ir = cuda.grid(2)
+
+    # Push the fields
+    if (iz < Nz) and (ir < Nr) :
+
+        # Save the electric fields, since it is needed for the B push
+        Ep_old = Ep[iz, ir]
+        Em_old = Em[iz, ir]
+        Ez_old = Ez[iz, ir]
+
+        # Calculate useful auxiliary arrays
+        if use_true_rho:
+            # Evaluation using the rho projected on the grid
+            rho_diff = rho_next_coef[iz, ir] * rho_next[iz, ir] \
+                    - rho_prev_coef[iz, ir] * rho_prev[iz, ir]
+        else:
             # Evaluation using div(E) and div(J)
             divE = kr[iz, ir]*( Ep[iz, ir] - Em[iz, ir] ) \
                 + 1.j*kz[iz, ir]*Ez[iz, ir]

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -1138,11 +1138,6 @@ class PsatdCoeffs(object) :
         else:
              self.j_corr_coef = inv_dt*np.ones_like(kz)
 
-        # Allocate useful auxiliary matrices
-        self.Ep = np.zeros( (Nz, Nr), dtype='complex' )
-        self.Em = np.zeros( (Nz, Nr), dtype='complex' )
-        self.Ez = np.zeros( (Nz, Nr), dtype='complex' )
-
         # Replace these array by arrays on the GPU, when using cuda
         if use_cuda :
             self.d_C = cuda.to_device(self.C)
@@ -1154,9 +1149,6 @@ class PsatdCoeffs(object) :
             self.d_rho_prev_coef = cuda.to_device(self.rho_prev_coef)
             self.d_rho_next_coef = cuda.to_device(self.rho_next_coef)
             self.d_j_corr_coef = cuda.to_device(self.j_corr_coef)
-            # NB : Ep, Em, Ez are not needed on the GPU (on-the-fly variables)
-
-
 
 
 # -----------------

--- a/fbpic/fields/numba_methods.py
+++ b/fbpic/fields/numba_methods.py
@@ -9,13 +9,111 @@ import numba
 from scipy.constants import c, epsilon_0, mu_0
 c2 = c**2
 
+@numba.jit('void(complex128[:,:], complex128[:,:], \
+           complex128[:,:], complex128[:,:], complex128[:,:], \
+           float64[:,:], float64[:,:], float64[:,:], \
+           float64, int32, int32)')
+def numba_correct_currents_standard( rho_prev, rho_next, Jp, Jm, Jz,
+                            kz, kr, inv_k2, inv_dt, Nz, Nr ):
+    """
+    Correct the currents in spectral space, using the standard pstad
+    """
+    # Loop over the 2D grid
+    for iz in range(Nz):
+        for ir in range(Nr):
+
+            # Calculate the intermediate variable F
+            F = - inv_k2[iz, ir] * (
+                (rho_next[iz, ir] - rho_prev[iz, ir])*inv_dt \
+                + 1.j*kz[iz, ir]*Jz[iz, ir] \
+                + kr[iz, ir]*( Jp[iz, ir] - Jm[iz, ir] ) )
+
+            # Correct the currents accordingly
+            Jp[iz, ir] +=  0.5 * kr[iz, ir] * F
+            Jm[iz, ir] += -0.5 * kr[iz, ir] * F
+            Jz[iz, ir] += -1.j * kz[iz, ir] * F
+
+@numba.jit('void(complex128[:,:], complex128[:,:], complex128[:,:], \
+           complex128[:,:], complex128[:,:], complex128[:,:], \
+           complex128[:,:], complex128[:,:], complex128[:,:], \
+           complex128[:,:], complex128[:,:], \
+           float64[:,:], float64[:,:], float64[:,:], \
+           float64[:,:], float64[:,:], float64[:,:], float64[:,:], float64, \
+           int8, int32, int32)')
+def numba_push_eb_standard( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
+                       rho_prev, rho_next,
+                       rho_prev_coef, rho_next_coef, j_coef,
+                       C, S_w, kr, kz, dt,
+                       use_true_rho, Nz, Nr) :
+    """
+    Push the fields over one timestep, using the standard psatd algorithm
+
+    See the documentation of SpectralGrid.push_eb_with
+    """
+    # Loop over the 2D grid
+    for iz in range(Nz):
+        for ir in range(Nr):
+
+            # Save the electric fields, since it is needed for the B push
+            Ep_old = Ep[iz, ir]
+            Em_old = Em[iz, ir]
+            Ez_old = Ez[iz, ir]
+
+            # Calculate useful auxiliary arrays
+            if use_true_rho:
+                # Evaluation using the rho projected on the grid
+                rho_diff = rho_next_coef[iz, ir] * rho_next[iz, ir] \
+                        - rho_prev_coef[iz, ir] * rho_prev[iz, ir]
+            else:
+                # Evaluation using div(E) and div(J)
+                divE = kr[iz, ir]*( Ep[iz, ir] - Em[iz, ir] ) \
+                    + 1.j*kz[iz, ir]*Ez[iz, ir]
+                divJ = kr[iz, ir]*( Jp[iz, ir] - Jm[iz, ir] ) \
+                    + 1.j*kz[iz, ir]*Jz[iz, ir]
+
+                rho_diff = (rho_next_coef[iz, ir] - rho_prev_coef[iz, ir]) \
+                  * epsilon_0 * divE - rho_next_coef[iz, ir] * dt * divJ
+
+            # Push the E field
+            Ep[iz, ir] = C[iz, ir]*Ep[iz, ir] + 0.5*kr[iz, ir]*rho_diff \
+                + c2*S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Bz[iz, ir] \
+                + kz[iz, ir]*Bp[iz, ir] - mu_0*Jp[iz, ir] )
+
+            Em[iz, ir] = C[iz, ir]*Em[iz, ir] - 0.5*kr[iz, ir]*rho_diff \
+                + c2*S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Bz[iz, ir] \
+                - kz[iz, ir]*Bm[iz, ir] - mu_0*Jm[iz, ir] )
+
+            Ez[iz, ir] = C[iz, ir]*Ez[iz, ir] - 1.j*kz[iz, ir]*rho_diff \
+                + c2*S_w[iz, ir]*( 1.j*kr[iz, ir]*Bp[iz, ir] \
+                + 1.j*kr[iz, ir]*Bm[iz, ir] - mu_0*Jz[iz, ir] )
+
+            # Push the B field
+            Bp[iz, ir] = C[iz, ir]*Bp[iz, ir] \
+                - S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Ez_old \
+                            + kz[iz, ir]*Ep_old ) \
+                + j_coef[iz, ir]*( -1.j*0.5*kr[iz, ir]*Jz[iz, ir] \
+                            + kz[iz, ir]*Jp[iz, ir] )
+
+            Bm[iz, ir] = C[iz, ir]*Bm[iz, ir] \
+                - S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Ez_old \
+                            - kz[iz, ir]*Em_old ) \
+                + j_coef[iz, ir]*( -1.j*0.5*kr[iz, ir]*Jz[iz, ir] \
+                            - kz[iz, ir]*Jm[iz, ir] )
+
+            Bz[iz, ir] = C[iz, ir]*Bz[iz, ir] \
+                - S_w[iz, ir]*( 1.j*kr[iz, ir]*Ep_old \
+                            + 1.j*kr[iz, ir]*Em_old ) \
+                + j_coef[iz, ir]*( 1.j*kr[iz, ir]*Jp[iz, ir] \
+                            + 1.j*kr[iz, ir]*Jm[iz, ir] )
+
 @numba.jit
-def numba_correct_currents( rho_prev, rho_next, Jp, Jm, Jz,
+def numba_correct_currents_comoving( rho_prev, rho_next, Jp, Jm, Jz,
                             kz, kr, inv_k2,
                             j_corr_coef, T_eb, T_cc,
                             inv_dt, Nz, Nr ) :
     """
-    Correct the currents in spectral space
+    Correct the currents in spectral space, using the assumption
+    of comoving currents
     """
     # Loop over the 2D grid
     for iz in range(Nz):
@@ -33,13 +131,16 @@ def numba_correct_currents( rho_prev, rho_next, Jp, Jm, Jz,
             Jz[iz, ir] += -1.j * kz[iz, ir] * F
 
 @numba.jit
-def numba_push_eb_with( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
+def numba_push_eb_comoving( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                        rho_prev, rho_next,
                        rho_prev_coef, rho_next_coef, j_coef,
                        C, S_w, T_eb, T_cc, T_rho,
                        kr, kz, dt, V, use_true_rho, Nz, Nr):
     """
-    Push the fields over one timestep, using the psatd algorithm
+    Push the fields over one timestep, using the psatd algorithm,
+    with the assumptions of comoving currents
+    (either with the galilean scheme or comoving scheme, depending on
+    the values of the coefficients that are passed)
 
     See the documentation of SpectralGrid.push_eb_with
     """
@@ -53,11 +154,11 @@ def numba_push_eb_with( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
             Ez_old = Ez[iz, ir]
 
             # Calculate useful auxiliary arrays
-            if use_true_rho :
+            if use_true_rho:
                 # Evaluation using the rho projected on the grid
                 rho_diff = rho_next_coef[iz, ir] * rho_next[iz, ir] \
                         - rho_prev_coef[iz, ir] * rho_prev[iz, ir]
-            else :
+            else:
                 # Evaluation using div(E) and div(J)
                 divE = kr[iz, ir]*( Ep[iz, ir] - Em[iz, ir] ) \
                     + 1.j*kz[iz, ir]*Ez[iz, ir]

--- a/fbpic/fields/numba_methods.py
+++ b/fbpic/fields/numba_methods.py
@@ -1,0 +1,85 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines the optimized fields methods that use numba on a CPU
+"""
+import numba
+from scipy.constants import c, epsilon_0, mu_0
+c2 = c**2
+
+@numba.jit
+def numba_push_eb_with( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
+                       rho_prev, rho_next,
+                       rho_prev_coef, rho_next_coef, j_coef,
+                       C, S_w, T_eb, T_cc, T_rho,
+                       kr, kz, dt, V, use_true_rho, Nz, Nr) :
+    """
+    Push the fields over one timestep, using the psatd algorithm
+
+    See the documentation of SpectralGrid.push_eb_with
+    """
+    # Loop over the grid
+    for iz in range(Nz):
+        for ir in range(Nr):
+
+            # Save the electric fields, since it is needed for the B push
+            Ep_old = Ep[iz, ir]
+            Em_old = Em[iz, ir]
+            Ez_old = Ez[iz, ir]
+
+            # Calculate useful auxiliary arrays
+            if use_true_rho :
+                # Evaluation using the rho projected on the grid
+                rho_diff = rho_next_coef[iz, ir] * rho_next[iz, ir] \
+                        - rho_prev_coef[iz, ir] * rho_prev[iz, ir]
+            else :
+                # Evaluation using div(E) and div(J)
+                divE = kr[iz, ir]*( Ep[iz, ir] - Em[iz, ir] ) \
+                    + 1.j*kz[iz, ir]*Ez[iz, ir]
+                divJ = kr[iz, ir]*( Jp[iz, ir] - Jm[iz, ir] ) \
+                    + 1.j*kz[iz, ir]*Jz[iz, ir]
+
+                rho_diff = ( T_eb[iz,ir] * rho_next_coef[iz, ir] \
+                  - rho_prev_coef[iz, ir] ) \
+                  * epsilon_0 * divE + T_rho[iz, ir] \
+                  * rho_next_coef[iz, ir] * divJ
+
+            # Push the E field
+            Ep[iz, ir] = \
+                T_eb[iz, ir]*C[iz, ir]*Ep[iz, ir] + 0.5*kr[iz, ir]*rho_diff \
+                + j_coef[iz, ir]*1.j*kz[iz, ir]*V*Jp[iz, ir] \
+                + c2*T_eb[iz, ir]*S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Bz[iz, ir] \
+                + kz[iz, ir]*Bp[iz, ir] - mu_0*T_cc[iz, ir]*Jp[iz, ir] )
+
+            Em[iz, ir] = \
+                T_eb[iz, ir]*C[iz, ir]*Em[iz, ir] - 0.5*kr[iz, ir]*rho_diff \
+                + j_coef[iz, ir]*1.j*kz[iz, ir]*V*Jm[iz, ir] \
+                + c2*T_eb[iz, ir]*S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Bz[iz, ir] \
+                - kz[iz, ir]*Bm[iz, ir] - mu_0*T_cc[iz, ir]*Jm[iz, ir] )
+
+            Ez[iz, ir] = \
+                T_eb[iz, ir]*C[iz, ir]*Ez[iz, ir] - 1.j*kz[iz, ir]*rho_diff \
+                + j_coef[iz, ir]*1.j*kz[iz, ir]*V*Jz[iz, ir] \
+                + c2*T_eb[iz, ir]*S_w[iz, ir]*( 1.j*kr[iz, ir]*Bp[iz, ir] \
+                + 1.j*kr[iz, ir]*Bm[iz, ir] - mu_0*T_cc[iz, ir]*Jz[iz, ir] )
+
+            # Push the B field
+            Bp[iz, ir] = T_eb[iz, ir]*C[iz, ir]*Bp[iz, ir] \
+                - T_eb[iz, ir]*S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Ez_old \
+                            + kz[iz, ir]*Ep_old ) \
+                + j_coef[iz, ir]*( -1.j*0.5*kr[iz, ir]*Jz[iz, ir] \
+                            + kz[iz, ir]*Jp[iz, ir] )
+
+            Bm[iz, ir] = T_eb[iz, ir]*C[iz, ir]*Bm[iz, ir] \
+                - T_eb[iz, ir]*S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Ez_old \
+                            - kz[iz, ir]*Em_old ) \
+                + j_coef[iz, ir]*( -1.j*0.5*kr[iz, ir]*Jz[iz, ir] \
+                            - kz[iz, ir]*Jm[iz, ir] )
+
+            Bz[iz, ir] = T_eb[iz, ir]*C[iz, ir]*Bz[iz, ir] \
+                - T_eb[iz, ir]*S_w[iz, ir]*( 1.j*kr[iz, ir]*Ep_old \
+                            + 1.j*kr[iz, ir]*Em_old ) \
+                + j_coef[iz, ir]*( 1.j*kr[iz, ir]*Jp[iz, ir] \
+                            + 1.j*kr[iz, ir]*Jm[iz, ir] )


### PR DESCRIPTION
This pull request creates numba functions for the field push and the current correction, when done on the CPU.

It also reintroduces the standard PSATD functions that were replaced by the galilean/comoving functions. This is for the sake of simplicity, for users that are only interested in the standard PSATD.

Note: I did not include the change that @MKirchen requested regarding setting V to None for the standard PSATD scheme. This is because I did not want this PR to become too big. I will include this in a future PR.