### PR TITLE
Fix error with cuda power operator

### DIFF
--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -571,6 +571,9 @@ if cuda_installed:
 
         # Only access values that are actually in the array
         if ir < field_array.shape[1] and iz < field_array.shape[0]:
-            # Shift fields backward
-            field_array[iz, ir] = field_array[iz, ir] \
-                * ( shift_factor[iz] )**n_move
+            # Calculate the shift factor (raising to the power n_move)
+            power_shift = shift_factor[iz]
+            for i in range(1,n_move):
+                power_shift *= shift_factor[iz]
+            # Shift fields backwards
+            field_array[iz, ir] *= power_shift


### PR DESCRIPTION
When running the tests on the GPU, I realized that the new function `shift_spect_array_gpu` is causing an error when running on GPU: the power operator (`**n_move`) does not seem to work correctly.

I by-passed this strange error by simply raising to the power `n_move` by hand (since `n_move` is typically 1 or otherwise a small integer).
