### PR TITLE
Add a section on "Advanced use" in the documentation

### DIFF
--- a/docs/source/advanced/advanced.rst
+++ b/docs/source/advanced/advanced.rst
@@ -1,7 +1,7 @@
 Advanced use
 ============
 
-This page contains a few more advanced tips, that can help you get
+This section contains several tips, that can help you get
 more performance and faster results from the code.
 
 **Topics:**

--- a/docs/source/advanced/advanced.rst
+++ b/docs/source/advanced/advanced.rst
@@ -1,0 +1,13 @@
+Advanced use
+============
+
+This page contains a few more advanced tips, that can help you get
+more performance and faster results from the code.
+
+**Topics:**
+
+.. toctree::
+   :maxdepth: 1
+
+   profiling
+   parameter_scans

--- a/docs/source/advanced/parameter_scans.rst
+++ b/docs/source/advanced/parameter_scans.rst
@@ -1,0 +1,2 @@
+Performing parameter scans
+==========================

--- a/docs/source/advanced/parameter_scans.rst
+++ b/docs/source/advanced/parameter_scans.rst
@@ -1,2 +1,20 @@
 Performing parameter scans in parallel
 ======================================
+
+On some clusters, a single compute node may contain several GPUs.
+In this case, it can sometimes be useful to run a separate PIC simulation on
+each GPU, as part of a parameter scan (where e.g. each separate PIC
+simulation is run with a different value of the laser intensity).
+
+However, launching these separate simulations with separate Python scripts may
+not be efficient, since it is possible that all simulations will be run on
+the same GPU, while the other GPUs will be left idle.
+
+Therefore, FBPIC provides the possibility to launch these different simulations
+as a single command with ``mpirun``, whereby each MPI rank will perform a separate
+PIC simulation, and FBPIC will make sure that each simulation runs on a separate
+GPU.
+
+Here is an example on how to structure the input script and specify the parameter
+to be varied between the separate simulations:
+:download:`parametric_script.py <../example_input/parametric_script.py>`

--- a/docs/source/advanced/parameter_scans.rst
+++ b/docs/source/advanced/parameter_scans.rst
@@ -1,2 +1,2 @@
-Performing parameter scans
-==========================
+Performing parameter scans in parallel
+======================================

--- a/docs/source/advanced/profiling.rst
+++ b/docs/source/advanced/profiling.rst
@@ -1,0 +1,2 @@
+Profiling the code
+==================

--- a/docs/source/advanced/profiling.rst
+++ b/docs/source/advanced/profiling.rst
@@ -14,7 +14,7 @@ On CPU
 ~~~~~~
 
 Run the code with
-`cProfile <http://docs.python.org/2/library/profile.html>`__
+`cProfile <http://docs.python.org/2/library/profile.html>`__ :
 
 ::
 
@@ -27,19 +27,21 @@ On GPU
 ~~~~~~
 
 Run the code with
+`nvprof <http://docs.nvidia.com/cuda/profiler-users-guide/index.html#nvprof-overview>`__ :
 
 ::
 
-    nvprof
+    nvprof --log-file gpu.log python fbpic_script.py
 
 in order to profile the device-side (i.e. GPU-side) code alone, or
 
 ::
 
-    nvprof
+    nvprof --log-file gpu.log python -m cProfile -s time fbpic_script.py > cpu.log
 
-in order to profile both the device-side and host-side code. Then open the
-files ``gpu.log`` and ``cpu.log`` with a text editor.
+in order to simultaneously profile the device-side (i.e. GPU-side)
+and host-side (i.e. CPU-side) code.
+Then open the files ``gpu.log`` and/or ``cpu.log`` with a text editor.
 
 
 Using a visual profiler
@@ -51,7 +53,7 @@ a graphical user interface).
 On CPU
 ~~~~~~
 Run the code with
-`cProfile <http://docs.python.org/2/library/profile.html>`__
+`cProfile <http://docs.python.org/2/library/profile.html>`__, using binary output:
 
 ::
 
@@ -65,7 +67,22 @@ and then open the file ``cpu.prof`` with `snakeviz <https://jiffyclub.github.io/
 
 On GPU
 ~~~~~~
+Run the code with
+`nvprof <http://docs.nvidia.com/cuda/profiler-users-guide/index.html#nvprof-overview>`__,
+using binary output:
 
+::
+
+    nvprof -o gpu.prof python fbpic_script.py
+
+and then launch
+`nvvp <http://docs.nvidia.com/cuda/profiler-users-guide/index.html#visual>`__:
+
+::
+
+    nvvp
+
+And click ``File > Open``, in order to select the file ``gpu.prof``.
 
 .. note::
 
@@ -75,3 +92,12 @@ On GPU
     was run on a remote cluster, you can simply transfer the
     files **cpu.prof** and/or **gpu.prof** to your local computer, and run
     **snakeviz** or **nvvp** locally.
+
+    You can install **nvvp** on your local computer by installing the
+    `cuda toolkit <http://developer.nvidia.com/cuda-downloads>`__.
+
+.. note::
+
+    When profiling the code with **nvprof**, the profiling data can quickly
+    become very large. Therefore we recommend to profile the code only
+    on a small number of PIC iterations (<1000).

--- a/docs/source/advanced/profiling.rst
+++ b/docs/source/advanced/profiling.rst
@@ -1,2 +1,77 @@
 Profiling the code
 ==================
+
+Profiling the code consists in finding which parts of the algorithm **dominate
+the computational time**, for your particular simulation setup.
+
+Quick text-based profiling
+--------------------------
+
+The tools below allow to dump timing statistics into a simple text file, so
+as to quickly profile the execution of a simulation.
+
+On CPU
+~~~~~~
+
+Run the code with
+`cProfile <http://docs.python.org/2/library/profile.html>`__
+
+::
+
+   python -m cProfile -s time fbpic_script.py > cpu.log
+
+and then open the file ``cpu.log`` with a text editor.
+
+
+On GPU
+~~~~~~
+
+Run the code with
+
+::
+
+    nvprof
+
+in order to profile the device-side (i.e. GPU-side) code alone, or
+
+::
+
+    nvprof
+
+in order to profile both the device-side and host-side code. Then open the
+files ``gpu.log`` and ``cpu.log`` with a text editor.
+
+
+Using a visual profiler
+-----------------------
+
+For a more detailed analysis, you can use visual profilers (i.e. profilers with
+a graphical user interface).
+
+On CPU
+~~~~~~
+Run the code with
+`cProfile <http://docs.python.org/2/library/profile.html>`__
+
+::
+
+   python -m cProfile -o cpu.prof fbpic_script.py
+
+and then open the file ``cpu.prof`` with `snakeviz <https://jiffyclub.github.io/snakeviz/>`__
+
+::
+
+   snakeviz cpu.prof
+
+On GPU
+~~~~~~
+
+
+.. note::
+
+    You do not need to run **snakeviz** or **nvvp** on the same machine on
+    which the simulation was run. (In particular, **nvvp** does not need to
+    have access to a GPU.) This means for example that, if your simulation
+    was run on a remote cluster, you can simply transfer the
+    files **cpu.prof** and/or **gpu.prof** to your local computer, and run
+    **snakeviz** or **nvvp** locally.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ that are accessible through FBPIC.
    install/installation
    how_to_run
    api_reference/api_reference.rst
-
+   advanced/advanced.rst
 
 Contributing to FBPIC
 ---------------------


### PR DESCRIPTION
The new section includes:
- how to profile the code on CPU and GPU
- how to run several separate simulations in parallel (this was not previously described in the documentation, but is often useful).

You can have a preview of the documentation by doing `make html` in the directory `docs` (see the `README` for the dependencies).