### PR TITLE
Remove calculation of `rho_prev` from initialization and restart

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -248,9 +248,6 @@ class Simulation(object):
         # Initialize an empty list of laser antennas
         self.laser_antennas = []
 
-        # Do the initial charge deposition (at t=0) now
-        self.deposit('rho_prev')
-
     def step(self, N=1, correct_currents=True,
             correct_divE=False, use_true_rho=False,
             move_positions=True, move_momenta=True, show_progress=True):
@@ -317,7 +314,12 @@ class Simulation(object):
 
             # Check whether this iteration involves
             # particle exchange / moving window
-            if self.iteration % self.comm.exchange_period == 0:
+            if self.iteration % self.comm.exchange_period == 0 or i_step == 0:
+
+                # Note: Particle exchange is imposed at the first iteration
+                # of this loop (i_step == 0) in order to make sure that:
+                # - All particles are inside the box initially
+                # - The quantity `rho_prev` is properly defined
 
                 # Move the grids if needed
                 if self.comm.moving_win is not None:

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -129,15 +129,6 @@ def restart_from_checkpoint( sim, iteration=None ):
             for coord in ['r', 't', 'z']:
                 load_fields( sim.fld.interp[m], fieldtype,
                              coord, ts, iteration )
-        # Load the charge density (to prepare charge conservation)
-        load_fields( sim.fld.interp[m], 'rho', None, ts, iteration )
-
-    # Convert 'rho' to spectral space ('rho_prev')
-    # to prepare charge conservation for the first timestep
-    sim.fld.interp2spect( 'rho_prev' )
-    if sim.filter_currents:
-        sim.fld.filter_spect( 'rho_prev' )
-
 
 def check_restart( sim, iteration ):
     """Verify that the restart is valid."""


### PR DESCRIPTION
At the end of the `__init__` function of the `Simulation` object, as well just after a restart, we used to calculate `rho_prev` (for the purpose of current correction). However, this was:
- Inefficient (because it is was done on the CPU, even when a GPU is available)
- Useless (because it was done again in the `step` function, due to the code on particle exchange / moving window, which gets called on the very first iteration of the PIC loop)
- Sometimes incorrect (because we might add new charged particles to the simulation between the initialization and the first call to the `step` function.)

Therefore, I removed the call to `deposit(rho_prev)` in the `__init__` function and the restart code. Also, in the `step` function, I explicitly imposed that on the first iteration of the loop, `rho_prev` should be calculated. In most cases, this is not really needed since the condition `self.iteration == 0 % self.comm.exchange_period == 0` is already met. However, this might not be the case when restarting from a checkpoint (e.g. if we restart from, say, iteration 51013), so in this case the condition `i_step == 0` is needed.