### PR TITLE
Add method to load particle distribution from openPMD hdf5 file

### DIFF
--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -344,8 +344,8 @@ def add_elec_bunch_openPMD( sim, ts_path, z_off=0., species=None, select=None,
         'uz' : [5., None]  (Particles with uz above 5 mc)
 
     iteration: integer (optional)
-       The iteration number of the checkpoint from which to restart
-       If None, the last iteration of the timeseries will be used.
+        The iteration number of the openPMD file from which to extract the
+        particles.
 
     boost : a BoostConverter object, optional
         A BoostConverter object defining the Lorentz boost of

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -383,7 +383,7 @@ def add_elec_bunch_openPMD( sim, ts_path, z_off=0., species=None, select=None,
                             dens_func=None, use_cuda=sim.use_cuda,
                             grid_shape=sim.fld.interp[0].Ez.shape )
 
-    # Replace dummy particle parameters with phase space from text file
+    # Replace dummy particle parameters with phase space from openPMD file
     # Convert lengths from microns to meters
     relat_elec.x[:] = x[:] * 1.e-6
     relat_elec.y[:] = y[:] * 1.e-6
@@ -393,9 +393,7 @@ def add_elec_bunch_openPMD( sim, ts_path, z_off=0., species=None, select=None,
     relat_elec.uz[:] = uz[:]
     relat_elec.inv_gamma[:] = 1./np.sqrt( \
         1. + relat_elec.ux**2 + relat_elec.uy**2 + relat_elec.uz**2 )
-    # Calculate weights (charge of macroparticle)
-    # assuming equally weighted particles as used in particle tracking codes
-    # multiply by -1 to make them negatively charged
+    # Convert number of particle weights to particle charge
     relat_elec.w[:] = -e * w[:]
 
     # Transform particle distribution in


### PR DESCRIPTION
I thought now that we have this nice unified file format we might also want to leverage it as an input format for FBPIC. Therefore, I wrote and additional `add_elec_bunch` method which loads a particle distribution from an openPMD time-series and initialises it with corresponding space charge fields.
Just like the checkpoint method it uses the openPMD-viewer. 
Let me know if you think this is useful or not or if you want any changes made to the code.