### PR TITLE
Changes precision of directory naming in parametric example script

### DIFF
--- a/docs/source/example_input/parametric_script.py
+++ b/docs/source/example_input/parametric_script.py
@@ -135,7 +135,7 @@ if __name__ == '__main__':
     # Add a field diagnostic
     # Parametric scan: each MPI rank should output its data to a
     # different directory
-    write_dir = 'diags_a0_%.1f' %a0
+    write_dir = 'diags_a0_%.2f' %a0
     sim.diags = [ FieldDiagnostic( diag_period, sim.fld,
                     comm=sim.comm, write_dir=write_dir ),
                 ParticleDiagnostic( diag_period, {"electrons" : sim.ptcl[0]},

--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -241,7 +241,7 @@ def test_parametric_sim_twoproc():
     # a0 (this is done by checking the a0 of the laser, with openPMD-viewer)
     for a0 in [ 2.0, 4.0 ]:
         # Open the diagnotics
-        diag_folder = 'diags_a0_%.1f/hdf5' %a0
+        diag_folder = 'diags_a0_%.2f/hdf5' %a0
         ts = LpaDiagnostics( diag_folder )
         # Check that the value of a0 in the diagnostics is the
         # expected one.


### PR DESCRIPTION
There is a problem, when using the parmetric_script.py, if you try to start a scan with closely spaced parameters, e.g. something like:

```python
a0_list = np.linspace(1.8, 2.2, 8)
```
i.e. values that require more than single digit precision.

For the diags the script creates directories with %.1f string replacements, meaning that 1.81 and 1.84 would create the same directory, which causes problems when writing the output.

As I couldn't think of a real robust solution I just changed the precision to %.2f. This doesn't fix the problem, but makes it less likely.