### PR TITLE
Changed cuda imports

### DIFF
--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -6,16 +6,14 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the structure necessary to handle mpi buffers for the fields
 """
 import numpy as np
-try:
-    from fbpic.cuda_utils import cuda_tpb_bpg_2d, cuda
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
+    from fbpic.cuda_utils import cuda, cuda_tpb_bpg_2d
     from .cuda_methods import \
         copy_EB_to_gpu_buffers, copy_EB_from_gpu_buffers, \
         copy_J_to_gpu_buffers, add_J_from_gpu_buffers, \
         copy_rho_to_gpu_buffers, add_rho_from_gpu_buffers
-    cuda_installed = True
-except ImportError:
-    cuda_installed = False
-
 
 class BufferHandler(object):
     """

--- a/fbpic/boundaries/guard_cell_damping.py
+++ b/fbpic/boundaries/guard_cell_damping.py
@@ -6,11 +6,10 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the structure that damps the fields in the guard cells.
 """
 import numpy as np
-try:
-    from fbpic.cuda_utils import cuda_tpb_bpg_2d, cuda
-    cuda_installed = cuda.is_available()
-except ImportError:
-    cuda_installed = False
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
+    from fbpic.cuda_utils import cuda, cuda_tpb_bpg_2d
 
 class GuardCellDamper(object):
     """
@@ -118,7 +117,7 @@ def generate_damp_array( n_guard, n_order, neighbor_proc, exchange_period ):
         If the stencil fits into the guard cells, no damping is performed,
         between two processors. (Damping is still performed in the guard
         cells that correspond to open boundaries)
-        
+
     neighbor_proc: int or None
         Indicate wether the present guard cells correspond to an open
         boundary (neighbor_proc = None) or a boundary with another

--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -9,14 +9,10 @@ import numpy as np
 from scipy.constants import c
 from fbpic.particles import Particles
 from fbpic.lpa_utils.boosted_frame import BoostConverter
-try:
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
     from fbpic.cuda_utils import cuda, cuda_tpb_bpg_2d
-    if cuda.is_available():
-        cuda_installed = True
-    else:
-        cuda_installed = False
-except ImportError:
-    cuda_installed = False
 
 class MovingWindow(object):
     """

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -7,14 +7,10 @@ It defines the structure necessary to handle mpi buffers for the particles
 """
 import numpy as np
 import numba
-try:
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
     from fbpic.cuda_utils import cuda, cuda_tpb_bpg_1d
-    if cuda.is_available():
-        cuda_installed = True
-    else:
-        cuda_installed = False
-except ImportError:
-    cuda_installed = False
 
 def remove_outside_particles(species, fld, nguard, left_proc, right_proc):
     """

--- a/fbpic/cuda_utils.py
+++ b/fbpic/cuda_utils.py
@@ -7,6 +7,12 @@ It defines a set of generic functions that operate on a GPU.
 """
 from numba import cuda
 
+# Check if CUDA is available and set variable accordingly
+try:
+    cuda_installed = cuda.is_available()
+except Exception:
+    cuda_installed = False
+
 # -----------------------------------------------------
 # CUDA grid utilities
 # -----------------------------------------------------

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -9,21 +9,18 @@ import numpy as np
 from scipy.constants import c, mu_0, epsilon_0
 from .numba_methods import numba_push_eb_standard, numba_push_eb_comoving, \
     numba_correct_currents_standard, numba_correct_currents_comoving
-from .spectral_transform import SpectralTransformer, cuda_installed
+from .spectral_transform import SpectralTransformer
 
-# If cuda is installed for the spectral transformer, import
-# the rest of the cuda methods
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
 if cuda_installed:
-    try:
-        from fbpic.cuda_utils import cuda_tpb_bpg_2d
-        from .cuda_methods import cuda, \
-        cuda_correct_currents_standard, cuda_correct_currents_comoving, \
-        cuda_divide_scalar_by_volume, cuda_divide_vector_by_volume, \
-        cuda_erase_scalar, cuda_erase_vector, \
-        cuda_filter_scalar, cuda_filter_vector, \
-        cuda_push_eb_standard, cuda_push_eb_comoving, cuda_push_rho
-    except ImportError:
-        cuda_installed = False
+    from fbpic.cuda_utils import cuda_tpb_bpg_2d
+    from .cuda_methods import cuda, \
+    cuda_correct_currents_standard, cuda_correct_currents_comoving, \
+    cuda_divide_scalar_by_volume, cuda_divide_vector_by_volume, \
+    cuda_erase_scalar, cuda_erase_vector, \
+    cuda_filter_scalar, cuda_filter_vector, \
+    cuda_push_eb_standard, cuda_push_eb_comoving, cuda_push_rho
 
 class Fields(object) :
     """

--- a/fbpic/fields/spectral_transform/fourier.py
+++ b/fbpic/fields/spectral_transform/fourier.py
@@ -8,13 +8,12 @@ and is used in spectral_transformer.py
 """
 import numpy as np
 import pyfftw
-try :
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
     from accelerate.cuda import fft as cufft, blas as cublas
-    from fbpic.cuda_utils import cuda_tpb_bpg_2d
-    from .cuda_methods import cuda, cuda_copy_2d_to_1d, cuda_copy_1d_to_2d
-    cuda_installed = True
-except ImportError :
-    cuda_installed = False
+    from fbpic.cuda_utils import cuda, cuda_tpb_bpg_2d
+    from .cuda_methods import cuda_copy_2d_to_1d, cuda_copy_1d_to_2d
 
 class FFT(object):
     """

--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -40,14 +40,12 @@ import numpy as np
 from scipy.special import jn, jn_zeros
 from scipy.optimize import fsolve
 
-# Try to import cuda and cublas
-try :
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
     from accelerate.cuda import blas as cublas
-    from fbpic.cuda_utils import cuda_tpb_bpg_2d
-    from .cuda_methods import cuda, cuda_copy_2d_to_2d
-    cuda_installed = True
-except ImportError :
-    cuda_installed = False
+    from fbpic.cuda_utils import cuda, cuda_tpb_bpg_2d
+    from .cuda_methods import cuda_copy_2d_to_2d
 
 # The list of available methods
 available_methods = [ 'QDHT', 'MDHT(m+1,m)', 'MDHT(m-1,m)', 'MDHT(m,m)']

--- a/fbpic/fields/spectral_transform/spectral_transformer.py
+++ b/fbpic/fields/spectral_transform/spectral_transformer.py
@@ -7,15 +7,13 @@ It defines the SpectralTransformer class, which handles conversion of
 the fields from the interpolation grid to the spectral grid and vice-versa.
 """
 from .hankel import DHT
-from .fourier import FFT, cuda_installed
+from .fourier import FFT
 
-# If the cuda FFT is installed, try importing all the other cuda methods.
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
 if cuda_installed:
-    try :
-        from fbpic.cuda_utils import cuda_tpb_bpg_2d
-        from .cuda_methods import cuda_rt_to_pm, cuda_pm_to_rt
-    except ImportError :
-        cuda_installed = False
+    from fbpic.cuda_utils import cuda_tpb_bpg_2d
+    from .cuda_methods import cuda_rt_to_pm, cuda_pm_to_rt
 
 class SpectralTransformer(object) :
     """

--- a/fbpic/lpa_utils/external_fields.py
+++ b/fbpic/lpa_utils/external_fields.py
@@ -1,8 +1,10 @@
 # Copyright 2016, FBPIC contributors
 # Authors: Remi Lehe, Manuel Kirchen
 # License: 3-Clause-BSD-LBNL
-from numba import cuda, vectorize, float64
+from numba import vectorize, float64
 import numpy as np
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
 
 class ExternalField( object ):
 
@@ -80,7 +82,7 @@ class ExternalField( object ):
                                float64, float64, float64, float64 ) ]
         cpu_compiler = vectorize( signature, target='cpu', nopython=True )
         self.cpu_func = cpu_compiler( field_func )
-        if cuda.is_available():
+        if cuda_installed:
             gpu_compiler = vectorize( signature, target='cuda' )
             self.gpu_func = gpu_compiler( field_func )
 

--- a/fbpic/lpa_utils/laser/antenna.py
+++ b/fbpic/lpa_utils/laser/antenna.py
@@ -13,12 +13,10 @@ from .profiles import gaussian_profile
 from fbpic.particles.utility_methods import weights
 from fbpic.particles.numba_methods import deposit_field_numba
 
-try:
-    from numba import cuda
-    from fbpic.cuda_utils import cuda_tpb_bpg_1d
-    cuda_installed = cuda.is_available()
-except ImportError:
-    cuda_installed = False
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
+    from fbpic.cuda_utils import cuda, cuda_tpb_bpg_1d
 
 class LaserAntenna( object ):
     """

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -10,21 +10,19 @@ This file steers and controls the simulation.
 # (This needs to be done before the other imports,
 # as it sets the cuda context)
 from mpi4py import MPI
-try:
-    from .cuda_utils import cuda, send_data_to_gpu, \
+# Check if CUDA is available, then import CUDA functions
+from .cuda_utils import cuda_installed
+if cuda_installed:
+    from .cuda_utils import send_data_to_gpu, \
                 receive_data_from_gpu, mpi_select_gpus
-    cuda_installed = cuda.is_available()
-    if cuda_installed:
-        mpi_select_gpus( MPI )
-except ImportError:
-    cuda_installed = False
+    mpi_select_gpus( MPI )
 
 # Import the rest of the requirements
 import sys, time
 from scipy.constants import m_e, m_p, e, c
 from .particles import Particles
 from .lpa_utils.boosted_frame import BoostConverter
-from .fields import Fields, cuda_installed
+from .fields import Fields
 from .boundaries import BoundaryCommunicator, MovingWindow
 
 class Simulation(object):

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -16,12 +16,10 @@ import numpy as np
 from scipy.constants import c
 from .field_diag import FieldDiagnostic
 
-# If accelerate is installed, it potentially allows to use a GPU
-try :
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
     from fbpic.cuda_utils import cuda, cuda_tpb_bpg_1d
-    cuda_installed = cuda.is_available()
-except ImportError:
-    cuda_installed = False
 
 class BoostedFieldDiagnostic(FieldDiagnostic):
     """

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -15,9 +15,9 @@ import numpy as np
 from scipy.constants import c, e
 from .particle_diag import ParticleDiagnostic
 
-# If cuda is installed, it potentially allows to use a GPU
-from numba import cuda
-if cuda.is_available():
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
     from .cuda_methods import extract_particles_from_gpu
 
 class BoostedParticleDiagnostic(ParticleDiagnostic):

--- a/fbpic/particles/ionization/inline_functions.py
+++ b/fbpic/particles/ionization/inline_functions.py
@@ -6,11 +6,10 @@ used in the ionization code.
 import math
 import numba
 from scipy.constants import e
-try:
-    from numba import cuda
-    cuda_installed = cuda.is_available()
-except ImportError:
-    cuda_installed = False
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
+    from fbpic.cuda_utils import cuda
 
 # ----------------------------
 # Function for field amplitude

--- a/fbpic/particles/ionization/ionizer.py
+++ b/fbpic/particles/ionization/ionizer.py
@@ -34,14 +34,13 @@ from scipy.constants import c, e, m_e, physical_constants
 from scipy.special import gamma
 from .read_atomic_data import get_ionization_energies
 from .numba_methods import ionize_ions_numba, copy_ionized_electrons_numba
-try:
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
     from accelerate.cuda.rand import PRNG
     from fbpic.cuda_utils import cuda_tpb_bpg_1d
     from .cuda_methods import ionize_ions_cuda, \
         copy_ionized_electrons_cuda, copy_particle_data_cuda
-    cuda_installed = True
-except ImportError:
-    cuda_installed = False
 
 class Ionizer(object):
     """

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -16,8 +16,9 @@ from .utility_methods import weights, unalign_angles
 from .numba_methods import push_p_numba, push_p_ioniz_numba, push_x_numba, \
         gather_field_numba, deposit_field_numba
 
-# If accelerate is installed, it potentially allows to use a GPU
-try :
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
     from fbpic.cuda_utils import cuda, cuda_tpb_bpg_1d, cuda_tpb_bpg_2d
     from .cuda_methods import push_p_gpu, push_p_ioniz_gpu, push_x_gpu, \
         gather_field_gpu_linear, gather_field_gpu_cubic, \
@@ -30,10 +31,6 @@ try :
         deposit_J_gpu_linear
     from .cuda_deposition.linear_non_atomic import deposit_rho_gpu, \
         deposit_J_gpu, add_rho, add_J
-    cuda_installed = True
-except ImportError:
-    cuda_installed = False
-
 
 class Particles(object) :
     """

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -7,11 +7,10 @@ It defines the structure and methods associated with particle tracking.
 """
 import numpy as np
 from numba import cuda
-cuda_installed = cuda.is_available()
-try:
+# Check if CUDA is available, then import CUDA functions
+from fbpic.cuda_utils import cuda_installed
+if cuda_installed:
     from fbpic.cuda_utils import cuda_tpb_bpg_1d
-except ImportError:
-    cuda_installed = False
 
 class ParticleTracker(object):
     """


### PR DESCRIPTION
This simplifies the import of cuda related methods. CUDA availability is now always checked in cuda_utils and stored in the variable cuda_installed. This variable is imported at the beginning of all other cuda-related files.