### PR TITLE
`w` should be the actual particle weight

### DIFF
--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -126,7 +126,7 @@ def remove_particles_cpu(species, fld, n_guard, left_proc, right_proc):
         if species.ionizer is not None:
             uint_send_left[i_attr,:] = \
                 species.ionizer.ionization_level[selec_left]
-            float_send_left[8,:] = species.ionizer.neutral_weight[selec_left]
+            float_send_left[8,:] = species.ionizer.w_times_level[selec_left]
     else:
         # No need to allocate and copy data ; return an empty array
         float_send_left = np.empty((n_float, 0), dtype=np.float64)
@@ -152,7 +152,7 @@ def remove_particles_cpu(species, fld, n_guard, left_proc, right_proc):
         if species.ionizer is not None:
             uint_send_right[i_attr,:] = \
                 species.ionizer.ionization_level[selec_right]
-            float_send_right[8,:] = species.ionizer.neutral_weight[selec_right]
+            float_send_right[8,:] = species.ionizer.w_times_level[selec_right]
     else:
         # No need to allocate and copy data ; return an empty array
         float_send_right = np.empty((n_float, 0), dtype = np.float64)
@@ -172,8 +172,8 @@ def remove_particles_cpu(species, fld, n_guard, left_proc, right_proc):
     if species.tracker is not None:
         species.tracker.id = species.tracker.id[selec_stay]
     if species.ionizer is not None:
-        species.ionizer.neutral_weight = \
-            species.ionizer.neutral_weight[selec_stay]
+        species.ionizer.w_times_level = \
+            species.ionizer.w_times_level[selec_stay]
         species.ionizer.ionization_level = \
             species.ionizer.ionization_level[selec_stay]
 
@@ -273,7 +273,7 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
                     (species,'ux'), (species,'uy'), (species,'uz'),
                     (species,'inv_gamma'), (species,'w') ]
     if species.ionizer is not None:
-        attr_list.append( (species.ionizer,'neutral_weight') )
+        attr_list.append( (species.ionizer,'w_times_level') )
     # Loop through the float attributes
     for i_attr in range(n_float):
         # Initialize 3 buffer arrays on the GPU (need to be initialized
@@ -427,8 +427,8 @@ def add_buffers_cpu( species, float_recv_left, float_recv_right,
     if species.ionizer is not None:
         species.ionizer.ionization_level = np.hstack( (uint_recv_left[i_attr],
             species.ionizer.ionization_level, uint_recv_right[i_attr]))
-        species.ionizer.neutral_weight = np.hstack( (float_recv_left[8],
-            species.ionizer.neutral_weight, float_recv_right[8]))
+        species.ionizer.w_times_level = np.hstack( (float_recv_left[8],
+            species.ionizer.w_times_level, float_recv_right[8]))
 
     # Adapt the total number of particles
     species.Ntot = species.Ntot + float_recv_left.shape[1] \
@@ -466,7 +466,7 @@ def add_buffers_gpu( species, float_recv_left, float_recv_right,
                   (species,'ux'), (species,'uy'), (species,'uz'), \
                   (species,'inv_gamma'), (species,'w') ]
     if species.ionizer is not None:
-        attr_list += [ (species.ionizer, 'neutral_weight') ]
+        attr_list += [ (species.ionizer, 'w_times_level') ]
     # Loop through the float quantities
     for i_attr in range( len(attr_list) ):
         # Copy the proper buffers to the GPU

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -648,8 +648,6 @@ class ParticleCatcher:
             # Optional integer quantities
             if species.ionizer is not None:
                 particle_data['charge'] = species.ionizer.ionization_level
-                # Replace particle weight
-                particle_data['w'] = species.ionizer.neutral_weight
             if species.tracker is not None:
                 particle_data['id'] = species.tracker.id
         # GPU

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -644,7 +644,7 @@ class ParticleCatcher:
             particle_data = {
                 'x': species.x, 'y': species.y, 'z': species.z,
                 'ux': species.ux, 'uy' : species.uy, 'uz': species.uz,
-                'w': species.w*(1./species.q), 'inv_gamma': species.inv_gamma }
+                'w': species.w, 'inv_gamma': species.inv_gamma }
             # Optional integer quantities
             if species.ionizer is not None:
                 particle_data['charge'] = species.ionizer.ionization_level

--- a/fbpic/openpmd_diag/particle_diag.py
+++ b/fbpic/openpmd_diag/particle_diag.py
@@ -445,7 +445,7 @@ class ParticleDiagnostic(OpenPMDDiagnostic) :
             if species.ionizer is not None:
                 quantity_one_proc = species.ionizer.neutral_weight
             else:
-                quantity_one_proc = species.w / species.q
+                quantity_one_proc = species.w
         else:
             quantity_one_proc = getattr( species, quantity )
 

--- a/fbpic/openpmd_diag/particle_diag.py
+++ b/fbpic/openpmd_diag/particle_diag.py
@@ -442,10 +442,7 @@ class ParticleDiagnostic(OpenPMDDiagnostic) :
         elif quantity == "charge":
             quantity_one_proc = constants.e * species.ionizer.ionization_level
         elif quantity == "w":
-            if species.ionizer is not None:
-                quantity_one_proc = species.ionizer.neutral_weight
-            else:
-                quantity_one_proc = species.w
+            quantity_one_proc = species.w
         else:
             quantity_one_proc = getattr( species, quantity )
 

--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -12,7 +12,7 @@ from scipy.constants import c
 import numpy as np
 
 # -------------------------------
-# Particle shape Factor functions 
+# Particle shape Factor functions
 # -------------------------------
 
 # Linear shapes
@@ -78,7 +78,7 @@ def r_shape_cubic(cell_position, index):
                 float64, float64, int32, \
                 complex128[:,:], complex128[:,:], \
                 int32[:], int32[:])')
-def deposit_rho_gpu_linear(x, y, z, w,
+def deposit_rho_gpu_linear(x, y, z, w, q,
                            invdz, zmin, Nz,
                            invdr, rmin, Nr,
                            rho_m0, rho_m1,
@@ -102,6 +102,11 @@ def deposit_rho_gpu_linear(x, y, z, w,
 
     w : 1d array of floats
         The weights of the particles
+        (For ionizable atoms: weight times the ionization level)
+
+    q : float
+        Charge of the species
+        (For ionizable atoms: this is always the elementary charge e)
 
     rho_m0, rho_m1 : 2darrays of complexs
         The charge density on the interpolation grid for
@@ -168,7 +173,7 @@ def deposit_rho_gpu_linear(x, y, z, w,
             yj = y[ptcl_idx]
             zj = z[ptcl_idx]
             # Weights
-            wj = w[ptcl_idx]
+            wj = q * w[ptcl_idx]
 
             # Cylindrical conversion
             rj = math.sqrt(xj**2 + yj**2)
@@ -253,7 +258,7 @@ def deposit_rho_gpu_linear(x, y, z, w,
                 complex128[:,:], complex128[:,:], \
                 complex128[:,:], complex128[:,:],\
                 int32[:], int32[:])')
-def deposit_J_gpu_linear(x, y, z, w,
+def deposit_J_gpu_linear(x, y, z, w, q,
                          ux, uy, uz, inv_gamma,
                          invdz, zmin, Nz,
                          invdr, rmin, Nr,
@@ -280,6 +285,11 @@ def deposit_J_gpu_linear(x, y, z, w,
 
     w : 1d array of floats
         The weights of the particles
+        (For ionizable atoms: weight times the ionization level)
+
+    q : float
+        Charge of the species
+        (For ionizable atoms: this is always the elementary charge e)
 
     ux, uy, uz : 1darray of floats (in meters * second^-1)
         The velocity of the particles
@@ -382,7 +392,7 @@ def deposit_J_gpu_linear(x, y, z, w,
             # Inverse gamma
             inv_gammaj = inv_gamma[ptcl_idx]
             # Weights
-            wj = w[ptcl_idx]
+            wj = q * w[ptcl_idx]
 
             # Cylindrical conversion
             rj = math.sqrt(xj**2 + yj**2)
@@ -526,7 +536,7 @@ def deposit_J_gpu_linear(x, y, z, w,
                 float64, float64, int32, \
                 complex128[:,:], complex128[:,:], \
                 int32[:], int32[:])')
-def deposit_rho_gpu_cubic(x, y, z, w,
+def deposit_rho_gpu_cubic(x, y, z, w, q,
                           invdz, zmin, Nz,
                           invdr, rmin, Nr,
                           rho_m0, rho_m1,
@@ -549,6 +559,11 @@ def deposit_rho_gpu_cubic(x, y, z, w,
 
     w : 1d array of floats
         The weights of the particles
+        (For ionizable atoms: weight times the ionization level)
+
+    q : float
+        Charge of the species
+        (For ionizable atoms: this is always the elementary charge e)
 
     rho_m0, rho_m1 : 2darrays of complexs
         The charge density on the interpolation grid for
@@ -653,7 +668,7 @@ def deposit_rho_gpu_cubic(x, y, z, w,
             yj = y[ptcl_idx]
             zj = z[ptcl_idx]
             # Weights
-            wj = w[ptcl_idx]
+            wj = q * w[ptcl_idx]
 
             # Cylindrical conversion
             rj = math.sqrt(xj**2 + yj**2)
@@ -894,7 +909,7 @@ def deposit_rho_gpu_cubic(x, y, z, w,
                 complex128[:,:], complex128[:,:], \
                 complex128[:,:], complex128[:,:],\
                 int32[:], int32[:])')
-def deposit_J_gpu_cubic(x, y, z, w,
+def deposit_J_gpu_cubic(x, y, z, w, q,
                         ux, uy, uz, inv_gamma,
                         invdz, zmin, Nz,
                         invdr, rmin, Nr,
@@ -920,6 +935,11 @@ def deposit_J_gpu_cubic(x, y, z, w,
 
     w : 1d array of floats
         The weights of the particles
+        (For ionizable atoms: weight times the ionization level)
+
+    q : float
+        Charge of the species
+        (For ionizable atoms: this is always the elementary charge e)
 
     ux, uy, uz : 1darray of floats (in meters * second^-1)
         The velocity of the particles
@@ -1104,7 +1124,7 @@ def deposit_J_gpu_cubic(x, y, z, w,
             # Inverse gamma
             inv_gammaj = inv_gamma[ptcl_idx]
             # Weights
-            wj = w[ptcl_idx]
+            wj = q * w[ptcl_idx]
 
             # Cylindrical conversion
             rj = math.sqrt(xj**2 + yj**2)

--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -74,7 +74,7 @@ def r_shape_cubic(cell_position, index):
 # -------------------------------
 
 @numba.njit(parallel=True)
-def deposit_rho_prange_linear(x, y, z, w,
+def deposit_rho_prange_linear(x, y, z, w, q,
                            invdz, zmin, Nz,
                            invdr, rmin, Nr,
                            rho_m0_global, rho_m1_global,
@@ -97,6 +97,11 @@ def deposit_rho_prange_linear(x, y, z, w,
 
     w : 1d array of floats
         The weights of the particles
+        (For ionizable atoms: weight times the ionization level)
+
+    q : float
+        Charge of the species
+        (For ionizable atoms: this is always the elementary charge e)
 
     rho_m0_global, rho_m1_global : 3darrays of complexs (nthread, Nz, Nr)
         The global helper arrays to store the thread local charge densities
@@ -132,7 +137,7 @@ def deposit_rho_prange_linear(x, y, z, w,
             yj = y[i_ptcl]
             zj = z[i_ptcl]
             # Weights
-            wj = w[i_ptcl]
+            wj = q * w[i_ptcl]
 
             # Cylindrical conversion
             rj = math.sqrt(xj**2 + yj**2)
@@ -233,7 +238,7 @@ def deposit_rho_prange_linear(x, y, z, w,
 # -------------------------------
 
 @numba.njit(parallel=True)
-def deposit_J_prange_linear(x, y, z, w,
+def deposit_J_prange_linear(x, y, z, w, q,
                          ux, uy, uz, inv_gamma,
                          invdz, zmin, Nz,
                          invdr, rmin, Nr,
@@ -259,6 +264,11 @@ def deposit_J_prange_linear(x, y, z, w,
 
     w : 1d array of floats
         The weights of the particles
+        (For ionizable atoms: weight times the ionization level)
+
+    q : float
+        Charge of the species
+        (For ionizable atoms: this is always the elementary charge e)
 
     ux, uy, uz : 1darray of floats (in meters * second^-1)
         The velocity of the particles
@@ -306,7 +316,7 @@ def deposit_J_prange_linear(x, y, z, w,
             # Inverse gamma
             inv_gammaj = inv_gamma[i_ptcl]
             # Weights
-            wj = w[i_ptcl]
+            wj = q * w[i_ptcl]
 
             # Cylindrical conversion
             rj = math.sqrt(xj**2 + yj**2)
@@ -481,7 +491,7 @@ def deposit_J_prange_linear(x, y, z, w,
 # -------------------------------
 
 @numba.njit(parallel=True)
-def deposit_rho_prange_cubic(x, y, z, w,
+def deposit_rho_prange_cubic(x, y, z, w, q,
                           invdz, zmin, Nz,
                           invdr, rmin, Nr,
                           rho_m0_global, rho_m1_global,
@@ -504,6 +514,11 @@ def deposit_rho_prange_cubic(x, y, z, w,
 
     w : 1d array of floats
         The weights of the particles
+        (For ionizable atoms: weight times the ionization level)
+
+    q : float
+        Charge of the species
+        (For ionizable atoms: this is always the elementary charge e)
 
     rho_m0_global, rho_m1_global : 3darrays of complexs (nthread, Nz, Nr)
         The global helper arrays to store the thread local charge densities
@@ -539,7 +554,7 @@ def deposit_rho_prange_cubic(x, y, z, w,
             yj = y[i_ptcl]
             zj = z[i_ptcl]
             # Weights
-            wj = w[i_ptcl]
+            wj = q * w[i_ptcl]
 
             # Cylindrical conversion
             rj = math.sqrt(xj**2 + yj**2)
@@ -810,7 +825,7 @@ def deposit_rho_prange_cubic(x, y, z, w,
 # -------------------------------
 
 @numba.njit(parallel=True)
-def deposit_J_prange_cubic(x, y, z, w,
+def deposit_J_prange_cubic(x, y, z, w, q,
                         ux, uy, uz, inv_gamma,
                         invdz, zmin, Nz,
                         invdr, rmin, Nr,
@@ -836,6 +851,11 @@ def deposit_J_prange_cubic(x, y, z, w,
 
     w : 1d array of floats
         The weights of the particles
+        (For ionizable atoms: weight times the ionization level)
+
+    q : float
+        Charge of the species
+        (For ionizable atoms: this is always the elementary charge e)
 
     ux, uy, uz : 1darray of floats (in meters * second^-1)
         The velocity of the particles
@@ -883,7 +903,7 @@ def deposit_J_prange_cubic(x, y, z, w,
             # Inverse gamma
             inv_gammaj = inv_gamma[i_ptcl]
             # Weights
-            wj = w[i_ptcl]
+            wj = q * w[i_ptcl]
 
             # Cylindrical conversion
             rj = math.sqrt(xj**2 + yj**2)

--- a/fbpic/particles/ionization/cuda_methods.py
+++ b/fbpic/particles/ionization/cuda_methods.py
@@ -8,7 +8,7 @@ It defines cuda methods that are used in particle ionization.
 Apart from synthactic details, this file is very close to numba_methods.py
 """
 from numba import cuda
-from scipy.constants import c, e
+from scipy.constants import c
 from .inline_functions import get_ionization_probability_cuda, \
     get_E_amplitude_cuda, copy_ionized_electrons_batch_cuda
 
@@ -16,13 +16,13 @@ from .inline_functions import get_ionization_probability_cuda, \
 def ionize_ions_cuda( N_batch, batch_size, Ntot, level_max,
     n_ionized, is_ionized, ionization_level, random_draw,
     adk_prefactor, adk_power, adk_exp_prefactor,
-    ux, uy, uz, Ex, Ey, Ez, Bx, By, Bz, w, neutral_weight ):
+    ux, uy, uz, Ex, Ey, Ez, Bx, By, Bz, w, w_times_level ):
     """
     For each ion macroparticle, decide whether it is going to
     be further ionized during this timestep, based on the ADK rate.
 
     Increment the elements in `ionization_level` accordingly, and update the
-    charged weight `w` of the ions to take into account the change in charge
+    `w_times_level` of the ions to take into account the change in level
     of the corresponding macroparticle.
 
     For the purpose of counting and creating the corresponding electrons,
@@ -62,7 +62,7 @@ def ionize_ions_cuda( N_batch, batch_size, Ntot, level_max,
                 n_ionized[i_batch] += 1
                 # Update the ionization level and the corresponding weight
                 ionization_level[ip] += 1
-                w[ip] = e * ionization_level[ip] * neutral_weight[ip]
+                w_times_level[ip] = w[ip] * ionization_level[ip]
             else:
                 is_ionized[ip] = 0
 
@@ -74,7 +74,7 @@ def copy_ionized_electrons_cuda(
     elec_ux, elec_uy, elec_uz, elec_w,
     elec_Ex, elec_Ey, elec_Ez, elec_Bx, elec_By, elec_Bz,
     ion_x, ion_y, ion_z, ion_inv_gamma,
-    ion_ux, ion_uy, ion_uz, ion_neutral_weight,
+    ion_ux, ion_uy, ion_uz, ion_w,
     ion_Ex, ion_Ey, ion_Ez, ion_Bx, ion_By, ion_Bz ):
     """
     Create the new electrons by copying the properties (position, momentum,
@@ -90,7 +90,7 @@ def copy_ionized_electrons_cuda(
             elec_ux, elec_uy, elec_uz, elec_w,
             elec_Ex, elec_Ey, elec_Ez, elec_Bx, elec_By, elec_Bz,
             ion_x, ion_y, ion_z, ion_inv_gamma,
-            ion_ux, ion_uy, ion_uz, ion_neutral_weight,
+            ion_ux, ion_uy, ion_uz, ion_w,
             ion_Ex, ion_Ey, ion_Ez, ion_Bx, ion_By, ion_Bz )
 
 @cuda.jit()

--- a/fbpic/particles/ionization/inline_functions.py
+++ b/fbpic/particles/ionization/inline_functions.py
@@ -5,7 +5,6 @@ used in the ionization code.
 """
 import math
 import numba
-from scipy.constants import e
 # Check if CUDA is available, then import CUDA functions
 from fbpic.cuda_utils import cuda_installed
 if cuda_installed:
@@ -75,7 +74,7 @@ def copy_ionized_electrons_batch(
     elec_ux, elec_uy, elec_uz, elec_w,
     elec_Ex, elec_Ey, elec_Ez, elec_Bx, elec_By, elec_Bz,
     ion_x, ion_y, ion_z, ion_inv_gamma,
-    ion_ux, ion_uy, ion_uz, ion_neutral_weight,
+    ion_ux, ion_uy, ion_uz, ion_w,
     ion_Ex, ion_Ey, ion_Ez, ion_Bx, ion_By, ion_Bz ):
     """
     Create the new electrons by copying the properties (position, momentum,
@@ -104,7 +103,7 @@ def copy_ionized_electrons_batch(
             elec_uy[elec_index] = ion_uy[ion_index]
             elec_uz[elec_index] = ion_uz[ion_index]
             elec_inv_gamma[elec_index] = ion_inv_gamma[ion_index]
-            elec_w[elec_index] = - e * ion_neutral_weight[ion_index]
+            elec_w[elec_index] = ion_w[ion_index]
             elec_Ex[elec_index] = ion_Ex[ion_index]
             elec_Ey[elec_index] = ion_Ey[ion_index]
             elec_Ez[elec_index] = ion_Ez[ion_index]

--- a/fbpic/particles/ionization/ionizer.py
+++ b/fbpic/particles/ionization/ionizer.py
@@ -54,9 +54,11 @@ class Ionizer(object):
     ---------------
     - ionization_level: 1darray of integers (one element per particle)
       which contains the ionization state of each particle
-    - neutral_weight: 1darray of floats (one element per particle)
+    - w_times_level: 1darray of floats (one element per particle)
       which contains the number of physical particle that correspond to each
-      macroparticle (not multiplied by the charge, unlike `w`)
+      macroparticle, multiplied by the ionization level. (This is updated
+      whenever further ionization happens, and is passed to the deposition
+      kernel as the effective weight of the particles)
     """
     def __init__( self, element, ionizable_species, target_species,
                     level_start, full_initialization=True ):
@@ -101,7 +103,7 @@ class Ionizer(object):
         # Initialize the required arrays
         Ntot = ionizable_species.Ntot
         self.ionization_level = np.ones( Ntot, dtype=np.uint64 ) * level_start
-        self.neutral_weight = ionizable_species.w.copy()
+        self.w_times_level = ionizable_species.w * self.ionization_level
 
     def initialize_ADK_parameters( self, element, dt ):
         """
@@ -184,7 +186,7 @@ class Ionizer(object):
             ion.ux, ion.uy, ion.uz,
             ion.Ex, ion.Ey, ion.Ez,
             ion.Bx, ion.By, ion.Bz,
-            ion.w, self.neutral_weight )
+            ion.w, self.w_times_level )
 
         # Count the total number of electrons (operation performed
         # on the CPU, as this is typically difficult on the GPU)
@@ -239,7 +241,7 @@ class Ionizer(object):
             elec.ux, elec.uy, elec.uz, elec.w,
             elec.Ex, elec.Ey, elec.Ez, elec.Bx, elec.By, elec.Bz,
             ion.x, ion.y, ion.z, ion.inv_gamma,
-            ion.ux, ion.uy, ion.uz, self.neutral_weight,
+            ion.ux, ion.uy, ion.uz, ion.w,
             ion.Ex, ion.Ey, ion.Ez, ion.Bx, ion.By, ion.Bz )
         elec.sorted = False
 
@@ -276,7 +278,7 @@ class Ionizer(object):
             ion.ux, ion.uy, ion.uz,
             ion.Ex, ion.Ey, ion.Ez,
             ion.Bx, ion.By, ion.Bz,
-            ion.w, self.neutral_weight )
+            ion.w, self.w_times_level )
 
         # Count the total number of electrons
         cumulative_n_ionized = np.zeros( len(n_ionized)+1, dtype=np.int64 )
@@ -314,7 +316,7 @@ class Ionizer(object):
             elec.ux, elec.uy, elec.uz, elec.w,
             elec.Ex, elec.Ey, elec.Ez, elec.Bx, elec.By, elec.Bz,
             ion.x, ion.y, ion.z, ion.inv_gamma,
-            ion.ux, ion.uy, ion.uz, self.neutral_weight,
+            ion.ux, ion.uy, ion.uz, ion.w,
             ion.Ex, ion.Ey, ion.Ez, ion.Bx, ion.By, ion.Bz )
 
         # If the electrons are tracked, generate new ids
@@ -329,7 +331,7 @@ class Ionizer(object):
         if self.use_cuda:
             # Arrays with one element per macroparticles
             self.ionization_level = cuda.to_device( self.ionization_level )
-            self.neutral_weight = cuda.to_device( self.neutral_weight )
+            self.w_times_level = cuda.to_device( self.w_times_level )
             # Small-size arrays with ADK parameters
             # (One element per ionization level)
             self.adk_power = cuda.to_device( self.adk_power )
@@ -343,7 +345,7 @@ class Ionizer(object):
         if self.use_cuda:
             # Arrays with one element per macroparticles
             self.ionization_level = self.ionization_level.copy_to_host()
-            self.neutral_weight = self.neutral_weight.copy_to_host()
+            self.w_times_level = self.w_times_level.copy_to_host()
             # Small-size arrays with ADK parameters
             # (One element per ionization level)
             self.adk_power = self.adk_power.copy_to_host()

--- a/fbpic/particles/ionization/ionizer.py
+++ b/fbpic/particles/ionization/ionizer.py
@@ -101,7 +101,7 @@ class Ionizer(object):
         # Initialize the required arrays
         Ntot = ionizable_species.Ntot
         self.ionization_level = np.ones( Ntot, dtype=np.uint64 ) * level_start
-        self.neutral_weight = ionizable_species.w/ionizable_species.q
+        self.neutral_weight = ionizable_species.w.copy()
 
     def initialize_ADK_parameters( self, element, dt ):
         """

--- a/fbpic/particles/ionization/numba_methods.py
+++ b/fbpic/particles/ionization/numba_methods.py
@@ -8,7 +8,7 @@ It defines numba methods that are used in particle ionization.
 Apart from synthactic, this file is very close to cuda_methods.py
 """
 import numba
-from scipy.constants import c, e
+from scipy.constants import c
 from .inline_functions import get_ionization_probability_numba, \
     get_E_amplitude_numba, copy_ionized_electrons_batch_numba
 
@@ -16,13 +16,13 @@ from .inline_functions import get_ionization_probability_numba, \
 def ionize_ions_numba( N_batch, batch_size, Ntot, level_max,
     n_ionized, is_ionized, ionization_level, random_draw,
     adk_prefactor, adk_power, adk_exp_prefactor,
-    ux, uy, uz, Ex, Ey, Ez, Bx, By, Bz, w, neutral_weight ):
+    ux, uy, uz, Ex, Ey, Ez, Bx, By, Bz, w, w_times_level ):
     """
     For each ion macroparticle, decide whether it is going to
     be further ionized during this timestep, based on the ADK rate.
 
-    Increment the elements in `ionization_level` accordingly, and update the
-    charged weight `w` of the ions to take into account the change in charge
+    Increment the elements in `ionization_level` accordingly, and update
+    `w_times_level` of the ions to take into account the change in level
     of the corresponding macroparticle.
 
     For the purpose of counting and creating the corresponding electrons,
@@ -61,7 +61,7 @@ def ionize_ions_numba( N_batch, batch_size, Ntot, level_max,
                 n_ionized[i_batch] += 1
                 # Update the ionization level and the corresponding weight
                 ionization_level[ip] += 1
-                w[ip] = e * ionization_level[ip] * neutral_weight[ip]
+                w_times_level[ip] = w[ip] * ionization_level[ip]
             else:
                 is_ionized[ip] = 0
 
@@ -73,7 +73,7 @@ def copy_ionized_electrons_numba(
     elec_ux, elec_uy, elec_uz, elec_w,
     elec_Ex, elec_Ey, elec_Ez, elec_Bx, elec_By, elec_Bz,
     ion_x, ion_y, ion_z, ion_inv_gamma,
-    ion_ux, ion_uy, ion_uz, ion_neutral_weight,
+    ion_ux, ion_uy, ion_uz, ion_w,
     ion_Ex, ion_Ey, ion_Ez, ion_Bx, ion_By, ion_Bz ):
     """
     Create the new electrons by copying the properties (position, momentum,
@@ -88,5 +88,5 @@ def copy_ionized_electrons_numba(
             elec_ux, elec_uy, elec_uz, elec_w,
             elec_Ex, elec_Ey, elec_Ez, elec_Bx, elec_By, elec_Bz,
             ion_x, ion_y, ion_z, ion_inv_gamma,
-            ion_ux, ion_uy, ion_uz, ion_neutral_weight,
+            ion_ux, ion_uy, ion_uz, ion_w,
             ion_Ex, ion_Ey, ion_Ez, ion_Bx, ion_By, ion_Bz )

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -889,7 +889,7 @@ class Particles(object) :
                     # Deposit the fields
                     # (The sign -1 with which the guards are added is not
                     # trivial to derive but avoids artifacts on the axis)
-                    deposit_field_numba(self.w*exptheta, grid[m].rho,
+                    deposit_field_numba( self.q*weight*exptheta, grid[m].rho,
                                             iz, ir, Sz, Sr, -1.)
 
             elif fieldtype == 'J':
@@ -897,9 +897,9 @@ class Particles(object) :
                 # Deposit the current density mode by mode
                 # ----------------------------------------
                 # Calculate the currents
-                Jr = self.w * c * self.inv_gamma*( cos*self.ux + sin*self.uy )
-                Jt = self.w * c * self.inv_gamma*( cos*self.uy - sin*self.ux )
-                Jz = self.w * c * self.inv_gamma*self.uz
+                Jr = self.q*weight * c * self.inv_gamma*( cos*self.ux + sin*self.uy )
+                Jt = self.q*weight * c * self.inv_gamma*( cos*self.uy - sin*self.ux )
+                Jz = self.q*weight * c * self.inv_gamma*self.uz
                 # Prepare auxiliary matrix
                 exptheta = np.ones( self.Ntot, dtype='complex')
                 # exptheta takes the value exp(im theta) throughout the loop

--- a/tests/test_ionization.py
+++ b/tests/test_ionization.py
@@ -156,12 +156,12 @@ def run_simulation( gamma_boost ):
     sim.step( N_step, use_true_rho=True )
 
     # Check the fraction of N5+ ions at the end of the simulation
-    w_neutral = sim.ptcl[1].ionizer.neutral_weight
+    w = sim.ptcl[1].w
     ioniz_level = sim.ptcl[1].ionizer.ionization_level
     # Get the total number of N atoms/ions (all ionization levels together)
-    ntot = w_neutral.sum()
+    ntot = w.sum()
     # Get the total number of N5+ ions
-    n_N5 = w_neutral[ioniz_level == 5].sum()
+    n_N5 = w[ioniz_level == 5].sum()
     # Get the fraction of N5+ ions, and check that it is close to 0.32
     N5_fraction = n_N5 / ntot
     print('N5+ fraction: %.4f' %N5_fraction)


### PR DESCRIPTION
In the code before this PR, the particle quantity `w` represented different things:
- For non-ionizable particles: it was the weight (i.e. number of physical particle per macroparticle) times the charge.
- For ionizable particles: it was the weight times the ionization level, times the elementary charge e. This also implied that we had to keep an additional quantity (`neutral_weight`) to store the actual number of physical particle per macroparticle, inside the `Ionizer` class.

This is confusing, and therefore the current pull request sets `w` to be the actual weight (i.e. number of physical particle per macroparticle) for both non-ionizable particles and ionizable particles. 
- For non-ionizable, this implies that `w` has to be multiplied by the charge inside the deposition kernel (this is a minor cost)
- For ionizable particles, `w` now plays the part that `neutral_weight` used to play. And therefore, inside the Ionizer class, `neutral_weight` is replaced by a new array `w_times_level`, which is only used for the deposition kernel, as the effective weight.

Note that a lot of the changes involve replacing `neutral_weight` by `w_times_level` in all the MPI communications. The code for the MPI communications of these optional quantities (e.g. `w_times_level`, `ionization_level`, etc.) is quite ugly, and should at some point be replaced by something better.

PS: In fact, `w_times_level` does not need to be communicated via MPI, since it can be recalculated at each `exchange_period`, from `w` and `ionization_level`. I kept the MPI communications mostly to minimize the changes in the code that this PR produces.

