### PR TITLE
Allow better scaling of the deposition with number of threads

### DIFF
--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -10,7 +10,6 @@ import numba
 from numba import prange, int64
 import math
 from scipy.constants import c
-import numpy as np
 
 # -------------------------------
 # Particle shape Factor functions 

--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -79,7 +79,6 @@ def deposit_rho_prange_linear(x, y, z, w,
                            invdz, zmin, Nz,
                            invdr, rmin, Nr,
                            rho_m0_global, rho_m1_global,
-                           rho_m0, rho_m1,
                            nthreads, tx_chunks, tx_N):
     """
     Deposition of the charge density rho using numba prange on the CPU.
@@ -120,8 +119,6 @@ def deposit_rho_prange_linear(x, y, z, w,
         # Create thread_local helper arrays
         # FIXME! ( instead of using zeros_like, 
         # it would be nicer to use np.zeros((Nz,Nr)) )
-        rho_m0_thread = np.zeros_like( rho_m0 )
-        rho_m1_thread = np.zeros_like( rho_m1 )
         # Loop over all particles in thread chunk
         for idx in range( tx_chunks[tx] ):
             # Calculate thread local particle index
@@ -203,21 +200,17 @@ def deposit_rho_prange_linear(x, y, z, w,
             if iz_cell+1 > Nz-1:
                 shift_z -= Nz
             # Write to thread local arrays
-            rho_m0_thread[iz_cell, ir_cell] += R_m0_00
-            rho_m1_thread[iz_cell, ir_cell] += R_m1_00
+            rho_m0_global[tx, iz_cell, ir_cell] += R_m0_00
+            rho_m1_global[tx, iz_cell, ir_cell] += R_m1_00
 
-            rho_m0_thread[iz_cell+1 + shift_z, ir_cell] += R_m0_01
-            rho_m1_thread[iz_cell+1 + shift_z, ir_cell] += R_m1_01
+            rho_m0_global[tx,iz_cell+1 + shift_z, ir_cell] += R_m0_01
+            rho_m1_global[tx,iz_cell+1 + shift_z, ir_cell] += R_m1_01
 
-            rho_m0_thread[iz_cell, ir_cell+1 + shift_r] += R_m0_10
-            rho_m1_thread[iz_cell, ir_cell+1 + shift_r] += R_m1_10
+            rho_m0_global[tx,iz_cell, ir_cell+1 + shift_r] += R_m0_10
+            rho_m1_global[tx,iz_cell, ir_cell+1 + shift_r] += R_m1_10
 
-            rho_m0_thread[iz_cell+1 + shift_z, ir_cell+1 + shift_r] += R_m0_11
-            rho_m1_thread[iz_cell+1 + shift_z, ir_cell+1 + shift_r] += R_m1_11
-
-        # Write thread local deposition arrays to global deposition arrays
-        rho_m0_global[:,:,tx] = rho_m0_thread
-        rho_m1_global[:,:,tx] = rho_m1_thread
+            rho_m0_global[tx,iz_cell+1 + shift_z, ir_cell+1 + shift_r] += R_m0_11
+            rho_m1_global[tx,iz_cell+1 + shift_z, ir_cell+1 + shift_r] += R_m1_11
 
     return
 
@@ -233,9 +226,6 @@ def deposit_J_prange_linear(x, y, z, w,
                          j_r_m0_global, j_r_m1_global,
                          j_t_m0_global, j_t_m1_global,
                          j_z_m0_global, j_z_m1_global,
-                         j_r_m0, j_r_m1,
-                         j_t_m0, j_t_m1,
-                         j_z_m0, j_z_m1,
                          nthreads, tx_chunks, tx_N):
     """
     Deposition of the current density J using numba prange on the CPU.
@@ -283,12 +273,6 @@ def deposit_J_prange_linear(x, y, z, w,
         # Create thread_local helper arrays
         # FIXME! ( instead of using zeros_like, 
         # it would be nicer to use np.zeros((Nz,Nr)) )
-        j_r_m0_thread = np.zeros_like( j_r_m0 )
-        j_t_m0_thread = np.zeros_like( j_t_m0 )
-        j_z_m0_thread = np.zeros_like( j_z_m0 )
-        j_r_m1_thread = np.zeros_like( j_r_m1 )
-        j_t_m1_thread = np.zeros_like( j_t_m1 )
-        j_z_m1_thread = np.zeros_like( j_z_m1 )
         # Loop over all particles in thread chunk
         for idx in range( tx_chunks[tx] ):
             # Calculate thread local particle index
@@ -407,48 +391,40 @@ def deposit_J_prange_linear(x, y, z, w,
             if (iz_cell+1) > Nz-1:
                 shift_z -= Nz
 
-            j_r_m0_thread[iz_cell, ir_cell] += J_r_m0_00
-            j_r_m1_thread[iz_cell, ir_cell] += J_r_m1_00
+            j_r_m0_global[tx,iz_cell, ir_cell] += J_r_m0_00
+            j_r_m1_global[tx,iz_cell, ir_cell] += J_r_m1_00
 
-            j_r_m0_thread[iz_cell+1 + shift_z, ir_cell] += J_r_m0_01
-            j_r_m1_thread[iz_cell+1 + shift_z, ir_cell] += J_r_m1_01
+            j_r_m0_global[tx,iz_cell+1 + shift_z, ir_cell] += J_r_m0_01
+            j_r_m1_global[tx,iz_cell+1 + shift_z, ir_cell] += J_r_m1_01
 
-            j_r_m0_thread[iz_cell, ir_cell+1 + shift_r] += J_r_m0_10
-            j_r_m1_thread[iz_cell, ir_cell+1 + shift_r] += J_r_m1_10
+            j_r_m0_global[tx,iz_cell, ir_cell+1 + shift_r] += J_r_m0_10
+            j_r_m1_global[tx,iz_cell, ir_cell+1 + shift_r] += J_r_m1_10
 
-            j_r_m0_thread[iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_r_m0_11
-            j_r_m1_thread[iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_r_m1_11
+            j_r_m0_global[tx,iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_r_m0_11
+            j_r_m1_global[tx,iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_r_m1_11
 
-            j_t_m0_thread[iz_cell, ir_cell] += J_t_m0_00
-            j_t_m1_thread[iz_cell, ir_cell] += J_t_m1_00
+            j_t_m0_global[tx,iz_cell, ir_cell] += J_t_m0_00
+            j_t_m1_global[tx,iz_cell, ir_cell] += J_t_m1_00
 
-            j_t_m0_thread[iz_cell+1 + shift_z, ir_cell] += J_t_m0_01
-            j_t_m1_thread[iz_cell+1 + shift_z, ir_cell] += J_t_m1_01
+            j_t_m0_global[tx,iz_cell+1 + shift_z, ir_cell] += J_t_m0_01
+            j_t_m1_global[tx,iz_cell+1 + shift_z, ir_cell] += J_t_m1_01
 
-            j_t_m0_thread[iz_cell, ir_cell+1 + shift_r] += J_t_m0_10
-            j_t_m1_thread[iz_cell, ir_cell+1 + shift_r] += J_t_m1_10
+            j_t_m0_global[tx,iz_cell, ir_cell+1 + shift_r] += J_t_m0_10
+            j_t_m1_global[tx,iz_cell, ir_cell+1 + shift_r] += J_t_m1_10
 
-            j_t_m0_thread[iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_t_m0_11
-            j_t_m1_thread[iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_t_m1_11
+            j_t_m0_global[tx,iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_t_m0_11
+            j_t_m1_global[tx,iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_t_m1_11
 
-            j_z_m0_thread[iz_cell, ir_cell] += J_z_m0_00
-            j_z_m1_thread[iz_cell, ir_cell] += J_z_m1_00
+            j_z_m0_global[tx,iz_cell, ir_cell] += J_z_m0_00
+            j_z_m1_global[tx,iz_cell, ir_cell] += J_z_m1_00
 
-            j_z_m0_thread[iz_cell+1 + shift_z, ir_cell] += J_z_m0_01
-            j_z_m1_thread[iz_cell+1 + shift_z, ir_cell] += J_z_m1_01
+            j_z_m0_global[tx,iz_cell+1 + shift_z, ir_cell] += J_z_m0_01
+            j_z_m1_global[tx,iz_cell+1 + shift_z, ir_cell] += J_z_m1_01
 
-            j_z_m0_thread[iz_cell, ir_cell+1 + shift_r] += J_z_m0_10
-            j_z_m1_thread[iz_cell, ir_cell+1 + shift_r] += J_z_m1_10
+            j_z_m0_global[tx,iz_cell, ir_cell+1 + shift_r] += J_z_m0_10
+            j_z_m1_global[tx,iz_cell, ir_cell+1 + shift_r] += J_z_m1_10
 
-            j_z_m0_thread[iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_z_m0_11
-            j_z_m1_thread[iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_z_m1_11
-
-        # Write thread local deposition arrays to global deposition arrays
-        j_r_m0_global[:,:,tx] = j_r_m0_thread
-        j_t_m0_global[:,:,tx] = j_t_m0_thread
-        j_z_m0_global[:,:,tx] = j_z_m0_thread
-        j_r_m1_global[:,:,tx] = j_r_m1_thread
-        j_t_m1_global[:,:,tx] = j_t_m1_thread
-        j_z_m1_global[:,:,tx] = j_z_m1_thread
+            j_z_m0_global[tx,iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_z_m0_11
+            j_z_m1_global[tx,iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_z_m1_11
 
     return

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -770,10 +770,10 @@ class Particles(object) :
             if fieldtype == 'rho':
                 # Generate temporary arrays for rho
                 rho_m0_global = np.zeros(
-                    (grid[0].rho.shape[0], grid[0].rho.shape[1], self.nthreads), 
+                    (self.nthreads, grid[0].rho.shape[0], grid[0].rho.shape[1]), 
                     dtype=grid[0].rho.dtype )
                 rho_m1_global = np.zeros(
-                    (grid[1].rho.shape[0], grid[1].rho.shape[1], self.nthreads), 
+                    (self.nthreads, grid[1].rho.shape[0], grid[1].rho.shape[1]), 
                     dtype=grid[1].rho.dtype )
                 # Deposit rho using CPU threading
                 if self.particle_shape == 'linear':
@@ -782,7 +782,6 @@ class Particles(object) :
                         grid[0].invdz, grid[0].zmin, grid[0].Nz,
                         grid[0].invdr, grid[0].rmin, grid[0].Nr,
                         rho_m0_global, rho_m1_global,
-                        grid[0].rho, grid[1].rho,
                         self.nthreads, tx_chunks, tx_N )
                 elif self.particle_shape == 'cubic':
                     print('Not yet implemented')
@@ -798,28 +797,28 @@ class Particles(object) :
                                       'linear' or 'cubic' \
                                        but is `%s`" % self.particle_shape)
                 # Sum thread-local results to main field array
-                grid[0].rho = np.sum(rho_m0_global, axis=2)
-                grid[1].rho = np.sum(rho_m1_global, axis=2)
+                grid[0].rho = np.sum(rho_m0_global, axis=0)
+                grid[1].rho = np.sum(rho_m1_global, axis=0)
 
             elif fieldtype == 'J':
                 # Generate temporary arrays for J
                 Jr_m0_global = np.zeros(
-                    (grid[0].Jr.shape[0], grid[0].Jr.shape[1], self.nthreads), 
+                    (self.nthreads, grid[0].Jr.shape[0], grid[0].Jr.shape[1]), 
                     dtype=grid[0].Jr.dtype )
                 Jt_m0_global = np.zeros(
-                    (grid[0].Jt.shape[0], grid[0].Jt.shape[1], self.nthreads), 
+                    (self.nthreads, grid[0].Jt.shape[0], grid[0].Jt.shape[1]), 
                     dtype=grid[0].Jt.dtype )
                 Jz_m0_global = np.zeros(
-                    (grid[0].Jz.shape[0], grid[0].Jz.shape[1], self.nthreads), 
+                    (self.nthreads, grid[0].Jz.shape[0], grid[0].Jz.shape[1]), 
                     dtype=grid[0].Jz.dtype )
                 Jr_m1_global = np.zeros(
-                    (grid[1].Jr.shape[0], grid[1].Jr.shape[1], self.nthreads), 
+                    (self.nthreads, grid[1].Jr.shape[0], grid[1].Jr.shape[1]), 
                     dtype=grid[1].Jr.dtype )
                 Jt_m1_global = np.zeros(
-                    (grid[1].Jt.shape[0], grid[1].Jt.shape[1], self.nthreads), 
+                    (self.nthreads, grid[1].Jt.shape[0], grid[1].Jt.shape[1]), 
                     dtype=grid[1].Jt.dtype )
                 Jz_m1_global = np.zeros(
-                    (grid[1].Jz.shape[0], grid[1].Jz.shape[1], self.nthreads), 
+                    (self.nthreads, grid[1].Jz.shape[0], grid[1].Jz.shape[1]), 
                     dtype=grid[1].Jz.dtype )
                 # Deposit J using CPU threading
                 if self.particle_shape == 'linear':
@@ -831,9 +830,6 @@ class Particles(object) :
                         Jr_m0_global, Jr_m1_global,
                         Jt_m0_global, Jt_m1_global,
                         Jz_m0_global, Jz_m1_global,
-                        grid[0].Jr, grid[1].Jr,
-                        grid[0].Jt, grid[1].Jt,
-                        grid[0].Jz, grid[1].Jz,
                         self.nthreads, tx_chunks, tx_N )
                 elif self.particle_shape == 'cubic':
                     print('Not yet implemented')
@@ -854,12 +850,12 @@ class Particles(object) :
                                       'linear' or 'cubic' \
                                        but is `%s`" % self.particle_shape)
                 # Sum thread-local results to main field array
-                grid[0].Jr = np.sum(Jr_m0_global, axis=2)
-                grid[0].Jt = np.sum(Jt_m0_global, axis=2)
-                grid[0].Jz = np.sum(Jz_m0_global, axis=2)
-                grid[1].Jr = np.sum(Jr_m1_global, axis=2)
-                grid[1].Jt = np.sum(Jt_m1_global, axis=2)
-                grid[1].Jz = np.sum(Jz_m1_global, axis=2)
+                grid[0].Jr = np.sum(Jr_m0_global, axis=0)
+                grid[0].Jt = np.sum(Jt_m0_global, axis=0)
+                grid[0].Jz = np.sum(Jz_m0_global, axis=0)
+                grid[1].Jr = np.sum(Jr_m1_global, axis=0)
+                grid[1].Jt = np.sum(Jt_m1_global, axis=0)
+                grid[1].Jz = np.sum(Jz_m1_global, axis=0)
 
             else:
                 raise ValueError("`fieldtype` should be either 'J' or \


### PR DESCRIPTION
This pull request introduces two changes, in order to have better scaling of the deposition routines with respect to the number of threads:
- The dimension of the global arrays (which duplicate data for each thread) are swapped (so that the thread index is the slowest index)
- The allocation of arrays that are local to each thread is removed

It turns out that on a Haswell 32-core CPU, this improves the scaling with threads quite dramatically.