### PR TITLE
Close #25 : Fix single-proc periodic simulations on GPU

### DIFF
--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -549,7 +549,8 @@ if cuda_installed:
         # Get box length
         l_box = zmax - zmin
         # Shift particle position
-        while z[i] >= zmax:
-            z[i] -= l_box
-        while z[i] < zmin:
-            z[i] += l_box
+        if i < z.shape[0]:
+            while z[i] >= zmax:
+                z[i] -= l_box
+            while z[i] < zmin:
+                z[i] += l_box

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -326,6 +326,8 @@ class Simulation(object):
                 # This includes MPI exchange of particles, removal of
                 # out-of-box particles and (if there is a moving window)
                 # injection of new particles by the moving window.
+                # (In the case of single-proc periodic simulations, particles
+                # are shifted by one box length, so they remain inside the box.) 
                 for species in self.ptcl:
                     self.comm.exchange_particles(species, fld, self.time)
 


### PR DESCRIPTION
This pull request solves issue #25 (Test of Cherenkov instability yields different result on the GPU).

The issue appeared in the case of a single-proc, periodic simulation, when the bulk of the plasma has a non-zero velocity. In this case, the particles progressively go out of the box. In principle, the pull request #9 (Prevent particles from getting too far out of the box, in the periodic case) should take care of that by forcing the exchange of particles even in the single-proc, periodic case. However, the changes of pull request #9 only work on the CPU (this is because, on the GPU, the exchange of particles relies on the presence of guard cells, but no guard cells are present in the single-proc, periodic case.)

Therefore, instead of using the standard particle exchange, the present pull request introduces a different means of keeping the particles inside the box, in the single-proc, periodic case: for the particles that are outside of the box, their z position is shifted by an integer number of box length so that they are back in the box again. 

I reran the test of issue #25 (test_boosted.py) with the code from this pull request, and it solves the issue: below is the evolution of the instability **on the GPU**.

![figure_1_gpu](https://cloud.githubusercontent.com/assets/6685781/21584873/1ad0b57e-d069-11e6-97b6-40abd4fa8f1c.png)
