### PR TITLE
Implement parallel reduce

### DIFF
--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -12,7 +12,7 @@ import math
 from scipy.constants import c
 
 # -------------------------------
-# Particle shape Factor functions 
+# Particle shape Factor functions
 # -------------------------------
 
 # Linear shapes
@@ -116,7 +116,7 @@ def deposit_rho_prange_linear(x, y, z, w,
     # Deposit the field per cell in parallel (for threads < number of cells)
     for tx in prange( nthreads ):
         # Create thread_local helper arrays
-        # FIXME! ( instead of using zeros_like, 
+        # FIXME! ( instead of using zeros_like,
         # it would be nicer to use np.zeros((Nz,Nr)) )
         # Loop over all particles in thread chunk
         for idx in range( tx_chunks[tx] ):
@@ -270,7 +270,7 @@ def deposit_J_prange_linear(x, y, z, w,
     # Deposit the field per cell in parallel (for threads < number of cells)
     for tx in prange( nthreads ):
         # Create thread_local helper arrays
-        # FIXME! ( instead of using zeros_like, 
+        # FIXME! ( instead of using zeros_like,
         # it would be nicer to use np.zeros((Nz,Nr)) )
         # Loop over all particles in thread chunk
         for idx in range( tx_chunks[tx] ):
@@ -427,3 +427,24 @@ def deposit_J_prange_linear(x, y, z, w,
             j_z_m1_global[tx,iz_cell+1 + shift_z, ir_cell+1 + shift_r] += J_z_m1_11
 
     return
+
+# -----------------------------------------------------------------------
+# Parallel reduction of the global arrays for threads into a single array
+# -----------------------------------------------------------------------
+
+@numba.njit( parallel=True )
+def sum_reduce_2d_array( global_array, reduced_array ):
+    """
+    # TODO
+    """
+    # Extract size of each dimension
+    Nreduce, Nz, Nr = global_array.shape
+
+    # Parallel loop over iz
+    for iz in prange( Nz ):
+        # Loop over the reduction dimension (slow dimension)
+        for it in range( Nreduce ):
+            # Loop over ir (fast dimension)
+            for ir in range( Nr ):
+
+                reduced_array[ iz, ir ] +=  global_array[ it, iz, ir ]

--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -435,7 +435,17 @@ def deposit_J_prange_linear(x, y, z, w,
 @numba.njit( parallel=True )
 def sum_reduce_2d_array( global_array, reduced_array ):
     """
-    # TODO
+    Sum the array `global_array` along its first axis and 
+    add it into `reduced_array`.
+
+    Parameters:
+    -----------
+    global_array: 3darray of complexs
+       Field array whose first dimension corresponds to the 
+       reduction dimension (typically: the number of threads used
+       during the current deposition)
+
+    reduced array: 2darray of complexs
     """
     # Extract size of each dimension
     Nreduce, Nz, Nr = global_array.shape

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -21,7 +21,7 @@ from .gathering.numba_methods import gather_field_numba
 from .push.threading_methods import push_p_prange, push_p_ioniz_prange, \
     push_x_prange
 from .deposition.threading_methods import deposit_rho_prange_linear, \
-    deposit_J_prange_linear #CUBIC tbd
+    deposit_J_prange_linear, sum_reduce_2d_array #CUBIC tbd
 from .gathering.threading_methods import gather_field_prange_linear, \
     gather_field_prange_cubic
 
@@ -797,8 +797,8 @@ class Particles(object) :
                                       'linear' or 'cubic' \
                                        but is `%s`" % self.particle_shape)
                 # Sum thread-local results to main field array
-                grid[0].rho = np.sum(rho_m0_global, axis=0)
-                grid[1].rho = np.sum(rho_m1_global, axis=0)
+                sum_reduce_2d_array( rho_m0_global, grid[0].rho )
+                sum_reduce_2d_array( rho_m1_global, grid[1].rho )
 
             elif fieldtype == 'J':
                 # Generate temporary arrays for J
@@ -850,12 +850,12 @@ class Particles(object) :
                                       'linear' or 'cubic' \
                                        but is `%s`" % self.particle_shape)
                 # Sum thread-local results to main field array
-                grid[0].Jr = np.sum(Jr_m0_global, axis=0)
-                grid[0].Jt = np.sum(Jt_m0_global, axis=0)
-                grid[0].Jz = np.sum(Jz_m0_global, axis=0)
-                grid[1].Jr = np.sum(Jr_m1_global, axis=0)
-                grid[1].Jt = np.sum(Jt_m1_global, axis=0)
-                grid[1].Jz = np.sum(Jz_m1_global, axis=0)
+                sum_reduce_2d_array( Jr_m0_global, grid[0].Jr )
+                sum_reduce_2d_array( Jt_m0_global, grid[0].Jt )
+                sum_reduce_2d_array( Jz_m0_global, grid[0].Jz )
+                sum_reduce_2d_array( Jr_m1_global, grid[1].Jr )
+                sum_reduce_2d_array( Jt_m1_global, grid[1].Jt )
+                sum_reduce_2d_array( Jz_m1_global, grid[1].Jz )
 
             else:
                 raise ValueError("`fieldtype` should be either 'J' or \


### PR DESCRIPTION
This pull request implements parallel reduction after the current deposition. It speeds up the reduction by roughly a factor of 2.

Here are the timings **before** this pull request (see green curve "reduce"
<img width="722" alt="screen shot 2017-07-15 at 6 33 27 pm" src="https://user-images.githubusercontent.com/6685781/28257404-7f695094-6a7f-11e7-8a48-6aab0832d19c.png">
)
and here is the timing **after** this pull request
<img width="733" alt="screen shot 2017-07-16 at 11 33 59 pm" src="https://user-images.githubusercontent.com/6685781/28257384-49703be2-6a7f-11e7-9dc5-b0c6bf10dc99.png">
