### PR TITLE
Reorganize ParticleDiagnostic and BoostedParticleDiagnostic 

### DIFF
--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -137,6 +137,7 @@ diag_period = 50        # Period of the diagnostics in number of timesteps
 # Whether to write the fields in the lab frame
 Ntot_snapshot_lab = 20
 dt_snapshot_lab = (zmax-zmin)/c
+track_bunch = False  # Whether to tag and track the particles of the bunch
 
 # ---------------------------
 # Carrying out the simulation
@@ -156,6 +157,8 @@ if __name__ == '__main__':
     # Add an electron bunch
     add_elec_bunch( sim, bunch_gamma, bunch_n, bunch_zmin,
                 bunch_zmax, 0, bunch_rmax )
+    if track_bunch:
+        sim.ptcl[2].track( sim.comm )
 
     # Add a laser to the fields of the simulation
     add_laser( sim, a0, w0, ctau, z0, lambda0=lambda0,

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -645,9 +645,9 @@ class ParticleCatcher:
                 'w' : species.w, 'inv_gamma' : species.inv_gamma }
             # Optional integer quantities
             if species.ionizer is not None:
-                particle_data['id'] = species.ionizer.ionization_level
+                particle_data['charge'] = species.ionizer.ionization_level
             if species.tracker is not None:
-                particle_data['charge'] = species.tracker.id
+                particle_data['id'] = species.tracker.id
         # GPU
         else:
             # Check if particles are sorted, otherwise raise exception
@@ -683,9 +683,9 @@ class ParticleCatcher:
                     particle_data[var] = np.empty( (0,), dtype=np.float64 )
                 # Empty optional integer quantities
                 if species.ionizer is not None:
-                    particle_data['id'] = np.empty( (0,), dtype=np.uint64 )
-                if species.tracker is not None:
                     particle_data['charge'] = np.empty( (0,), dtype=np.uint64 )
+                if species.tracker is not None:
+                    particle_data['id'] = np.empty( (0,), dtype=np.uint64 )
 
         return( particle_data )
 

--- a/fbpic/openpmd_diag/cuda_methods.py
+++ b/fbpic/openpmd_diag/cuda_methods.py
@@ -1,0 +1,132 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This files contains cuda methods that are used in the boosted-frame
+diagnostics
+"""
+import numpy as np
+from fbpic.cuda_utils import cuda, cuda_tpb_bpg_1d
+
+@cuda.jit()
+def extract_slice_from_gpu( pref_sum_curr, N_area, species ):
+    """
+    Extract the particles which have which have index between pref_sum_curr
+    and pref_sum_curr + N_area, and return them in dictionaries.
+
+    Parameters
+    ----------
+    pref_sum_curr: int
+        The starting index needed for the extraction process
+    N_area: int
+        The number of particles to extract.
+    species: an fbpic Species object
+        The species from to extract data
+
+    Returns
+    -------
+    particle_data : A dictionary of 1D float arrays (that are on the CPU)
+        A dictionary that contains the particle data of
+        the simulation (with normalized weigths).
+    integer_data : A dictionary of 1D integer arrays (that are on the CPU
+        A dictionary that contains the optional particle data
+        (ionization level and particle id)
+    """
+    # Call kernel that extracts particles from GPU
+    dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d(N_area)
+    # - General particle quantities
+    part_data = cuda.device_array( (8, N_area), dtype=np.float64 )
+    extract_particles_from_gpu[dim_grid_1d, dim_block_1d]( pref_sum_curr,
+         species.x, species.y, species.z, species.ux, species.uy, species.uz,
+         species.w, species.inv_gamma, part_data )
+    # - Optional integer particle arrays
+    integer_data = {}
+    if species.tracker is not None:
+        integer_data['id'] = cuda.device_array( (N_area,), dtype=np.uint64 )
+        extract_integers_from_gpu[dim_grid_1d, dim_block_1d](
+            pref_sum_curr, species.tracker.id, integer_data['id'] )
+    if species.ionizer is not None:
+        integer_data['charge'] = cuda.device_array( (N_area,), dtype=np.uint64 )
+        extract_integers_from_gpu[dim_grid_1d, dim_block_1d]( pref_sum_curr,
+          species.ionizer.ionization_level, integer_data['charge'] )
+
+    # Copy GPU arrays to the host
+    part_data = part_data.copy_to_host()
+    if species.ionizer is not None:
+        integer_data['charge'] = \
+            integer_data['charge'].copy_to_host()
+    if species.tracker is not None:
+        integer_data['id'] = \
+            integer_data['id'].copy_to_host()
+
+    # Return the data as dictionaries
+    particle_data = { 'x':part_data[0], 'y':part_data[1], 'z':part_data[2],
+        'ux':part_data[3], 'uy':part_data[4], 'uz':part_data[5],
+        'w':part_data[6], 'inv_gamma':part_data[7] }
+
+    return( particle_data, integer_data )
+
+
+@cuda.jit()
+def extract_particles_from_gpu( part_idx_start, x, y, z, ux, uy, uz, w,
+                                inv_gamma, selected ):
+    """
+    Extract a selection of particles from the GPU and
+    store them in a 2D array (8, N_part) in the following
+    order: x, y, z, ux, uy, uz, w, inv_gamma.
+    Selection goes from starting index (part_idx_start)
+    to (part_idx_start + N_part-1), where N_part is derived
+    from the shape of the 2D array (selected).
+
+    Parameters
+    ----------
+    part_idx_start : int
+        The starting index needed for the extraction process.
+        ( minimum particle index to be extracted )
+
+    x, y, z, ux, uy, uz, w, inv_gamma : 1D arrays of floats
+        The GPU particle arrays for a given species.
+
+    selected : 2D array of floats
+        An empty GPU array to store the particles
+        that are extracted.
+    """
+    i = cuda.grid(1)
+    N_part = selected.shape[1]
+
+    if i < N_part:
+        ptcl_idx = part_idx_start+i
+        selected[0, i] = x[ptcl_idx]
+        selected[1, i] = y[ptcl_idx]
+        selected[2, i] = z[ptcl_idx]
+        selected[3, i] = ux[ptcl_idx]
+        selected[4, i] = uy[ptcl_idx]
+        selected[5, i] = uz[ptcl_idx]
+        selected[6, i] = w[ptcl_idx]
+        selected[7, i] = inv_gamma[ptcl_idx]
+
+def extract_integers_from_gpu( part_idx_start, integer_array, selected ):
+    """
+    Extract a selection of particles from the GPU and
+    store them in a 1D array (N_part,)
+    Selection goes from starting index (part_idx_start)
+    to (part_idx_start + N_part-1), where N_part is derived
+    from the shape of the array `selected`.
+
+    Parameters
+    ----------
+    part_idx_start : int
+        The starting index needed for the extraction process.
+        ( minimum particle index to be extracted )
+
+    integer_array : 1D arrays of ints
+        The GPU particle arrays for a given species. (e.g. particle id)
+
+    selected : 1D array of ints
+        An empty GPU array to store the particles that are extracted.
+    """
+    i = cuda.grid(1)
+    N_part = selected.shape[1]
+
+    if i < N_part:
+        selected[i] = integer_array[part_idx_start+i]

--- a/fbpic/openpmd_diag/data_dict.py
+++ b/fbpic/openpmd_diag/data_dict.py
@@ -39,4 +39,4 @@ weighting_power_dict = {
     "position": 0.,
     "positionOffset": 0.,
     "momentum": 1.,
-    "id": 0 }
+    "id": 0. }

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ class PyTest(TestCommand):
 
     def run_tests(self):
         import pytest
-        errcode = pytest.main(['--ignore=tests/unautomated'])
+        errcode = pytest.main(['--ignore=tests/unautomated', '--durations=10'])
         sys.exit(errcode)
 
 setup(

--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -164,6 +164,16 @@ def test_boosted_frame_sim_twoproc():
     response = os.system( 'mpirun -np 2 python boosted_frame_script.py' )
     assert response==0
 
+    # Check that the particle ids are unique at each iterations
+    ts = OpenPMDTimeSeries('./lab_diags/hdf5')
+    print('Checking particle ids...')
+    start_time = time.time()
+    for iteration in ts.iterations:
+        pid, = ts.get_particle(["id"], iteration=iteration)
+        assert len(np.unique(pid)) == len(pid)
+    end_time = time.time()
+    print( "%.2f seconds" %(end_time-start_time))
+
     # Exit the temporary directory and suppress it
     os.chdir('../../')
     shutil.rmtree( temporary_dir )

--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -149,9 +149,17 @@ def test_boosted_frame_sim_twoproc():
     os.mkdir( temporary_dir )
     shutil.copy('./docs/source/example_input/boosted_frame_script.py',
                     temporary_dir )
-
-    # Enter the temporary directory and run the script
+    # Enter the temporary directory
     os.chdir( temporary_dir )
+
+    # Read the script and check that the targeted lines are present
+    with open('boosted_frame_script.py') as f:
+        script = f.read()
+    # Modify the script so as to enable particle tracking
+    script = script.replace('track_bunch = False', 'track_bunch = True')
+    with open('boosted_frame_script.py', 'w') as f:
+        f.write(script)
+
     # Launch the script from the OS
     response = os.system( 'mpirun -np 2 python boosted_frame_script.py' )
     assert response==0


### PR DESCRIPTION
# Overview

The aim of this pull request is to add optional integer arrays (like the ionization level, and the particle IDs) to the boosted-frame diagnostics. 

Because the boosted-frame diagnostics used to store (buffer) the quantities in a **2d array of floats** (where the first dimension correspond to the particle quantity and the second corresponds to individual macroparticles), I had to change the data structures in the boosted-frame diagnostics. I now use dictionaries, whose keys are particle quantities (e.g. 'x', 'ux', 'id', etc.) and whose values are 1d arrays (either of float or integers).

This change lead to substantial modifications in the code.

# Summary of the changes

- Dictionaries containing 1d arrays are now used everywhere in the boosted-diagnostics.
- The quantity `self.array_quantities_dict` (which contains the particle quantities which should be written to the file, for each species) used to contain strings like `'position'`, `'momentum'`, etc. It now contains directly quantities like `'x'`,  `'y'`, `'ux'`, which are the keys of the above-mentioned dictionaries. This made it easier to work with the dictionaries, but required additional changes, including in the regular particle diagnostics (which also use `self.array_quantities_dict`).
- The functions that handle the GPU part of the boosted-frame diagnostics (e.g. extracting a slice of particles) were removed from `boosted_particle_diag.py` and put into a new file `cuda_methods.py`. A new function (for integer arrays) was added.
- The tests were updated, so as to run boosted-frame diagnostics using the particle ids.
