### PR TITLE
Particle tracking

### DIFF
--- a/docs/source/example_input/lwfa_script.py
+++ b/docs/source/example_input/lwfa_script.py
@@ -69,13 +69,14 @@ diag_period = 10         # Period of the diagnostics in number of timesteps
 save_checkpoints = False # Whether to write checkpoint files
 checkpoint_period = 50   # Period for writing the checkpoints
 use_restart = False      # Whether to restart from a previous checkpoint
+track_electrons = False  # Whether to track and write particle ids
 
 # The density profile
 ramp_start = 30.e-6
 ramp_length = 40.e-6
 
 def dens_func( z, r ) :
-    """Returns relative density at position z and r"""    
+    """Returns relative density at position z and r"""
     # Allocate relative density
     n = np.ones_like(z)
     # Make linear ramp
@@ -99,16 +100,18 @@ if __name__ == '__main__':
         use_cuda=use_cuda )
 
     # Load initial fields
-    if use_restart is False: 
+    if use_restart is False:
         # Add a laser to the fields of the simulation
         add_laser( sim, a0, w0, ctau, z0 )
+        # Track electrons if required (species 0 correspond to the electrons)
+        sim.ptcl[0].track( sim.comm )
     else:
         # Load the fields and particles from the latest checkpoint file
         restart_from_checkpoint( sim )
-    
+
     # Configure the moving window
     sim.set_moving_window( v=v_window )
-    
+
     # Add a field diagnostic
     sim.diags = [ FieldDiagnostic( diag_period, sim.fld, comm=sim.comm ),
                 ParticleDiagnostic( diag_period, {"electrons" : sim.ptcl[0]},

--- a/docs/source/example_input/lwfa_script.py
+++ b/docs/source/example_input/lwfa_script.py
@@ -104,7 +104,8 @@ if __name__ == '__main__':
         # Add a laser to the fields of the simulation
         add_laser( sim, a0, w0, ctau, z0 )
         # Track electrons if required (species 0 correspond to the electrons)
-        sim.ptcl[0].track( sim.comm )
+        if track_electrons:
+            sim.ptcl[0].track( sim.comm )
     else:
         # Load the fields and particles from the latest checkpoint file
         restart_from_checkpoint( sim )

--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -32,7 +32,7 @@ class BufferHandler(object):
         ----------
         n_guard: int
            Number of guard cells
-           
+
         Nr, Nm: int
            Number of points in the radial direction and
            number of azimuthal modes
@@ -164,14 +164,14 @@ class BufferHandler(object):
                         interp[m].Et[:ng,:] = self.EB_recv_l[1+offset,:,:]
                         interp[m].Ez[:ng,:] = self.EB_recv_l[2+offset,:,:]
                         interp[m].Br[:ng,:] = self.EB_recv_l[3+offset,:,:]
-                        interp[m].Bt[:ng,:] = self.EB_recv_l[4+offset,:,:] 
+                        interp[m].Bt[:ng,:] = self.EB_recv_l[4+offset,:,:]
                         interp[m].Bz[:ng,:] = self.EB_recv_l[5+offset,:,:]
                     if copy_right:
                         interp[m].Er[-ng:,:] = self.EB_recv_r[0+offset,:,:]
                         interp[m].Et[-ng:,:] = self.EB_recv_r[1+offset,:,:]
                         interp[m].Ez[-ng:,:] = self.EB_recv_r[2+offset,:,:]
                         interp[m].Br[-ng:,:] = self.EB_recv_r[3+offset,:,:]
-                        interp[m].Bt[-ng:,:] = self.EB_recv_r[4+offset,:,:] 
+                        interp[m].Bt[-ng:,:] = self.EB_recv_r[4+offset,:,:]
                         interp[m].Bz[-ng:,:] = self.EB_recv_r[5+offset,:,:]
 
     def copy_J_buffers( self, interp,

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -114,7 +114,7 @@ def restart_from_checkpoint( sim, iteration=None ):
     # Loop through the different species
     for i in range(len(sim.ptcl)):
         name = 'species %d' %i
-        load_species( sim.ptcl[i], name, ts, iteration)
+        load_species( sim.ptcl[i], name, ts, iteration, sim.comm )
 
     # Load the fields
     # Loop through the different modes
@@ -224,7 +224,7 @@ def load_fields( grid, fieldtype, coord, ts, iteration ):
     length_new = grid.zmax - grid.zmin
     assert np.allclose( length_old, length_new )
 
-def load_species( species, name, ts, iteration ):
+def load_species( species, name, ts, iteration, comm ):
     """
     Read the species data from the checkpoint `ts`
     and load it into the Species object `species`
@@ -242,6 +242,9 @@ def load_species( species, name, ts, iteration ):
 
     iteration: integer
         The iteration at which to load the checkpoint
+
+    comm: an fbpic.BoundaryCommunicator object
+        Contains information about the number of procs
     """
     # Get the particles' positions (convert to meters)
     x, y, z = ts.get_particle(
@@ -256,19 +259,21 @@ def load_species( species, name, ts, iteration ):
     # Get the inverse gamma
     species.inv_gamma = 1./np.sqrt(
         1 + species.ux**2 + species.uy**2 + species.uz**2 )
+    # Take into account the fact that the arrays are resized
+    Ntot = len(species.w)
+    species.Ntot = Ntot
+
     # Check if the particles where tracked
     if "id" in ts.avail_record_components[name]:
         pid, = ts.get_particle( ['id'], iteration=iteration, species=name )
-        species.track()
-        species.id[:] = pid
+        species.track( comm )
+        species.tracker.rewrite_ids( pid, comm )
 
     # As a safe-guard, check that the loaded data is in float64
     for attr in ['x', 'y', 'z', 'ux', 'uy', 'uz', 'w', 'inv_gamma' ]:
         assert getattr( species, attr ).dtype == np.float64
+    assert species.tracker.id.dtype == np.uint64
 
-    # Take into account the fact that the arrays are resized
-    Ntot = len(species.w)
-    species.Ntot = Ntot
     # Field arrays
     species.Ez = np.zeros( Ntot )
     species.Ex = np.zeros( Ntot )

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -267,7 +267,7 @@ def load_species( species, name, ts, iteration, comm ):
     if "id" in ts.avail_record_components[name]:
         pid, = ts.get_particle( ['id'], iteration=iteration, species=name )
         species.track( comm )
-        species.tracker.rewrite_ids( pid, comm )
+        species.tracker.overwrite_ids( pid, comm )
 
     # As a safe-guard, check that the loaded data is in float64
     for attr in ['x', 'y', 'z', 'ux', 'uy', 'uz', 'w', 'inv_gamma' ]:

--- a/fbpic/openpmd_diag/data_dict.py
+++ b/fbpic/openpmd_diag/data_dict.py
@@ -20,8 +20,9 @@ unit_dimension_dict = {
     "weighting" : np.array([0., 0., 0., 0., 0., 0., 0.]),
     "position" : np.array([1., 0., 0., 0., 0., 0., 0.]),
     "positionOffset" : np.array([1., 0., 0., 0., 0., 0., 0.]),
-    "momentum" : np.array([1., 1.,-1., 0., 0., 0., 0.]) }
-    
+    "momentum" : np.array([1., 1.,-1., 0., 0., 0., 0.]),
+    "id" : np.array([0., 0., 0., 0., 0., 0., 0.]) }
+
 # Typical weighting of different particle properties
 macro_weighted_dict = {
     "charge": np.uint32(0),
@@ -29,11 +30,13 @@ macro_weighted_dict = {
     "weighting": np.uint32(1),
     "position": np.uint32(0),
     "positionOffset": np.uint32(0),
-    "momentum" : np.uint32(0) }
+    "momentum" : np.uint32(0),
+    "id" : np.uint32(0) }
 weighting_power_dict = {
     "charge": 1.,
     "mass": 1.,
     "weighting": 1.,
     "position": 0.,
     "positionOffset": 0.,
-    "momentum": 1. }
+    "momentum": 1.,
+    "id": 0 }

--- a/fbpic/openpmd_diag/particle_diag.py
+++ b/fbpic/openpmd_diag/particle_diag.py
@@ -239,7 +239,7 @@ class ParticleDiagnostic(OpenPMDDiagnostic) :
             the rules of self.select
         """
         # If needed, add the id to the quantities to be written
-        particle_data = self.particle_data.copy()
+        particle_data = self.particle_data[:]
         if species.tracker is not None:
             particle_data.append("id")
 

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -285,8 +285,7 @@ class Particles(object) :
         comm: an fbpic.BoundaryCommunicator object
             Contains information about the number of processors
         """
-        self.tracker = ParticleTracker( comm.size, comm.rank,
-                                        self.Ntot, self.use_cuda )
+        self.tracker = ParticleTracker( comm.size, comm.rank, self.Ntot )
         self.n_integer_quantities += 1
 
     def rearrange_particle_arrays( self ):

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -272,7 +272,7 @@ class Particles(object) :
 
             # Copy particle tracker data
             if self.tracker is not None:
-                self.track.receive_from_gpu()
+                self.tracker.receive_from_gpu()
 
     def track( self, comm ):
         """

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -153,6 +153,9 @@ class Particles(object) :
 
         # By default, there is no particle tracking
         self.tracker = None
+        # Total number of quantities (necessary in MPI communications)
+        self.n_integer_quantities = 0
+        self.n_float_quantities = 8 # x, y, z, ux, uy, uz, inv_gamma, w
 
         if Ntot > 0:
             # Get the 1d arrays of evenly-spaced positions for the particles
@@ -191,8 +194,8 @@ class Particles(object) :
             self.grid_shape = grid_shape
             # Allocate arrays for the particles sorting when using CUDA
             self.cell_idx = np.empty( Ntot, dtype=np.int32)
-            self.sorted_idx = np.arange( Ntot, dtype=np.uint32)
-            self.sorting_buffer = np.arange( Ntot, dtype=np.float64 )
+            self.sorted_idx = np.empty( Ntot, dtype=np.uint32)
+            self.sorting_buffer = np.empty( Ntot, dtype=np.float64 )
             self.prefix_sum = np.empty( grid_shape[0]*grid_shape[1],
                                         dtype=np.int32 )
             # Register boolean that records if the particles are sorted or not
@@ -284,6 +287,7 @@ class Particles(object) :
         """
         self.tracker = ParticleTracker( comm.size, comm.rank,
                                         self.Ntot, self.use_cuda )
+        self.n_integer_quantities += 1
 
     def rearrange_particle_arrays( self ):
         """

--- a/fbpic/particles/tracking/__init__.py
+++ b/fbpic/particles/tracking/__init__.py
@@ -1,0 +1,8 @@
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It imports the ParticleTracker object, which is used in order to tag
+particles with ids.
+"""
+
+from .tracking import ParticleTracker
+__all__ = ['ParticleTracker']

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -31,8 +31,7 @@ class ParticleTracker(object):
         self.next_attributed_id = new_next_attributed_id
 
         # Create a sorting buffer
-        if use_cuda:
-            self.sorting_buffer = np.empty( N, dtype=np.uint64 )
+        self.sorting_buffer = np.empty( N, dtype=np.uint64 )
 
     def send_to_gpu(self):
         """
@@ -48,7 +47,7 @@ class ParticleTracker(object):
         self.id = self.id.copy_to_host()
         self.sorting_buffer = self.sorting_buffer.copy_to_host()
 
-    def get_new_ids( self, N ):
+    def generate_new_ids( self, N ):
         """
         # TODO
         """

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -1,0 +1,41 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines the structure and methods associated with particle tracking.
+"""
+import numpy as np
+
+class ParticleTracker(object):
+    """
+    # TODO
+    """
+    def __init__( self, comm_size, comm_rank, N ):
+        """
+        # TODO
+        """
+        # Prepare how to attribute new ids
+        self.next_attributed_id = comm_rank
+        self.id_step = comm_size
+        # Everytime a new id is attributed, next_attributed_id is incremented
+        # by id_step ; this way, all the particles (even across different
+        # MPI proc) have unique id.
+
+        # Initialize the array of ids
+        new_next_attributed_id = self.next_attributed_id + N*self.id_step
+        self.id = np.arange( start=self.next_attributed_id,
+                                stop=new_next_attributed_id,
+                                step=self.id_step, dtype=np.uint64 )
+        self.next_attributed_id = new_next_attributed_id
+
+    def get_new_ids( self, N ):
+        """
+        # TODO
+        """
+        new_next_attributed_id = self.next_attributed_id + N*self.id_step
+        new_ids = np.arange( start=self.next_attributed_id,
+                                stop=new_next_attributed_id,
+                                step=self.id_step, dtype=np.uint64 )
+        self.next_attributed_id = new_next_attributed_id
+        return( new_ids )

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -57,3 +57,26 @@ class ParticleTracker(object):
             step=self.id_step, dtype=np.uint64 )
         self.next_attributed_id = new_next_attributed_id
         return( new_ids )
+
+    def rewrite_ids( self, pid, comm ):
+        """
+        # TODO
+        """
+        # Get the new ids
+        self.id[:] = pid
+
+        # Set self.next_attributed_id, so that attributed ids are still unique
+        # In order to do this, find the maximum of all pid across processors
+        if len(pid) > 0:
+            local_id_max = pid.max()
+        else:
+            local_id_max = 0
+        if comm.mpi_comm is None:
+            global_id_max = local_id_max
+        else:
+            local_id_max_list = comm.mpi_comm.allgather( local_id_max )
+            global_id_max = max( local_id_max_list )
+        # Find the next_attibuted_id: has to be of the form
+        # comm.rank + n*self.id_step
+        n = int( (global_id_max - comm.rank)/self.id_step ) + 1
+        self.next_attibuted_id = comm.rank + n*self.id_step

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -6,12 +6,13 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the structure and methods associated with particle tracking.
 """
 import numpy as np
+from numba import cuda
 
 class ParticleTracker(object):
     """
     # TODO
     """
-    def __init__( self, comm_size, comm_rank, N ):
+    def __init__( self, comm_size, comm_rank, N, use_cuda ):
         """
         # TODO
         """
@@ -24,18 +25,36 @@ class ParticleTracker(object):
 
         # Initialize the array of ids
         new_next_attributed_id = self.next_attributed_id + N*self.id_step
-        self.id = np.arange( start=self.next_attributed_id,
-                                stop=new_next_attributed_id,
-                                step=self.id_step, dtype=np.uint64 )
+        self.id = np.arange(
+            start=self.next_attributed_id, stop=new_next_attributed_id,
+            step=self.id_step, dtype=np.uint64 )
         self.next_attributed_id = new_next_attributed_id
+
+        # Create a sorting buffer
+        if use_cuda:
+            self.sorting_buffer = np.empty( N, dtype=np.uint64 )
+
+    def send_to_gpu(self):
+        """
+        # TODO
+        """
+        self.id = cuda.to_device( self.id )
+        self.sorting_buffer = cuda.to_device( self.sorting_buffer )
+
+    def receive_from_gpu(self):
+        """
+        # TODO
+        """
+        self.id = self.id.copy_to_host()
+        self.sorting_buffer = self.sorting_buffer.copy_to_host()
 
     def get_new_ids( self, N ):
         """
         # TODO
         """
         new_next_attributed_id = self.next_attributed_id + N*self.id_step
-        new_ids = np.arange( start=self.next_attributed_id,
-                                stop=new_next_attributed_id,
-                                step=self.id_step, dtype=np.uint64 )
+        new_ids = np.arange(
+            start=self.next_attributed_id, stop=new_next_attributed_id,
+            step=self.id_step, dtype=np.uint64 )
         self.next_attributed_id = new_next_attributed_id
         return( new_ids )

--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -66,12 +66,15 @@ def test_lpa_sim_twoproc_restart():
         # Check that the targeted lines are present
         if script.find('save_checkpoints = False') == -1 \
             or script.find('use_restart = False') == -1 \
+            or script.find('track_electrons = False') == -1 \
             or script.find('N_step = 200') == -1:
             raise RuntimeError('Did not find expected lines in lwfa_script.py')
 
     # Modify the script so as to enable checkpoints
     script = script.replace('save_checkpoints = False',
                                 'save_checkpoints = True')
+    script = script.replace('track_electrons = False',
+                                'track_electrons = True')
     script = script.replace('N_step = 200', 'N_step = 101')
     with open('lwfa_script.py', 'w') as f:
         f.write(script)


### PR DESCRIPTION
## Overview

This pull request adds particle tracking to `fbpic`: when activated, a unique ID is attributed to each macroparticles (including new macroparticles created by the moving window) and these ID are written in the openPMD file, so that particles can be tracked in postprocessing, using the openPMD-viewer (see https://github.com/openPMD/openPMD-viewer/pull/139)

This pull request is compatible with:
- the GPU implementation (the array of particle ID is updated whenever the particles are sorted)
- MPI communications (the arrays of particle ID are communicated via MPI)
- Checkpoint / restarts (when restarting from a checkpoint that contains particle ID, the simulation automatically loads these particle ID and tracks the corresponding species)

## API

In order to activate tracking for a given species, use:
```
species.track( comm )
```
where `species` is the `fbpic.Particles` object that represents the species to be tracked and `comm` is the `BoundaryCommunicator` (see below for why it is necessary to pass it). The API is not ideal, but works for now.

When the species is tracked, its ID is automatically added to the openPMD output (no need to pass "id" in the API of the openPMD diagnostics).

## Implementation

When a species is tracked, it has an attribute `tracker`, which is an instance of `ParticleTracker` and is responsible for:
- storing the `id` of the existing particles in an array
- generating new unique `id` whenever needed.

In order to generate ids that are unique **across all MPI processes**, the `ParticleTracker` on a given process generates integers of the form:
```
mpi_rank + k * mpi_size
```
where `mpi_rank` is the rank of this MPI process, and where `k` is an integer (which varies from macroparticle to macroparticle)

Note that because the `id` is an array of integer (whereas other particle attributes are arrays of floats), I had to create new MPI buffers and sorting buffers to work with the `id`.