### PR TITLE
Fix gaussian beam initialization for zero energy spread and update test file

### DIFF
--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -174,7 +174,14 @@ def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0, sig_gamma,
     ux = np.random.normal(0., sig_ur, N)
     uy = np.random.normal(0., sig_ur, N)
     # Now we imprint an energy spread on the gammas of each particle
-    gamma = np.random.normal(gamma0, sig_gamma, N)
+    if sig_gamma > 0.:
+        gamma = np.random.normal(gamma0, sig_gamma, N)
+    else:
+        # Or set it to zero
+        gamma = np.full(N, gamma0)
+        if sig_gamma < 0.:
+            print("Warning: Negative energy spread sig_gamma detected."
+                  " sig_gamma will be set to zero. \n")
     # Finally we calculate the uz of each particle 
     # from the gamma and the transverse momenta ux, uy
     uz = np.sqrt((gamma**2-1) - ux**2 - uy**2)

--- a/tests/unautomated/test_space_charge_gaussian.py
+++ b/tests/unautomated/test_space_charge_gaussian.py
@@ -79,9 +79,9 @@ if show_fields:
     print( 'Done' )
 
 # Create empty arrays for saving rms bunch sizes
-sig_zp = np.zeros(N_step/N_show+1)
-sig_xp = np.zeros(N_step/N_show+1)
-sig_yp = np.zeros(N_step/N_show+1)
+sig_zp = np.zeros(int(N_step/N_show)+1)
+sig_xp = np.zeros(int(N_step/N_show)+1)
+sig_yp = np.zeros(int(N_step/N_show)+1)
 
 # Set initial bunch sizes
 sig_zp[0] = np.std(sim.ptcl[0].z)
@@ -89,13 +89,13 @@ sig_xp[0] = np.std(sim.ptcl[0].x)
 sig_yp[0] = np.std(sim.ptcl[0].y)
 
 # Create array corresponding to the propagation distance of the bunch
-z_prop  = np.arange(N_step/N_show+1) * ((zmax-zmin)/Nz) * N_show
+z_prop  = np.arange(int(N_step/N_show)+1) * ((zmax-zmin)/Nz) * N_show
 z_prop += -20.e-6
 if l_boost:
     z_prop, = boost.copropag_length([z_prop], beta_object = boost.beta0)
 
 # Carry out the simulation
-for k in range(N_step/N_show) :
+for k in range(int(N_step/N_show)) :
     sim.step(N_show)
     sig_zp[k+1] = np.std(sim.ptcl[0].z)
     sig_xp[k+1] = np.std(sim.ptcl[0].x)


### PR DESCRIPTION
The function `np.random.normal(gamma, sig_gamma, N)` will throw a ValueError if sig_gamma<=0.
However a user might desire to initialise a bunch with a constant energy so this PR is meant to implement that by simply filling a numpy array of desired size with the desired value for each entry by using [numpy.full()](https://docs.scipy.org/doc/numpy/reference/generated/numpy.full.html). If the user selected a negative energy spread it will be set to zero and a warning is given.

Furthermore I updated the corresponding test file as it threw errors at me because Python 3.5 handles integer division differently than Python 2.x.
