### PR TITLE
Close #36 Checkpoints not working with use_all_mpi_ranks = False

### DIFF
--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -44,7 +44,7 @@ n_guard = 40     # Number of guard cells
 exchange_period = 10
 # The simulation timestep
 dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
-N_step = 201     # Number of iterations to perform
+N_step = 101     # Number of iterations to perform
                  # (increase this number for a real simulation)
 
 # Boosted frame
@@ -152,7 +152,7 @@ if __name__ == '__main__':
         v_comoving=-0.9999*c, use_galilean=False,
         n_guard=n_guard, exchange_period=exchange_period,
         gamma_boost=gamma_boost, boundaries='open', use_cuda=use_cuda )
-    
+
     # Add an electron bunch
     add_elec_bunch( sim, bunch_gamma, bunch_n, bunch_zmin,
                 bunch_zmax, 0, bunch_rmax )
@@ -172,7 +172,7 @@ if __name__ == '__main__':
                     dt_snapshot_lab, Ntot_snapshot_lab, gamma_boost,
                     period=diag_period, fldobject=sim.fld, comm=sim.comm),
                 BoostedParticleDiagnostic( zmin, zmax, c, dt_snapshot_lab,
-                    Ntot_snapshot_lab, gamma_boost, diag_period, sim.fld, 
+                    Ntot_snapshot_lab, gamma_boost, diag_period, sim.fld,
                     select={'uz':[0.,None]}, species={'electrons':sim.ptcl[2]},
                     comm=sim.comm )
                     ]

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -11,35 +11,38 @@ import os, re
 import numpy as np
 from .field_diag import FieldDiagnostic
 from .particle_diag import ParticleDiagnostic
+from mpi4py.MPI import COMM_WORLD as comm
 
 def set_periodic_checkpoint( sim, period ):
     """
     Set up periodic checkpoints of the simulation
 
-    The checkpoints are saved in openPMD format, in the directory 
-    `./checkpoints`, with one subdirectory per process. 
+    The checkpoints are saved in openPMD format, in the directory
+    `./checkpoints`, with one subdirectory per process.
     All the field and particle information of each processor is saved.
- 
+
     NB: Checkpoints are registered among the list of diagnostics
-    `diags` of the Simulation object `sim`. 
+    `diags` of the Simulation object `sim`.
 
     Parameters
     ----------
     sim: a Simulation object
        The simulation that is to be saved in checkpoints
-    
+
     period: integer
        The number of PIC iteration between each checkpoint.
     """
     # Only processor 0 creates a directory where checkpoints will be stored
     # Make sure that all processors wait until this directory is created
-    if sim.comm.rank == 0:
+    # (Use the global MPI communicator instead of the `BoundaryCommunicator`
+    # so that this still works in the case `use_all_ranks=False`)
+    if comm.rank == 0:
         if os.path.exists('./checkpoints') is False:
             os.mkdir('./checkpoints')
-    sim.comm.mpi_comm.Barrier()
-    
+    comm.Barrier()
+
     # Choose the name of the directory: one directory per processor
-    write_dir = 'checkpoints/proc%d/' %sim.comm.rank
+    write_dir = 'checkpoints/proc%d/' %comm.rank
 
     # Register a periodic FieldDiagnostic in the diagnostics of the simulation
     sim.diags.append(
@@ -64,17 +67,17 @@ def restart_from_checkpoint( sim, iteration=None ):
     - Values of the field arrays
     - Size and values of the particle arrays
 
-    Any other information (e.g. diagnostics of the simulation, presence of a 
+    Any other information (e.g. diagnostics of the simulation, presence of a
     moving window, presence of a laser antenna, etc.) need to be set by hand.
 
-    For this reason, a successful restart will often require to modify the 
-    original input script that produced the checkpoint, rather than to start 
+    For this reason, a successful restart will often require to modify the
+    original input script that produced the checkpoint, rather than to start
     a new input script from scratch.
 
     NB: This function should always be called *before* the initialization
     of the moving window, since the moving window infers the position of
     particle injection from the existing particle data.
- 
+
     Parameters
     ----------
     sim: a Simulation object
@@ -93,19 +96,21 @@ def restart_from_checkpoint( sim, iteration=None ):
         '\nPlease install it from https://github.com/openPMD/openPMD-viewer')
 
     # Verify that the restart is valid (only for the first processor)
-    if sim.comm.rank == 0:
+    # (Use the global MPI communicator instead of the `BoundaryCommunicator`,
+    # so that this also works for `use_all_ranks=False`)
+    if comm.rank == 0:
         check_restart( sim, iteration )
-    sim.comm.mpi_comm.Barrier()
+    comm.Barrier()
 
     # Choose the name of the directory from which to restart:
     # one directory per processor
-    checkpoint_dir = 'checkpoints/proc%d/hdf5' %sim.comm.rank
+    checkpoint_dir = 'checkpoints/proc%d/hdf5' %comm.rank
     ts = OpenPMDTimeSeries( checkpoint_dir )
     # Select the iteration, and its index
     if iteration is None:
         iteration = ts.iterations[-1]
     i_iteration = ts.iterations.index( iteration )
-    
+
     # Modify parameters of the simulation
     sim.iteration = iteration
     sim.time = ts.t[ i_iteration ]
@@ -113,7 +118,7 @@ def restart_from_checkpoint( sim, iteration=None ):
     # Load the particles
     # Loop through the different species
     for i in range(len(sim.ptcl)):
-        name = 'species %d' %i        
+        name = 'species %d' %i
         load_species( sim.ptcl[i], name, ts, iteration)
 
     # Load the fields
@@ -149,7 +154,7 @@ def check_restart( sim, iteration ):
     for directory in os.listdir('./checkpoints'):
         if regex_matcher.match(directory) is not None:
             nproc += 1
-    if nproc != sim.comm.size:
+    if nproc != comm.size:
         raise RuntimeError('For a valid restart, the current simulation '
         'should use %d MPI processes.' %nproc)
 
@@ -169,7 +174,7 @@ def load_fields( grid, fieldtype, coord, ts, iteration ):
     ----------
     grid: an InterpolationGrid object
        The object into which data should be loaded
-    
+
     fieldtype: string
        Either 'E', 'B', 'J' or 'rho'. Indicates which field to load.
 
@@ -231,7 +236,7 @@ def load_species( species, name, ts, iteration ):
 
     Parameters:
     -----------
-    species: a Species object 
+    species: a Species object
         The object into which data is loaded
 
     name: string
@@ -244,7 +249,7 @@ def load_species( species, name, ts, iteration ):
         The iteration at which to load the checkpoint
     """
     # Get the particles' positions (convert to meters)
-    x, y, z = ts.get_particle( 
+    x, y, z = ts.get_particle(
                 ['x', 'y', 'z'], iteration=iteration, species=name )
     species.x, species.y, species.z = 1.e-6*x, 1.e-6*y, 1.e-6*z
     # Get the particles' momenta
@@ -260,7 +265,7 @@ def load_species( species, name, ts, iteration ):
     # As a safe-guard, check that the loaded data is in float64
     for attr in ['x', 'y', 'z', 'ux', 'uy', 'uz', 'w', 'inv_gamma' ]:
         assert getattr( species, attr ).dtype == np.float64
-    
+
     # Take into account the fact that the arrays are resized
     Ntot = len(species.w)
     species.Ntot = Ntot

--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -15,8 +15,8 @@ runs **without crashing**. It runs the following scripts:
 Usage:
 This file is meant to be run from the top directory of fbpic,
 by any of the following commands
-$ python tests/test_example_docs_script.py
-$ py.test -q tests/test_example_docs_script.py
+$ python tests/test_example_docs_scripts.py
+$ py.test -q tests/test_example_docs_scripts.py
 $ python setup.py test
 """
 import os
@@ -38,7 +38,34 @@ def test_lpa_sim_singleproc():
 
     # Enter the temporary directory and run the script
     os.chdir( temporary_dir )
+
+    # Read the script and check that the targeted lines are present
+    with open('lwfa_script.py') as f:
+        script = f.read()
+        # Check that the targeted lines are present
+        if script.find('save_checkpoints = False') == -1 \
+            or script.find('use_restart = False') == -1 \
+            or script.find('N_step = 200') == -1:
+            raise RuntimeError('Did not find expected lines in lwfa_script.py')
+
+    # Modify the script so as to enable checkpoints
+    script = script.replace('save_checkpoints = False',
+                                'save_checkpoints = True')
+    script = script.replace('N_step = 200', 'N_step = 101')
+    with open('lwfa_script.py', 'w') as f:
+        f.write(script)
     # Launch the script from the OS
+    response = os.system( 'python lwfa_script.py' )
+    assert response==0
+
+    # Modify the script so as to enable restarts
+    script = script.replace('use_restart = False',
+                                'use_restart = True')
+    script = script.replace('save_checkpoints = True',
+                                'save_checkpoints = False')
+    with open('lwfa_script.py', 'w') as f:
+        f.write(script)
+    # Launch the modified script from the OS, with 2 proc
     response = os.system( 'python lwfa_script.py' )
     assert response==0
 
@@ -133,6 +160,31 @@ def test_parametric_sim_twoproc():
     # Enter the temporary directory
     os.chdir( temporary_dir )
 
+    # Read the script and check that the targeted lines are present
+    with open('parametric_script.py') as f:
+        script = f.read()
+        # Check that the targeted lines are present
+        if script.find('save_checkpoints = False') == -1 \
+            or script.find('use_restart = False') == -1:
+            raise RuntimeError(
+            'Did not find expected lines in parametric_script.py')
+
+    # Modify the script so as to enable checkpoints
+    script = script.replace('save_checkpoints = False',
+                                'save_checkpoints = True')
+    with open('parametric_script.py', 'w') as f:
+        f.write(script)
+    # Launch the modified script from the OS, with 2 proc
+    response = os.system( 'mpirun -np 2 python parametric_script.py' )
+    assert response==0
+
+    # Modify the script so as to enable restarts
+    script = script.replace('use_restart = False',
+                                'use_restart = True')
+    script = script.replace('save_checkpoints = True',
+                                'save_checkpoints = False')
+    with open('parametric_script.py', 'w') as f:
+        f.write(script)
     # Launch the modified script from the OS, with 2 proc
     response = os.system( 'mpirun -np 2 python parametric_script.py' )
     assert response==0
@@ -146,7 +198,7 @@ def test_parametric_sim_twoproc():
         ts = LpaDiagnostics( diag_folder )
         # Check that the value of a0 in the diagnostics is the
         # expected one.
-        a0_in_diag = ts.get_a0( iteration=40, pol='x' )
+        a0_in_diag = ts.get_a0( iteration=80, pol='x' )
         assert abs( (a0 - a0_in_diag)/a0 ) < 1.e-2
 
     # Exit the temporary directory and suppress it
@@ -154,7 +206,7 @@ def test_parametric_sim_twoproc():
     shutil.rmtree( temporary_dir )
 
 if __name__ == '__main__':
+    test_parametric_sim_twoproc()
     test_lpa_sim_singleproc()
     test_lpa_sim_twoproc_restart()
     test_boosted_frame_sim_twoproc()
-    test_parametric_sim_twoproc()


### PR DESCRIPTION
As reported by @soerenjalas, the checkpoints were not working when `use_all_mpi_ranks=False`, because the `BoundaryCommunicator` object does not contain an MPI communicator (in order to prevent the independent simulations from talking to each other).
However, when writing the checkpoints, the independent simulations do need to synchronize, in order to prepare the output folders. I fixed the issue by using the global MPI communicator **only** in the checkpoint code (see the file `checkpoint_restart.py`).

I also expanded the automatic tests so that they test the checkpoint/restart in the case of `use_all_mpi_ranks=False`.

The list of changes for this pull request is somewhat messy, because (as usual) Atom linted the code to remove trailing spaces and empty lines. Sorry about this. The only important changes are in `checkpoint_restart.py`. The rest is linting + expansion of the automatic tests.