### PR TITLE
Only apply external fields to a species if this species has macroparticles

### DIFF
--- a/fbpic/lpa_utils/external_fields.py
+++ b/fbpic/lpa_utils/external_fields.py
@@ -106,13 +106,17 @@ class ExternalField( object ):
             # apply the field only on this species
             if (self.species is None) or (species is self.species):
 
-                field = getattr( species, self.fieldtype )
+                # Only apply the field if there are macroparticles
+                # in this species
+                if species.Ntot > 0:
 
-                if type( field ) is np.ndarray:
-                    # Call the CPU function
-                    self.cpu_func( field, species.x, species.y, species.z,
-                        t, self.amplitude, self.length_scale, out=field )
-                else:
-                    # Call the GPU function
-                    self.gpu_func( field, species.x, species.y, species.z,
-                        t, self.amplitude, self.length_scale, out=field )
+                    field = getattr( species, self.fieldtype )
+
+                    if type( field ) is np.ndarray:
+                        # Call the CPU function
+                        self.cpu_func( field, species.x, species.y, species.z,
+                              t, self.amplitude, self.length_scale, out=field )
+                    else:
+                        # Call the GPU function
+                        self.gpu_func( field, species.x, species.y, species.z,
+                              t, self.amplitude, self.length_scale, out=field )


### PR DESCRIPTION
When external fields, and when on of the species is empty (i.e. contains no macroparticles), then the code crashes on GPU. This is apparently because `numba.vectorize` does not support empty arrays as arguments when `target` is `'cuda``.  

This caused the automated tests for ionization to crash on the GPU.

The current pull request implements a fix by simply checking whether the species is empty before applying the fields.