### PR TITLE
Removed the use of `keys()` when looping through species

### DIFF
--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -168,7 +168,8 @@ class BoostedParticleDiagnostic(ParticleDiagnostic):
 
                 # Loop through the particle species and register the
                 # data dictionaries in the snapshot objects (buffering)
-                for species_name, species in self.species_dict.items():
+                for species_name in self.species_names_list:
+                    species = self.species_dict[species_name]
                     # Extract the slice of particles
                     slice_data_dict = self.particle_catcher.extract_slice(
                         species, snapshot.current_z_boost,
@@ -186,7 +187,7 @@ class BoostedParticleDiagnostic(ParticleDiagnostic):
 
             # Compact the successive slices that have been buffered
             # over time into a single array
-            for species_name in self.species_dict:
+            for species_name in self.species_names_list:
 
                 # Get list of quantities to be written to file
                 quantities_in_file = self.array_quantities_dict[species_name]
@@ -332,7 +333,8 @@ class BoostedParticleDiagnostic(ParticleDiagnostic):
             # Setup the meshes group (contains all the particles)
             particle_path = "/data/%d/particles/" %iteration
 
-            for species_name, species in self.species_dict.items():
+            for species_name in self.species_names_list:
+                species = self.species_dict[species_name]
                 species_path = particle_path+"%s/" %(species_name)
                 # Create and setup the h5py.Group species_grp
                 species_grp = f.require_group( species_path )


### PR DESCRIPTION
When using the `ParticleDiagnostic`, the user passes the species that need to be written as a dictionary. Then, internally, the code loops over species (e.g. in order to do MPI Gather) by looping over the keys of the dictionary. 

However, this is a very bad practice, since the keys of a dictionary do not have a well-defined order in Python. This means that different MPI proc could loop over species in different order. 

This PR fixes the problem by using the attribute `species_names_list`, which has a well-defined order.