### PR TITLE
Proposed changes to 3rd order implementation in all files except `linear.py` and `cubic.py`

### DIFF
--- a/fbpic/lpa_utils/laser/antenna.py
+++ b/fbpic/lpa_utils/laser/antenna.py
@@ -1,5 +1,5 @@
 # Copyright 2016, FBPIC contributors
-# Authors: Remi Lehe, Manuel Kirchen
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
 # License: 3-Clause-BSD-LBNL
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)

--- a/fbpic/lpa_utils/laser/antenna.py
+++ b/fbpic/lpa_utils/laser/antenna.py
@@ -48,6 +48,8 @@ class LaserAntenna( object ):
     For GPU performance, the charge/current are deposited in a small-size array
     (corresponding to a thin slice in z) which is then transfered to the GPU
     and added into the full-size array of charge/current.
+    Note that the antenna always uses linear shape factors (even when the
+    rest of the simulation uses cubic shape factors.)
     """
     def __init__( self, E0, w0, ctau, z0, zf, k0,
                     theta_pol, z0_antenna, dr_grid, Nr_grid, Nm,
@@ -326,20 +328,20 @@ class LaserAntenna( object ):
         grid: a list of InterpolationGrid object
             The grids on which to the deposit the charge/current
 
-        iz, ir :  2darray of ints
-            (one element per macroparticle per cell)
-            Contains the index of the cells that the macro particle
-            will gather from.
-            i.E.: iz[2][1] is the cell index of the 3. Cell(from left)
-            of the particle with number 1.
+        iz, ir : 2darray of ints
+            Arrays of shape (shape_order+1, Ntot)
+            where Ntot is the number of macroparticles.
+            Contains the index of the cells that each virtual macroparticle
+            will deposit to.
             (In the case of the laser antenna, these arrays are constant
             in principle; but they are kept as arrays for compatibility
             with the deposit_field_numba function.)
 
         Sz, Sr: 2darray of ints
-            (one element per macroparticle per cell)
-            Contains the weight for respective sells from iz and ir
-            per partice
+            Arrays of shape (shape_order+1, Ntot)
+            where Ntot is the number of macroparticles
+            Contains the weight for respective cells from iz and ir,
+            for each macroparticle.
         """
         # Position of the particles
         x = self.baseline_x + q*self.excursion_x

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -164,11 +164,11 @@ class Simulation(object):
               parameters and output folder depend on the MPI rank.
 
         particle_shape: str, optional
-            This attribute sets the particle shape for the deposition steps
+            Set the particle shape for the charge/current deposition.
             Possible values are 'cubic', 'linear' and 'linear_non_atomic'.
-            While 'cubic' is identified with third order shapes and linear
-            with first order shapes, 'linear_non_atomic' uses an equivalent
-            deposition scheme to 'linear' which is for now supported for tests.
+            While 'cubic' corresponds to third order shapes and 'linear'
+            to first order shapes, 'linear_non_atomic' uses an equivalent
+            deposition scheme to 'linear' which avoids atomics on the GPU.
         """
         # Check whether to use cuda
         self.use_cuda = use_cuda

--- a/fbpic/particles/cuda_deposition/cubic.py
+++ b/fbpic/particles/cuda_deposition/cubic.py
@@ -1,5 +1,5 @@
 # Copyright 2016, FBPIC contributors
-# Authors: Remi Lehe, Manuel Kirchen
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
 # License: 3-Clause-BSD-LBNL
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)

--- a/fbpic/particles/cuda_deposition/linear.py
+++ b/fbpic/particles/cuda_deposition/linear.py
@@ -1,5 +1,5 @@
 # Copyright 2016, FBPIC contributors
-# Authors: Remi Lehe, Manuel Kirchen
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
 # License: 3-Clause-BSD-LBNL
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)

--- a/fbpic/particles/cuda_deposition/linear_non_atomic.py
+++ b/fbpic/particles/cuda_deposition/linear_non_atomic.py
@@ -1,5 +1,5 @@
 # Copyright 2016, FBPIC contributors
-# Authors: Remi Lehe, Manuel Kirchen
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
 # License: 3-Clause-BSD-LBNL
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)

--- a/fbpic/particles/cuda_methods.py
+++ b/fbpic/particles/cuda_methods.py
@@ -1,5 +1,5 @@
 # Copyright 2016, FBPIC contributors
-# Authors: Remi Lehe, Manuel Kirchen
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
 # License: 3-Clause-BSD-LBNL
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)

--- a/fbpic/particles/cuda_methods.py
+++ b/fbpic/particles/cuda_methods.py
@@ -482,7 +482,7 @@ def gather_field_gpu_cubic(x, y, z,
     """
     Gathering of the fields (E and B) using numba on the GPU.
     Iterates over the particles, calculates the weighted amount
-    of fields acting on each particle based on its shape (linear).
+    of fields acting on each particle based on its shape (cubic).
     Fields are gathered in cylindrical coordinates and then
     transformed to cartesian coordinates.
     Supports only mode 0 and 1.
@@ -609,9 +609,11 @@ def gather_field_gpu_cubic(x, y, z,
                 Fr_m += Sz[index_z]*Sr[index_r]*Er_m0[iz[index_z], ir[index_r]]
                 Ft_m += Sz[index_z]*Sr[index_r]*Et_m0[iz[index_z], ir[index_r]]
                 if Sz[index_z]*Sr[index_r] < 0:
-                    Fz_m += (-1.)*Sz[index_z]*Sr[index_r]*Ez_m0[iz[index_z], ir[index_r]]
+                    Fz_m += (-1.)*Sz[index_z]*Sr[index_r]* \
+                        Ez_m0[iz[index_z], ir[index_r]]
                 else:
-                    Fz_m += Sz[index_z]*Sr[index_r]*Ez_m0[iz[index_z], ir[index_r]]
+                    Fz_m += Sz[index_z]*Sr[index_r]* \
+                        Ez_m0[iz[index_z], ir[index_r]]
 
         Fr += (Fr_m*exptheta_m0).real
         Ft += (Ft_m*exptheta_m0).real
@@ -628,11 +630,15 @@ def gather_field_gpu_cubic(x, y, z,
         for index_r in range(4):
             for index_z in range(4):
                 if Sz[index_z]*Sr[index_r] < 0:
-                    Fr_m += (-1.)*Sz[index_z]*Sr[index_r]*Er_m1[iz[index_z], ir[index_r]]
-                    Ft_m += (-1.)*Sz[index_z]*Sr[index_r]*Et_m1[iz[index_z], ir[index_r]]
+                    Fr_m += (-1.)*Sz[index_z]*Sr[index_r]* \
+                                Er_m1[iz[index_z], ir[index_r]]
+                    Ft_m += (-1.)*Sz[index_z]*Sr[index_r]* \
+                                Et_m1[iz[index_z], ir[index_r]]
                 else:
-                    Fr_m += Sz[index_z]*Sr[index_r]*Er_m1[iz[index_z], ir[index_r]]
-                    Ft_m += Sz[index_z]*Sr[index_r]*Et_m1[iz[index_z], ir[index_r]]
+                    Fr_m += Sz[index_z]*Sr[index_r]* \
+                                Er_m1[iz[index_z], ir[index_r]]
+                    Ft_m += Sz[index_z]*Sr[index_r]* \
+                                Et_m1[iz[index_z], ir[index_r]]
                 Fz_m += Sz[index_z]*Sr[index_r]*Ez_m1[iz[index_z], ir[index_r]]
 
         # Add the fields from the mode 1
@@ -664,12 +670,16 @@ def gather_field_gpu_cubic(x, y, z,
         # Add the fields for mode 0
         for index_r in range(4):
             for index_z in range(4):
-                Fr_m += Sz[index_z]*Sr[index_r]*Br_m0[iz[index_z], ir[index_r]]
-                Ft_m += Sz[index_z]*Sr[index_r]*Bt_m0[iz[index_z], ir[index_r]]
+                Fr_m += Sz[index_z]*Sr[index_r]* \
+                    Br_m0[iz[index_z], ir[index_r]]
+                Ft_m += Sz[index_z]*Sr[index_r]* \
+                    Bt_m0[iz[index_z], ir[index_r]]
                 if Sz[index_z]*Sr[index_r] < 0:
-                    Fz_m += (-1.)*Sz[index_z]*Sr[index_r]*Bz_m0[iz[index_z], ir[index_r]]
+                    Fz_m += (-1.)*Sz[index_z]*Sr[index_r]* \
+                        Bz_m0[iz[index_z], ir[index_r]]
                 else:
-                    Fz_m += Sz[index_z]*Sr[index_r]*Bz_m0[iz[index_z], ir[index_r]]
+                    Fz_m += Sz[index_z]*Sr[index_r]* \
+                        Bz_m0[iz[index_z], ir[index_r]]
 
         # Add the fields from the mode 0
         Fr += (Fr_m*exptheta_m0).real
@@ -688,11 +698,15 @@ def gather_field_gpu_cubic(x, y, z,
         for index_r in range(4):
             for index_z in range(4):
                 if Sz[index_z]*Sr[index_r] < 0:
-                    Fr_m += (-1.)*Sz[index_z]*Sr[index_r]*Br_m1[iz[index_z], ir[index_r]]
-                    Ft_m += (-1.)*Sz[index_z]*Sr[index_r]*Bt_m1[iz[index_z], ir[index_r]]
+                    Fr_m += (-1.)*Sz[index_z]*Sr[index_r]* \
+                        Br_m1[iz[index_z], ir[index_r]]
+                    Ft_m += (-1.)*Sz[index_z]*Sr[index_r]* \
+                        Bt_m1[iz[index_z], ir[index_r]]
                 else:
-                    Fr_m += Sz[index_z]*Sr[index_r]*Br_m1[iz[index_z], ir[index_r]]
-                    Ft_m += Sz[index_z]*Sr[index_r]*Bt_m1[iz[index_z], ir[index_r]]
+                    Fr_m += Sz[index_z]*Sr[index_r]* \
+                        Br_m1[iz[index_z], ir[index_r]]
+                    Ft_m += Sz[index_z]*Sr[index_r]* \
+                        Bt_m1[iz[index_z], ir[index_r]]
                 Fz_m += Sz[index_z]*Sr[index_r]*Bz_m1[iz[index_z], ir[index_r]]
 
         # Add the fields from the mode 1

--- a/fbpic/particles/numba_methods.py
+++ b/fbpic/particles/numba_methods.py
@@ -1,5 +1,5 @@
 # Copyright 2016, FBPIC contributors
-# Authors: Remi Lehe, Manuel Kirchen
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
 # License: 3-Clause-BSD-LBNL
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -1,5 +1,5 @@
 # Copyright 2016, FBPIC contributors
-# Authors: Remi Lehe, Manuel Kirchen
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
 # License: 3-Clause-BSD-LBNL
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
@@ -111,11 +111,11 @@ class Particles(object) :
             to initialize the sorting of the particles per cell.
 
         particle_shape: str, optional
-            This attribute sets the particle shape for the deposition steps
+            Set the particle shape for the charge/current deposition.
             Possible values are 'cubic', 'linear' and 'linear_non_atomic'.
-            While 'cubic' is identified with third order shapes and linear
-            with first order shapes, 'linear_non_atomic' uses an equivalent
-            deposition scheme to 'linear' which is for now supported for tests.
+            While 'cubic' corresponds to third order shapes and 'linear'
+            to first order shapes, 'linear_non_atomic' uses an equivalent
+            deposition scheme to 'linear' which avoids atomics on the GPU.
         """
         # Register the timestep
         self.dt = dt

--- a/fbpic/particles/utility_methods.py
+++ b/fbpic/particles/utility_methods.py
@@ -1,5 +1,5 @@
 # Copyright 2016, FBPIC contributors
-# Authors: Remi Lehe, Manuel Kirchen
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
 # License: 3-Clause-BSD-LBNL
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
@@ -37,7 +37,7 @@ def weights(x, invdx, offset, Nx, direction, shape_order):
 
     shape_order : int
         Order of the shape factor.
-        Either 1, 2 or 3
+        Either 1 or 3
 
 
     -------

--- a/fbpic/particles/utility_methods.py
+++ b/fbpic/particles/utility_methods.py
@@ -43,17 +43,17 @@ def weights(x, invdx, offset, Nx, direction, shape_order):
     --------
     A tuple containing :
 
-    i: 2darray of floats
-        An array of shape (shape_order+1, Nptcl)
-        where Nptcl is the number of macroparticles
+    i: 2darray of ints
+        An array of shape (shape_order+1, Ntot)
+        where Ntot is the number of macroparticles
         (i.e. the number of elements in the array x)
         This array contains the indices of the grid cells
         (along the axis specified by `direction`) where each macroparticle
         deposits charge/current and gathers field data.
 
     S: 2darray of floats
-        An array of shape (shape_order+1, Nptcl)
-        where Nptcl is the number of macroparticles
+        An array of shape (shape_order+1, Ntot)
+        where Ntot is the number of macroparticles
         (i.e. the number of elements in the array x)
         This array contains the shape factors (a.k.a. interpolation weights)
         that correspond to each of the indices in the array `i`.

--- a/tests/test_laser_antenna.py
+++ b/tests/test_laser_antenna.py
@@ -12,8 +12,6 @@ longitudinal resolution on the amplitude of the emitted laser:
 below ~30 points per laser wavelength, the emitted a0 can be ~10%
 smaller than the desired value.
 
-This is tested for different particle shapes.
-
 Usage :
 -------
 In order to show the images of the laser, and manually check the
@@ -38,7 +36,7 @@ from fbpic.lpa_utils.boosted_frame import BoostConverter
 
 # Parameters
 # ----------
-show = False
+show = True
 write_files = True
 # Whether to show the plots, and check them manually
 use_cuda = True
@@ -66,41 +64,21 @@ N_show = 3 # Number of instants in which to show the plots (during propagation)
 # The boost in the case of the boosted frame run
 gamma_boost = 10.
 
-def test_antenna_labframe_cubic(show=False, write_files=False):
+def test_antenna_labframe(show=False, write_files=False):
     """
     Function that is run by py.test, when doing `python setup.py test`
     Test the emission of a laser by an antenna, in the lab frame
     """
-    run_and_check_laser_antenna(None, 'cubic', show, write_files)
+    run_and_check_laser_antenna(None, show, write_files)
 
-def test_antenna_labframe_linear(show=False, write_files=False):
-    """
-    Function that is run by py.test, when doing `python setup.py test`
-    Test the emission of a laser by an antenna, in the lab frame
-    """
-    run_and_check_laser_antenna(None, 'linear', show, write_files)
-    if use_cuda:
-        run_and_check_laser_antenna(None, 'linear_non_atomic', 
-                                    show, write_files)
-
-def test_antenna_boostedframe_cubic(show=False, write_files=False):
+def test_antenna_boostedframe(show=False, write_files=False):
     """
     Function that is run by py.test, when doing `python setup.py test`
     Test the emission of a laser by an antenna, in the boosted frame
     """
-    run_and_check_laser_antenna(gamma_boost, 'cubic', show, write_files)
+    run_and_check_laser_antenna(gamma_boost, show, write_files)
 
-def test_antenna_boostedframe_linear(show=False, write_files=False):
-    """
-    Function that is run by py.test, when doing `python setup.py test`
-    Test the emission of a laser by an antenna, in the boosted frame
-    """
-    run_and_check_laser_antenna(gamma_boost, 'linear', show, write_files)
-    if use_cuda:
-        run_and_check_laser_antenna(gamma_boost, 'linear_non_atomic', 
-                                show, write_files)
-
-def run_and_check_laser_antenna(gamma_b, shape, show, write_files):
+def run_and_check_laser_antenna(gamma_b, show, write_files):
     """
     Generic function, which runs and check the laser antenna for 
     both boosted frame and lab frame
@@ -109,9 +87,6 @@ def run_and_check_laser_antenna(gamma_b, shape, show, write_files):
     ----------
     gamma_b: float or None
         The Lorentz factor of the boosted frame
-
-    shape: string
-        Indicates the particle shape that is being used
 
     show: bool
         Whether to show the images of the laser as pop-up windows
@@ -123,7 +98,7 @@ def run_and_check_laser_antenna(gamma_b, shape, show, write_files):
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, p_zmin=0, p_zmax=0,
                     p_rmin=0, p_rmax=0, p_nz=2, p_nr=2, p_nt=2, n_e=0.,
                     zmin=zmin, use_cuda=use_cuda, boundaries='open',
-                    gamma_boost=gamma_b, particle_shape=shape)
+                    gamma_boost=gamma_b)
 
     # Remove the particles
     sim.ptcl = []
@@ -157,7 +132,7 @@ def run_and_check_laser_antenna(gamma_b, shape, show, write_files):
     sim.step( Ntot_step - N_show*N_step, show_progress=False )
 
     # Check the transverse E and B field
-    Nz_half = int(sim.fld.interp[1].Nz/2) + 2
+    Nz_half = sim.fld.interp[1].Nz/2 + 2
     z = sim.fld.interp[1].z[Nz_half:-sim.comm.n_guard]
     r = sim.fld.interp[1].r
     # Loop through the different fields
@@ -246,7 +221,5 @@ def gaussian_laser( z, r, a0, z0_phase, z0_prop, ctau, lambda0 ):
 if __name__ == '__main__' :
 
     # Run the testing functions
-    test_antenna_labframe_cubic(show, write_files)
-    test_antenna_labframe_linear(show, write_files)
-    test_antenna_boostedframe_cubic(show, write_files)
-    test_antenna_boostedframe_linear(show, write_files)
+    test_antenna_labframe(show, write_files)
+    test_antenna_boostedframe(show, write_files)


### PR DESCRIPTION
Hi Kevin,

Here are a few suggested changes to the pull request on 3rd order shape factor (except for the files `linear.py` and `cubic.py`, for which I will propose changes in a separate pull request).

Feel free to reject/discuss some of these changes, they are only suggestions.

Here are the main changes:
- I added you name to the files you changed (in the header)
- I rephrased some of the docstrings and some of the inline comments (this is me being very picky ; sorry!)
- In the CPU function `weights`, I used 2darrays directly instead of lists of 1darrays which are later converted to 2darrays. I am not sure it is much faster, but it makes the implementation slightly more compact.
- I reverted the changes that I made to the file `test_laser.py` (I previously added tests that initialize the `Simulation` object with different shape order and then test the laser antenna, but when reviewing your PR in more details, I realized that the laser antenna always uses shape factors of order 1, so there is no point in changing the shape factors for the `Simulation` object)