### PR TITLE
Prevent calls gathering functions when the simulation is single-proc

### DIFF
--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -192,7 +192,7 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
                 self.slice_handler.transform_fields_to_lab_frame( field_array )
 
             # Gather the slices on the first proc
-            if self.comm is not None:
+            if self.comm is not None and self.comm.size > 1:
                 global_field_array, global_iz_min, global_iz_max = \
                     self.gather_slices( field_array, iz_min, iz_max )
             else:

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -195,7 +195,7 @@ class BoostedParticleDiagnostic(ParticleDiagnostic):
                 local_particle_array = snapshot.compact_slices(species_name)
 
                 # Gather the slices on the first proc
-                if self.comm is not None:
+                if self.comm is not None and self.comm.size > 1:
                     particle_array = self.gather_particle_arrays(
                                     local_particle_array )
                 else:


### PR DESCRIPTION
When we use the flag `use_all_mpi_rank=False` with the boosted-frame, the calls to the MPI gathering routines in the boosted-frame output cause the code to crash because the MPI communicator is `None` in this case. This pull request avoids this problem.