### PR TITLE
Simplify laser profile function and add temporal chirp

### DIFF
--- a/fbpic/lpa_utils/boosted_frame.py
+++ b/fbpic/lpa_utils/boosted_frame.py
@@ -219,28 +219,6 @@ class BoostConverter( object ):
 
         return( boosted_frame_vars )
 
-
-    def curvature( self, lab_frame_vars ):
-        """
-        Converts a list of laser curvature from the lab frame
-        to the boosted frame:
-        R' = R / ( 1 + beta0 )
-
-        Parameters
-        ----------
-        lab_frame_vars: list of floats
-            A list containing several curvatures to be converted
-
-        Returns
-        -------
-        A list with the same number of elements, with the converted quantities
-        """
-        boosted_frame_vars = []
-        for R in lab_frame_vars:
-            boosted_frame_vars.append( R /( 1 + self.beta0 ) )
-
-        return( boosted_frame_vars )
-
     def boost_particles( self, particles ):
         """
         Transforms particles to the boosted frame and propagates

--- a/fbpic/lpa_utils/laser/antenna.py
+++ b/fbpic/lpa_utils/laser/antenna.py
@@ -51,9 +51,9 @@ class LaserAntenna( object ):
     Note that the antenna always uses linear shape factors (even when the
     rest of the simulation uses cubic shape factors.)
     """
-    def __init__( self, E0, w0, ctau, z0, zf, k0,
-                    theta_pol, z0_antenna, dr_grid, Nr_grid, Nm,
-                    npr=2, nptheta=4, epsilon=0.01, boost=None ):
+    def __init__( self, E0, w0, ctau, z0, zf, k0, cep_phase,
+        phi2_chirp, theta_pol, z0_antenna, dr_grid, Nr_grid, Nm,
+        npr=2, nptheta=4, epsilon=0.01, boost=None ):
         """
         Initialize a LaserAntenna object (see class docstring for more info)
 
@@ -76,6 +76,18 @@ class LaserAntenna( object ):
 
         k0: float (m^-1)
             Laser wavevector *in the lab frame*
+
+        cep_phase: float (rad)
+            Carrier Enveloppe Phase (CEP), i.e. the phase of the laser
+            oscillations, at the position where the laser enveloppe is maximum.
+
+        phi2_chirp: float (in second^2)
+            The amount of temporal chirp, at focus *in the lab frame*
+            Namely, a wave packet centered on the frequency (w0 + dw) will
+            reach its peak intensity at a time z(dw) = z0 - c*phi2*dw.
+            Thus, a positive phi2 corresponds to positive chirp, i.e. red part
+            of the spectrum in the front of the pulse and blue part of the
+            spectrum in the back.
 
         theta_pol: float (rad)
             Polarization angle of the laser
@@ -160,6 +172,8 @@ class LaserAntenna( object ):
         self.ctau = ctau
         self.z0 = z0
         self.zf = zf
+        self.cep_phase = cep_phase
+        self.phi2_chirp = phi2_chirp
         self.theta_pol = theta_pol
         self.boost = boost
 
@@ -226,7 +240,8 @@ class LaserAntenna( object ):
         # calculating the electric field on the particles.
         Eu = self.E0 * gaussian_profile( z_lab, self.baseline_r, t_lab,
                         self.w0, self.ctau, self.z0, self.zf,
-                        self.k0, boost=None, output_Ez_profile=False )
+                        self.k0, self.cep_phase, self.phi2_chirp,
+                        boost=None, output_Ez_profile=False )
 
         # Calculate the corresponding velocity. This takes into account
         # lab-frame to boosted-frame conversion, through a modification

--- a/fbpic/lpa_utils/laser/antenna.py
+++ b/fbpic/lpa_utils/laser/antenna.py
@@ -222,18 +222,6 @@ class LaserAntenna( object ):
         t: float (seconds)
             The time at which to calculate the velocities
         """
-        # The electric field is calculated from its lab-frame expression.
-        # Thus, in case of a boost, find the time and position in the lab-frame
-        if self.boost is not None:
-            gamma0 = self.boost.gamma0
-            beta0 = self.boost.beta0
-            inv_c = 1./c
-            z_lab = gamma0*( self.baseline_z + c*beta0*t )
-            t_lab = gamma0*( t + inv_c*beta0*self.baseline_z )
-        else:
-            z_lab = self.baseline_z
-            t_lab = t
-
         # Calculate the electric field to be emitted (in the lab-frame)
         # Eu is the amplitude along the polarization direction
         # Note that we neglect the (small) excursion of the particles when
@@ -241,7 +229,7 @@ class LaserAntenna( object ):
         Eu = self.E0 * gaussian_profile( z_lab, self.baseline_r, t_lab,
                         self.w0, self.ctau, self.z0, self.zf,
                         self.k0, self.cep_phase, self.phi2_chirp,
-                        boost=None, output_Ez_profile=False )
+                        boost=self.boost, output_Ez_profile=False )
 
         # Calculate the corresponding velocity. This takes into account
         # lab-frame to boosted-frame conversion, through a modification

--- a/fbpic/lpa_utils/laser/antenna.py
+++ b/fbpic/lpa_utils/laser/antenna.py
@@ -226,7 +226,7 @@ class LaserAntenna( object ):
         # Eu is the amplitude along the polarization direction
         # Note that we neglect the (small) excursion of the particles when
         # calculating the electric field on the particles.
-        Eu = self.E0 * gaussian_profile( z_lab, self.baseline_r, t_lab,
+        Eu = self.E0 * gaussian_profile( self.baseline_z, self.baseline_r, t,
                         self.w0, self.ctau, self.z0, self.zf,
                         self.k0, self.cep_phase, self.phi2_chirp,
                         boost=self.boost, output_Ez_profile=False )

--- a/fbpic/lpa_utils/laser/profiles.py
+++ b/fbpic/lpa_utils/laser/profiles.py
@@ -88,22 +88,33 @@ def gaussian_profile( z, r, t, w0, ctau, z0, zf, k0, cep_phase=0, phi2_chirp=0,
         z = zlab_source
         t = tlab_source
 
-    # Lab-frame formula for the laser:
+    # Lab-frame formula for the laser
+    # Note: this formula is expressed with complex numbers for compactness and
+    # simplicity, but only the real part is used in the end
+    # (see final return statement)
+    # The formula for the laser (in complex numbers) is obtained by multiplying
+    # the Fourier transform of the laser at focus
+    # E(k_x,k_y,\omega) = exp( -(\omega-\omega_0)^2(\tau^2/4 + \phi^(2)/2)
+    #                                - (k_x^2 + k_y^2)w_0^2/4 )
+    # by the paraxial propagator e^(i(\omega/c - (k_x^2 +k_y^2)/2k0)(z-z_foc))
+    # and then by taking the inverse Fourier transform in x, y, and t
+
     # Diffraction and stretch_factor
     diffract_factor = 1. - 1j*(z-zf)*inv_zr
     stretch_factor = 1 + 2j * phi2_chirp * c**2 * inv_ctau2
-
     # Calculate the argument of the complex exponential
     exp_argument = 1j*cep_phase + 1j*k0*( c*t + z0 - z ) \
         - r**2 / (w0**2 * diffract_factor) \
         - 1./stretch_factor * inv_ctau2 * ( c*t  + z0 - z )**2
-
     # Get the transverse profile
     profile_Eperp = np.exp(exp_argument) \
         / ( diffract_factor * stretch_factor**0.5 )
 
     # Get the profile for the Ez fields (to ensure div(E) = 0)
-    # (This uses the approximation lambda0 << ctau for long_profile )
+    # (This uses the approximation lambda0 << ctau for long_profile.
+    # In addition, it uses the fact that, for a linearly polarized laser in
+    # mode m=1: Er = E_perp e^i pol_angle and E_theta = -i E_perp e^i pol_angle
+    # so that div(E) = 0 becomes \partial_z E_z + \partial_r E_perp = 0.)
     if output_Ez_profile:
         profile_Ez = 1.j * r * inv_zr / diffract_factor * profile_Eperp
 

--- a/fbpic/lpa_utils/laser/profiles.py
+++ b/fbpic/lpa_utils/laser/profiles.py
@@ -8,7 +8,7 @@ It defines a set of common laser profiles
 import numpy as np
 from scipy.constants import c
 
-def gaussian_profile( z, r, t, w0, ctau, z0, zf, k0,
+def gaussian_profile( z, r, t, w0, ctau, z0, zf, k0, phi2=0.,
                       prop=1., boost=None, output_Ez_profile=False ):
     """
     Calculate the profile of a Gaussian pulse
@@ -45,6 +45,14 @@ def gaussian_profile( z, r, t, w0, ctau, z0, zf, k0,
     k0: float (m)
         The wavenumber *in the lab frame*
 
+    phi2: float (in second^2)
+        The amount of temporal chirp, at focus *in the lab frame*
+        Namely, a wave packet centered on the frequency (w0 + dw) will
+        reach its peak intensity at a time z(dw) = z0 - c*phi2*dw.
+        Thus, a positive phi2 corresponds to positive chirp, i.e. red part
+        of the spectrum in the front of the pulse and blue part of the
+        spectrum in the back.
+
     prop: float (either +1 or -1)
         Whether the laser is forward or backward propagating
 
@@ -62,48 +70,39 @@ def gaussian_profile( z, r, t, w0, ctau, z0, zf, k0,
        a tuple with 2 array of reals of the same shape as z and r
     """
     # Calculate the Rayleigh length
-    zr = k0*w0**2 / 2.
+    zr = 0.5*k0*w0**2
+    inv_zr = 1./zr
+    inv_ctau2 = 1./ctau**2
 
-    # When running in a boosted frame, convert the different laser quantities
+    # When running in a boosted frame, convert the position and time at
+    # which to find the laser amplitude.
     if boost is not None:
-        zr, zf = boost.static_length([ zr, zf])
-        ctau, z0 = boost.copropag_length([ ctau, z0 ])
-        k0, = boost.wavenumber([ k0 ])
+        zlab_source = self.boost.gamma0*( z + self.boost.beta0*c*t )
+        tlab_source = self.boost.gamma0*( t + self.boost.beta0*z/c )
+        # Overwrite boosted frame values, within the scope of this function
+        z = zlab_source
+        t = tlab_source
 
-    # Calculate the laser waist and curvature in the pulse (2d arrays)
-    waist = w0*np.sqrt( 1+( (z-zf) /zr)**2 )
-    # Calculate the curvature (avoid division by 0)
-    z_minus_zf = np.where( z-zf != 0, (z-zf), np.nan )
-    R = (z-zf)*( 1 + (zr/z_minus_zf)**2 )
-    # Convert the curvature, when running a simulation in the boosted frame
-    if boost is not None:
-        R, = boost.curvature([ R ])
-    # Calculate the inverse of the curvature and correct the NaNs where
-    # there was potential division by 0 (in these cases inv_R is physically 0)
-    inv_R = np.where( z-zf != 0, 1./R, 0. )
+    # Lab-frame formula for the laser:
+    # Diffraction and stretch_factor
+    diffract_factor = 1. - 1j*(z-zf)*inv_zr
+    stretch_factor = 1 + 2j * phi2 * c**2 * inv_ctau2
 
-    # Longitudinal and transverse profile
-    long_profile = np.exp( -(z-c*prop*t-z0)**2/ctau**2 )
-    trans_profile_Eperp = w0/waist * np.exp( -(r/waist)**2 )
-    # Curvature and laser oscillations (cos part)
-    propag_phase = np.arctan((z-zf)/zr) - 0.5*k0*r**2*inv_R \
-      - k0*(z-c*prop*t-zf)
-    curvature_oscillations_cos = np.cos( propag_phase )
+    # Calculate the argument of the complex exponential
+    exp_argument = 1j*k0*(c*t + z0 - z) - r**2 / (w0**2 * diffract_factor) \
+      - 1./stretch_factor * inv_ctau2 * ( c*t  + z0 - z )**2
+
+    # Get the transverse profile
+    profile_Eperp = np.exp(exp_argument) \
+        / ( diffract_factor * stretch_factor**0.5 )
+
     # Get the profile for the Ez fields (to ensure div(E) = 0)
     # (This uses the approximation lambda0 << ctau for long_profile )
     if output_Ez_profile:
-        trans_profile_Ez = - r/zr * ( w0/waist )**3 * np.exp( -(r/waist)**2 )
-        curvature_oscillations_sin = np.sin( propag_phase )
-
-    # Combine profiles to create the Eperp and Ez profiles
-    profile_Eperp = long_profile * trans_profile_Eperp \
-                      * curvature_oscillations_cos
-    if output_Ez_profile:
-        profile_Ez = long_profile * trans_profile_Ez * \
-        ( curvature_oscillations_sin + (z-zf)/zr*curvature_oscillations_cos )
+        profile_Ez = 1.j * r * inv_zr / diffract_factor * profile_Eperp
 
     # Return the profiles
     if output_Ez_profile is False:
-        return( profile_Eperp )
+        return( profile_Eperp.real )
     else:
-        return( profile_Eperp, profile_Ez )
+        return( profile_Eperp.real, profile_Ez.real )


### PR DESCRIPTION
This simplifies the expression for a gaussian laser pulse:
- The expression uses complex numbers, which makes it simpler and more compact.
- In the boosted-frame case, we convert the points at which to calculate the laser to the lab-frame, instead of converting the wavelength, radius of curvature etc. to the boosted-frame.

In addition, I added the possibility to add temporal chirp (and a CEP phase) in the laser.
