### PR TITLE
Change order of particles at initialization

### DIFF
--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -182,9 +182,10 @@ class Particles(object) :
             # Get the corresponding particles positions
             # (copy=True is important here, since it allows to
             # change the angles individually)
-            zp, rp, thetap = np.meshgrid( z_reg, r_reg, theta_reg, copy=True)
+            zp, rp, thetap = np.meshgrid( z_reg, r_reg, theta_reg,
+                                        copy=True, indexing='ij' )
             # Prevent the particles from being aligned along any direction
-            unalign_angles( thetap, Npr, Npz, method='random' )
+            unalign_angles( thetap, Npz, Npr, method='random' )
             # Flatten them (This performs a memory copy)
             r = rp.flatten()
             self.x[:] = r * np.cos( thetap.flatten() )


### PR DESCRIPTION
Before this pull request, the particles were initialized such that, when going through the array of particles in order:
- `theta` changes the fastest (while `z` and `r` remain constant)
- then `z` changes 
- then `r` changes the slowest

However, in order to optimize cache reuse, in the current deposition and gathering, it is better to have the following order:
- `theta` changes the fastest (while `z` and `r` remain constant)
- then `r` changes 
- then `z` changes the slowest

This pull request implements the above change. 

Although this order is theoretically supposed to be more efficient (on CPU), I did not observe any significant speedup in practice. I think it still makes sense to merge this PR, as this is the most logical order for the particles to be in.