### PR TITLE
Update the diagnostics

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -315,17 +315,17 @@ class Simulation(object):
             if show_progress and self.comm.rank==0:
                 progression_bar( i_step, N, measured_start )
 
+            # Run the diagnostics
+            # (E, B, rho, x are defined at time n; J, p at time n-1/2)
+            for diag in self.diags:
+                # Check if the diagnostic should be written at this iteration
+                # and write it, if it is the case.
+                # (If needed: bring rho/J from spectral space, where they 
+                # were smoothed/corrected, and copy the data from the GPU.)
+                diag.write( self.iteration )
+
             # Exchanges to prepare for this iteration
             # ---------------------------------------
-
-            # Run the diagnostics
-            # (E, B, rho, x are defined at time n)
-            # (J, p are defined at time n-1/2)
-            for diag in self.diags:
-                # Check if the fields should be written at
-                # this iteration and do it if needed.
-                # (Send the data to the GPU if needed.)
-                diag.write( self.iteration )
 
             # Exchange the fields (EB) in the guard cells between MPI domains
             self.comm.exchange_fields(fld.interp, 'EB')
@@ -333,15 +333,15 @@ class Simulation(object):
             # Check whether this iteration involves particle exchange,
             # defined by "exchange_period".
             # Note: Particle exchange is imposed at the first iteration
-            # of this loop (i_step == 0) in order to make sure that
-            # all particles are inside the box initially
+            # of this loop (i_step == 0) in order to ensure that all
+            # particles are inside the box, and that 'rho_prev' is correct
             if self.iteration % self.comm.exchange_period == 0 or i_step == 0:
                 # Particle exchange after moving window / mpi communications
                 # This includes MPI exchange of particles, removal of
                 # out-of-box particles and (if there is a moving window)
                 # injection of new particles by the moving window.
                 # (In the case of single-proc periodic simulations, particles
-                # are shifted by one box length, so they remain inside the box.)
+                # are shifted by one box length, so they remain inside the box)
                 for species in self.ptcl:
                     self.comm.exchange_particles(species, fld, self.time)
                 # Set again the number of cells to be injected to 0
@@ -349,9 +349,10 @@ class Simulation(object):
                 if self.comm.moving_win is not None:
                     self.comm.moving_win.nz_inject = 0
                 # Reproject the charge on the interpolation grid
-                # (Since the moving window has moved or particles
-                # have been removed / added to the simulation)
+                # (Since particles have been removed / added to the simulation;
+                # otherwise rho_prev is obtained from the previous iteration)
                 self.deposit('rho_prev')
+
 
             # Gather the fields from the grid at t = n dt
             for species in ptcl:

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -259,8 +259,9 @@ class Simulation(object):
 
         # Initialize an empty list of external fields
         self.external_fields = []
-        # Initialize an empty list of diagnostics
+        # Initialize an empty list of diagnostics and checkpoints
         self.diags = []
+        self.checkpoints = []
         # Initialize an empty list of laser antennas
         self.laser_antennas = []
 
@@ -305,6 +306,9 @@ class Simulation(object):
         if self.use_cuda:
             send_data_to_gpu(self)
 
+        # Beginning of the N iterations
+        # -----------------------------
+
         # Loop over timesteps
         for i_step in range(N):
 
@@ -320,7 +324,7 @@ class Simulation(object):
             for diag in self.diags:
                 # Check if the diagnostic should be written at this iteration
                 # and write it, if it is the case.
-                # (If needed: bring rho/J from spectral space, where they 
+                # (If needed: bring rho/J from spectral space, where they
                 # were smoothed/corrected, and copy the data from the GPU.)
                 diag.write( self.iteration )
 
@@ -330,15 +334,13 @@ class Simulation(object):
             # Exchange the fields (EB) in the guard cells between MPI domains
             self.comm.exchange_fields(fld.interp, 'EB')
 
-            # Check whether this iteration involves particle exchange,
-            # defined by "exchange_period".
+            # Check whether this iteration involves particle exchange.
             # Note: Particle exchange is imposed at the first iteration
             # of this loop (i_step == 0) in order to ensure that all
             # particles are inside the box, and that 'rho_prev' is correct
             if self.iteration % self.comm.exchange_period == 0 or i_step == 0:
-                # Particle exchange after moving window / mpi communications
-                # This includes MPI exchange of particles, removal of
-                # out-of-box particles and (if there is a moving window)
+                # Particle exchange includes MPI exchange of particles, removal
+                # of out-of-box particles and (if there is a moving window)
                 # injection of new particles by the moving window.
                 # (In the case of single-proc periodic simulations, particles
                 # are shifted by one box length, so they remain inside the box)
@@ -348,11 +350,14 @@ class Simulation(object):
                 # (This number is incremented when `move_grids` is called)
                 if self.comm.moving_win is not None:
                     self.comm.moving_win.nz_inject = 0
+
                 # Reproject the charge on the interpolation grid
                 # (Since particles have been removed / added to the simulation;
                 # otherwise rho_prev is obtained from the previous iteration)
                 self.deposit('rho_prev')
 
+            # Main PIC iteration
+            # ------------------
 
             # Gather the fields from the grid at t = n dt
             for species in ptcl:
@@ -422,6 +427,13 @@ class Simulation(object):
             # Increment the global time and iteration
             self.time += self.dt
             self.iteration += 1
+
+            # Write the checkpoints if needed
+            for checkpoint in self.checkpoints:
+                checkpoint.write( self.iteration )
+
+        # End of the N iterations
+        # -----------------------
 
         # Finalize PIC loop
         # Get the charge density and the current from spectral space.

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -319,8 +319,8 @@ class Simulation(object):
             # ---------------------------------------
 
             # Run the diagnostics
-            # (E, B, rho are defined at time n)
-            # (J, x, p are defined at time n+1/2)
+            # (E, B, rho, x are defined at time n)
+            # (J, p are defined at time n-1/2)
             for diag in self.diags:
                 # Check if the fields should be written at
                 # this iteration and do it if needed.

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -260,6 +260,7 @@ class Simulation(object):
         # Initialize an empty list of external fields
         self.external_fields = []
         # Initialize an empty list of diagnostics and checkpoints
+        # (Checkpoints are used for restarting the simulation)
         self.diags = []
         self.checkpoints = []
         # Initialize an empty list of laser antennas

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -69,6 +69,8 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
             for "E" and "B" (because "rho" and "J" are staggered in time).
             The user can still output "rho" and "J" by changing `fieldtypes`,
             but has to be aware that there may errors in the backward transform.
+            Moreover, writing rho/J slows down the simulation, as these fields
+            are then brought from spectral to real space, at each iteration.
         """
         # Do not leave write_dir as None, as this may conflict with
         # the default directory ('./diags') in which diagnostics in the
@@ -130,6 +132,13 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
         iteration : int
             The current iteration in the boosted frame simulation
         """
+        # If needed: Bring rho/J from spectral space (where they where
+        # smoothed/corrected) to real space
+        if "rho" in self.fieldtypes or "J" in self.fieldtypes:
+            # Get 'rho_prev', since it correspond to rho at time n
+            self.fld.spect2interp('rho_prev')
+            self.fld.spect2interp('J')
+
         # Find the limits of the local subdomain at this iteration
         zmin_boost = self.fld.interp[0].zmin
         zmax_boost = self.fld.interp[0].zmax

--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -67,7 +67,15 @@ class FieldDiagnostic(OpenPMDDiagnostic):
         iteration : int
              The current iteration number of the simulation.
         """
-        # Receive data from the GPU if needed
+        # If needed: Bring rho/J from spectral space (where they where
+        # smoothed/corrected) to real space
+        if "rho" in self.fieldtypes:
+            # Get 'rho_prev', since it correspond to rho at time n
+            self.fld.spect2interp('rho_prev')
+        if "J" in self.fieldtypes:
+            self.fld.spect2interp('J')
+
+        # If needed: Receive data from the GPU
         if self.fld.use_cuda :
             self.fld.receive_fields_from_gpu()
 

--- a/fbpic/openpmd_diag/particle_diag.py
+++ b/fbpic/openpmd_diag/particle_diag.py
@@ -401,7 +401,12 @@ class ParticleDiagnostic(OpenPMDDiagnostic) :
                 dtype = 'uint64'
             else:
                 dtype = 'f8'
-            dset = species_grp.require_dataset(path, datashape, dtype=dtype )
+            # If the dataset already exists, remove it.
+            # (This avoids errors with diags from previous simulations,
+            # in case the number of particles is not exactly the same.)
+            if path in species_grp.keys():
+                del species_grp[path]
+            dset = species_grp.create_dataset(path, datashape, dtype=dtype )
             self.setup_openpmd_species_component( dset, quantity )
 
         # Fill the dataset with the quantity

--- a/fbpic/openpmd_diag/particle_diag.py
+++ b/fbpic/openpmd_diag/particle_diag.py
@@ -404,7 +404,7 @@ class ParticleDiagnostic(OpenPMDDiagnostic) :
             # If the dataset already exists, remove it.
             # (This avoids errors with diags from previous simulations,
             # in case the number of particles is not exactly the same.)
-            if path in species_grp.keys():
+            if path in species_grp:
                 del species_grp[path]
             dset = species_grp.create_dataset(path, datashape, dtype=dtype )
             self.setup_openpmd_species_component( dset, quantity )


### PR DESCRIPTION
This pull request fixes a number of issues with the diagnostics:
 - The checkpoints are now done at the end of the PIC loop
 - `rho` and `J` are only brought back from spectral space if they are needed for the diagnostics
 - The code does not crash anymore when trying to write into a diagnostic file that previously existed (this issue was typically due to a different number of particles in the pre-existing diagnostic)

In addition, I updated and cleaned the comments in the main step function.