### PR TITLE
Parallel boosted frame output

### DIFF
--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -115,7 +115,7 @@ def dens_func( z, r ):
     return(n)
 
 # The bunch
-bunch_zmin = z0 - 27.e-6
+bunch_zmin = z0 - 10.e-6
 bunch_zmax = bunch_zmin + 4.e-6
 bunch_rmax = 10.e-6
 bunch_gamma = 400.
@@ -173,7 +173,7 @@ if __name__ == '__main__':
                     period=diag_period, fldobject=sim.fld, comm=sim.comm),
                 BoostedParticleDiagnostic( zmin, zmax, c, dt_snapshot_lab,
                     Ntot_snapshot_lab, gamma_boost, diag_period, sim.fld, 
-                    select={'uz':[0.,None]}, species={'electrons':sim.ptcl[0]},
+                    select={'uz':[0.,None]}, species={'electrons':sim.ptcl[2]},
                     comm=sim.comm )
                     ]
 

--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -34,9 +34,9 @@ from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic, \
 use_cuda = True
 
 # The simulation box
-Nz = 1600        # Number of gridpoints along z
+Nz = 400         # Number of gridpoints along z
 zmax = 0.e-6     # Length of the box along z (meters)
-zmin = -80.e-6
+zmin = -20.e-6
 Nr = 75          # Number of gridpoints along r
 rmax = 150.e-6   # Length of the box along r (meters)
 Nm = 2           # Number of modes used
@@ -44,7 +44,7 @@ n_guard = 40     # Number of guard cells
 exchange_period = 10
 # The simulation timestep
 dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
-N_step = 101     # Number of iterations to perform
+N_step = 201     # Number of iterations to perform
                  # (increase this number for a real simulation)
 
 # Boosted frame
@@ -54,8 +54,8 @@ boost = BoostConverter(gamma_boost)
 # The laser (conversion to boosted frame is done inside 'add_laser')
 a0 = 2.          # Laser amplitude
 w0 = 50.e-6      # Laser waist
-ctau = 9.e-6     # Laser duration
-z0 = -20.e-6     # Laser centroid
+ctau = 5.e-6     # Laser duration
+z0 = -10.e-6     # Laser centroid
 zfoc = 0.e-6     # Focal position
 lambda0 = 0.8e-6 # Laser wavelength
 
@@ -135,7 +135,7 @@ v_window, = boost.velocity( [ v_window ] )
 # The diagnostics
 diag_period = 50        # Period of the diagnostics in number of timesteps
 # Whether to write the fields in the lab frame
-Ntot_snapshot_lab = 25
+Ntot_snapshot_lab = 20
 dt_snapshot_lab = (zmax-zmin)/c
 
 # ---------------------------
@@ -166,14 +166,15 @@ if __name__ == '__main__':
 
     # Add a field diagnostic
     sim.diags = [ FieldDiagnostic(diag_period, sim.fld, sim.comm ),
-                ParticleDiagnostic(diag_period,
-                    {"electrons":sim.ptcl[0], "bunch":sim.ptcl[2]}, sim.comm),
-                BoostedFieldDiagnostic( zmin, zmax, c,
+                 ParticleDiagnostic(diag_period,
+                     {"electrons":sim.ptcl[0], "bunch":sim.ptcl[2]}, sim.comm),
+                 BoostedFieldDiagnostic( zmin, zmax, c,
                     dt_snapshot_lab, Ntot_snapshot_lab, gamma_boost,
                     period=diag_period, fldobject=sim.fld, comm=sim.comm),
                 BoostedParticleDiagnostic( zmin, zmax, c, dt_snapshot_lab,
                     Ntot_snapshot_lab, gamma_boost, diag_period, sim.fld, 
-                    select={'uz':[0.,None]}, species={'electrons':sim.ptcl[0]})
+                    select={'uz':[0.,None]}, species={'electrons':sim.ptcl[0]},
+                    comm=sim.comm )
                     ]
 
     ### Run the simulation

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -16,7 +16,7 @@ import numpy as np
 from scipy.constants import c
 from .field_diag import FieldDiagnostic
 
-# If numbapro is installed, it potentially allows to use a GPU
+# If accelerate is installed, it potentially allows to use a GPU
 try :
     from fbpic.cuda_utils import cuda, cuda_tpb_bpg_1d
     cuda_installed = cuda.is_available()
@@ -184,22 +184,110 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
         for snapshot in self.snapshots:
 
             # Compact the successive slices that have been buffered
-            # over time into a single array
+            # over time into a single array, on each proc
             field_array, iz_min, iz_max = snapshot.compact_slices()
+            # Perform the Lorentz transformation of the field values
+            # *from the boosted frame to the lab frame*, on each proc
+            if field_array is not None:
+                self.slice_handler.transform_fields_to_lab_frame( field_array )
+
+            # Gather the slices on the first proc
+            if self.comm is not None:
+                global_field_array, global_iz_min, global_iz_max = \
+                    self.gather_slices( field_array, iz_min, iz_max )
+            else:
+                global_field_array = field_array
+                global_iz_min = iz_min
+                global_iz_max = iz_max
+
+            # First proc writes the global array to disk (if it is not empty)
+            if (self.rank==0) and (global_field_array is not None):
+
+                # Write to disk
+                self.write_slices( field_array, global_iz_min, global_iz_max,
+                    snapshot, self.slice_handler.field_to_index )
+
             # Erase the memory buffers
             snapshot.buffered_slices = []
             snapshot.buffer_z_indices = []
 
-            # Write this array to disk (if this snapshot has new slices)
-            if field_array is not None:
+    def gather_slices( self, field_array, iz_min, iz_max ):
+        """
+        Stitch together the field_array of the different processors
 
-                # First perform the Lorentz transformation of the field values
-                # *from the boosted frame to the lab frame*
-                self.slice_handler.transform_fields_to_lab_frame( field_array )
+        Parameters:
+        -----------
+        field_array: ndarray of reals, or None
+            If the local proc has no slice data, this is None
+            Otherwise, it is an array of shape (10, 2*Nm-1, Nr, nslice_local)
 
-                # Write to disk
-                self.write_slices( field_array, iz_min, iz_max,
-                    snapshot, self.slice_handler.field_to_index )
+        iz_min, iz_max: ints or None
+            If the local proc has no slice data, this is None
+            Otherwise, it corresponds to the indices at which the data should
+            written, in final dataset which is on disk
+
+        Returns:
+        --------
+        A tuple with:
+        global_field_array: an array of shape (10, 2*Nm-1, Nr, nslice_global),
+           or None if none of the procs had any data
+        global_izmin, global_izmax: the indices at which the global_field_array
+           should be written (or None)
+        """
+        # Gather objects into lists (one element per proc)
+        # Note: this is slow, as it uses the generic mpi4py routines gather.
+        # (This is because for some proc field_array can be None.)
+        field_array_list = self.comm.gather( field_array, comm=self.comm_world )
+        iz_min_list = self.comm.gather( iz_min, comm=self.comm_world )
+        iz_max_list = self.comm.gather( iz_max, comm=self.comm_world )
+
+        # First proc: merge the results
+        if self.rank == 0:
+
+            # Check whether any processor had some slices
+            no_slices = True
+            for f_array in field_array_list:
+                if f_array is not None:
+                    no_slices = False
+                    n_modes = f_array.shape[1] # n_modes is 2*Nm - 1
+                    Nr = f_array.shape[2]
+
+            # If there are no slices, set global quantities to None
+            if no_slices:
+                global_field_array = None
+                global_iz_min = None
+                global_iz_max = None
+
+            # If there are some slices, gather them
+            else:
+                # Find the global iz_min and global iz_max
+                global_iz_min = min([n for n in iz_min_list if n is not None])
+                global_iz_max = max([n for n in iz_max_list if n is not None])
+
+                # Allocate a the global field array, with the proper size
+                nslice = global_iz_max - global_iz_min
+                datashape = (10, n_modes, Nr, nslice)
+                global_array = np.zeros( data_shape )
+
+                # Loop through all the processors
+                # Fit the field arrays one by one into the global_array
+                for i_proc in xrange(self.top.nprocs):
+
+                    # If this proc has no data, skip it
+                    if field_array_list[ i_proc ] is None:
+                        continue
+                    # Longitudinal indices within the array global_array
+                    s_min = iz_min_list[ i_proc ] - global_iz_min
+                    s_max = iz_max_list[ i_proc ] - global_iz_min
+                    # Copy the array to the proper position
+                    global_array[:,:,:, s_min:s_max] = field_array_list[i_proc]
+
+            # The first proc returns the result
+            return( global_field_array, global_iz_min, global_iz_max )
+
+        # Other processors return a dummy placeholder
+        else:
+            return( None, None, None )
 
     def write_slices( self, field_array, iz_min, iz_max, snapshot, f2i ):
         """

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -204,8 +204,8 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
             if (self.rank==0) and (global_field_array is not None):
 
                 # Write to disk
-                self.write_slices( field_array, global_iz_min, global_iz_max,
-                    snapshot, self.slice_handler.field_to_index )
+                self.write_slices( global_field_array, global_iz_min,
+                    global_iz_max, snapshot, self.slice_handler.field_to_index)
 
             # Erase the memory buffers
             snapshot.buffered_slices = []
@@ -237,9 +237,10 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
         # Gather objects into lists (one element per proc)
         # Note: this is slow, as it uses the generic mpi4py routines gather.
         # (This is because for some proc field_array can be None.)
-        field_array_list = self.comm.gather( field_array, comm=self.comm_world )
-        iz_min_list = self.comm.gather( iz_min, comm=self.comm_world )
-        iz_max_list = self.comm.gather( iz_max, comm=self.comm_world )
+        mpi_comm = self.comm.mpi_comm
+        field_array_list = mpi_comm.gather( field_array )
+        iz_min_list = mpi_comm.gather( iz_min )
+        iz_max_list = mpi_comm.gather( iz_max )
 
         # First proc: merge the results
         if self.rank == 0:
@@ -266,21 +267,22 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
 
                 # Allocate a the global field array, with the proper size
                 nslice = global_iz_max - global_iz_min
-                datashape = (10, n_modes, Nr, nslice)
-                global_array = np.zeros( data_shape )
+                data_shape = (10, n_modes, Nr, nslice)
+                global_field_array = np.zeros( data_shape )
 
                 # Loop through all the processors
-                # Fit the field arrays one by one into the global_array
-                for i_proc in xrange(self.top.nprocs):
+                # Fit the field arrays one by one into the global_field_array
+                for i_proc in range(self.comm.size):
 
                     # If this proc has no data, skip it
                     if field_array_list[ i_proc ] is None:
                         continue
-                    # Longitudinal indices within the array global_array
+                    # Longitudinal indices within the array global_field_array
                     s_min = iz_min_list[ i_proc ] - global_iz_min
                     s_max = iz_max_list[ i_proc ] - global_iz_min
                     # Copy the array to the proper position
-                    global_array[:,:,:, s_min:s_max] = field_array_list[i_proc]
+                    global_field_array[:,:,:, s_min:s_max] = \
+                                                    field_array_list[i_proc]
 
             # The first proc returns the result
             return( global_field_array, global_iz_min, global_iz_max )

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -210,7 +210,7 @@ class BoostedParticleDiagnostic(ParticleDiagnostic):
 
                 snapshot.buffered_slices[species_name] = []
 
-    def gather_particle_arrays( array, root=0 ):
+    def gather_particle_arrays( self, array, root=0 ):
         """
         Gather the compacted arrays of particle slices, on the
 
@@ -230,7 +230,7 @@ class BoostedParticleDiagnostic(ParticleDiagnostic):
         """
         # Send the local number of particles to all procs
         n_particles_local = array.shape[1]
-        n_particles_list = self.comm.allgather( n_particles_local )
+        n_particles_list = self.comm.mpi_comm.allgather( n_particles_local )
 
         # Prepare the send and receive buffers
         if self.rank == root:
@@ -246,7 +246,7 @@ class BoostedParticleDiagnostic(ParticleDiagnostic):
         recvbuf = [ gathered_array, n_size_procs, i_start_procs, REAL8 ]
 
         # Send/receive the arrays
-        self.mpi_comm.Gatherv( sendbuf, recvbuf, root=root )
+        self.comm.mpi_comm.Gatherv( sendbuf, recvbuf, root=root )
 
         # Return the receive buffer
         return( recvbuf )

--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -8,7 +8,7 @@ It makes sure that the example input scripts in `docs/source/example_input`
 runs **without crashing**. It runs the following scripts:
 - lwfa_script.py with a single proc
 - lwfa_script.py with two proc using checkpoint and restart
-- boosted_frame_script.py with a single proc
+- boosted_frame_script.py with two procs
 - parametric_script.py with two procs
 **It does not actually check the validity of the physics involved.**
 
@@ -73,7 +73,7 @@ def test_lpa_sim_twoproc_restart():
     script = script.replace('save_checkpoints = False',
                                 'save_checkpoints = True')
     script = script.replace('N_step = 200', 'N_step = 101')
-    with open('lwfa_script.py', 'w') as f: 
+    with open('lwfa_script.py', 'w') as f:
         f.write(script)
     # Launch the modified script from the OS, with 2 proc
     response = os.system( 'mpirun -np 2 python lwfa_script.py' )
@@ -84,7 +84,7 @@ def test_lpa_sim_twoproc_restart():
                                 'use_restart = True')
     script = script.replace('save_checkpoints = True',
                                 'save_checkpoints = False')
-    with open('lwfa_script.py', 'w') as f: 
+    with open('lwfa_script.py', 'w') as f:
         f.write(script)
     # Launch the modified script from the OS, with 2 proc
     response = os.system( 'mpirun -np 2 python lwfa_script.py' )
@@ -94,9 +94,8 @@ def test_lpa_sim_twoproc_restart():
     os.chdir('../../')
     shutil.rmtree( temporary_dir )
 
-
-def test_boosted_frame_sim_singleproc():
-    "Test the example input script with one proc in `docs/source/example_input`"
+def test_boosted_frame_sim_twoproc():
+    "Test the example input script with two procs in `docs/source/example_input`"
 
     temporary_dir = './tests/tmp_test_dir'
 
@@ -111,7 +110,7 @@ def test_boosted_frame_sim_singleproc():
     # Enter the temporary directory and run the script
     os.chdir( temporary_dir )
     # Launch the script from the OS
-    response = os.system( 'python boosted_frame_script.py' )
+    response = os.system( 'mpirun -np 2 python boosted_frame_script.py' )
     assert response==0
 
     # Exit the temporary directory and suppress it
@@ -122,7 +121,7 @@ def test_parametric_sim_twoproc():
     "Test the example input script with two proc in `docs/source/example_input`"
 
     temporary_dir = './tests/tmp_test_dir'
-    
+
     # Create a temporary directory for the simulation
     # and copy the example script into this directory
     if os.path.exists( temporary_dir ):
@@ -149,13 +148,13 @@ def test_parametric_sim_twoproc():
         # expected one.
         a0_in_diag = ts.get_a0( iteration=40, pol='x' )
         assert abs( (a0 - a0_in_diag)/a0 ) < 1.e-2
-    
+
     # Exit the temporary directory and suppress it
     os.chdir('../../')
     shutil.rmtree( temporary_dir )
-    
+
 if __name__ == '__main__':
     test_lpa_sim_singleproc()
     test_lpa_sim_twoproc_restart()
-    test_boosted_frame_sim_singleproc()
+    test_boosted_frame_sim_twoproc()
     test_parametric_sim_twoproc()


### PR DESCRIPTION
This generalizes the boosted-frame output to the case of a multi-CPU or multi-GPU.

The implementation is similar to that of [Warp](https://bitbucket.org/berkeleylab/warp).

More specifically, the data that needs to be written is cached on each processor until the simulation reaches an output iteration (as defined by the parameter `diag_period`). Then this cached data is gathered on rank 0, and rank 0 writes the data to disk.

Note: I also modified the boosted-frame example input script (to make it faster to run), and switched the boosted-frame automated test from single proc to two-proc. (So that the parallel boosted frame output are automatically tested for each push.)