### PR TITLE
Fix and test ionization output in the boosted-frame

### DIFF
--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -679,7 +679,7 @@ class ParticleCatcher:
             # Check if there are particles to extract
             if N_area > 0:
                 # Only copy a particle slice of size N_area from the GPU
-                particle_data = extract_particles_from_gpu(
+                particle_data = extract_slice_from_gpu(
                                     pref_sum_curr, N_area, species )
             else:
                 # Empty particle data

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -18,7 +18,7 @@ from .particle_diag import ParticleDiagnostic
 # Check if CUDA is available, then import CUDA functions
 from fbpic.cuda_utils import cuda_installed
 if cuda_installed:
-    from .cuda_methods import extract_particles_from_gpu
+    from .cuda_methods import extract_slice_from_gpu
 
 class BoostedParticleDiagnostic(ParticleDiagnostic):
     """

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -654,10 +654,11 @@ class ParticleCatcher:
                 particle_data['id'] = species.tracker.id
         # GPU
         else:
-            # Check if particles are sorted, otherwise raise exception
+            # Check if particles are sorted, otherwise sort them
             if species.sorted == False:
-                raise ValueError('Particle boosted-frame diagnostic: \
-                 The particles are not sorted!')
+                species.sort_particles(fld=self.fld)
+                # The particles are now sorted and rearranged
+                species.sorted = True
             # Precalculating quantities and shortcuts
             dt = self.fld.dt
             dz = self.fld.interp[0].dz

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -649,7 +649,7 @@ class ParticleCatcher:
             if species.ionizer is not None:
                 particle_data['charge'] = species.ionizer.ionization_level
                 # Replace particle weight
-                particle_data['w'] = species.neutral_weight
+                particle_data['w'] = species.ionizer.neutral_weight
             if species.tracker is not None:
                 particle_data['id'] = species.tracker.id
         # GPU

--- a/fbpic/openpmd_diag/cuda_methods.py
+++ b/fbpic/openpmd_diag/cuda_methods.py
@@ -124,7 +124,7 @@ def extract_array_from_gpu( part_idx_start, array, selected ):
         An empty GPU array to store the particles that are extracted.
     """
     i = cuda.grid(1)
-    N_part = selected.shape[1]
+    N_part = selected.shape[0]
 
     if i < N_part:
         selected[i] = array[part_idx_start+i]

--- a/tests/test_ionization.py
+++ b/tests/test_ionization.py
@@ -22,7 +22,7 @@ through external fields.
 # -------
 # Imports
 # -------
-import math
+import os, shutil, math
 import numpy as np
 from scipy.constants import c, m_e, m_p, e
 # Import the relevant structures in FBPIC
@@ -31,12 +31,13 @@ from fbpic.particles import Particles
 from fbpic.lpa_utils.external_fields import ExternalField
 from fbpic.lpa_utils.boosted_frame import BoostConverter
 from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic
+# Import openPMD-viewer for checking output files
+from opmd_viewer import OpenPMDTimeSeries
 
 # ----------
 # Parameters
 # ----------
 use_cuda = True
-output_hdf5_files = False
 
 def run_simulation( gamma_boost ):
     """
@@ -113,7 +114,10 @@ def run_simulation( gamma_boost ):
     v_plasma, = boost.velocity( [ 0. ] )
 
     # The diagnostics
-    diag_period = int(N_step/50) # Period of the diagnostics in number of timesteps
+    diag_period = N_step-1 # Period of the diagnostics in number of timesteps
+
+    # Move into directory `tests`
+    os.chdir('./tests')
 
     # Initialize the simulation object
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
@@ -145,11 +149,9 @@ def run_simulation( gamma_boost ):
         ExternalField( laser_func, 'By', B0, 0. ) ]
 
     # Add a field diagnostic
-    if output_hdf5_files:
-        sim.diags = [ FieldDiagnostic( diag_period, sim.fld, sim.comm ),
-                        ParticleDiagnostic( diag_period,
-                        {"electrons":sim.ptcl[0], "ions":sim.ptcl[1]},
-                        comm=sim.comm) ]
+    sim.diags = [ FieldDiagnostic( diag_period, sim.fld, comm=sim.comm ),
+                    ParticleDiagnostic( diag_period,
+                    {"ions":sim.ptcl[1]}, comm=sim.comm) ]
 
     # Run the simulation
     sim.step( N_step, use_true_rho=True )
@@ -165,6 +167,19 @@ def run_simulation( gamma_boost ):
     N5_fraction = n_N5 / ntot
     print('N5+ fraction: %.4f' %N5_fraction)
     assert ((N5_fraction > 0.30) and (N5_fraction < 0.34))
+
+    # Check consistency in the regular openPMD diagnostics
+    ts = OpenPMDTimeSeries('./diags/hdf5/')
+    last_iteration = ts.iterations[-1]
+    w, q = ts.get_particle( ['w', 'charge'], species="ions",
+                                iteration=last_iteration )
+    # Check that the openPMD file contains the same number of N5+ ions
+    n_N5_openpmd = np.sum(w[ (4.5*e < q) & (q < 5.5*e) ])
+    assert np.isclose( n_N5_openpmd, n_N5 )
+
+    # Remove openPMD files
+    shutil.rmtree('./diags/')
+    os.chdir('../')
 
 def test_ionization_labframe():
     run_simulation(1.)


### PR DESCRIPTION
When implementing the automated tests for the openPMD output with ionization (see issue #58), I realized that there was a bug in the boosted-frame output for ionization (which caused the code to crash when using it!).

The present pull request fixes this bug and implements corresponding automated tests.

Note that this pull request is to the `master` branch and not the `dev` branch. This is intentional: once the pull request is merged, I'll do a new release (`0.4.1`) that corrects this bug. I will then merge `master` into `dev` so that `dev` also has the bug fix.