### PR TITLE
Add threading to ionization routines

### DIFF
--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -56,8 +56,11 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install -c conda-forge numba scipy h5py pyfftw mpi4py accelerate
-       conda install -c numba cudatoolkit=8.0
+       conda install numba spicy h5py
+       conda install -c conda-forge mpi4py
+       conda install -c numba cudatoolkit
+       conda install —-no-debs accelerate accelerate_cudalib
+       conda install —-no-deps -c conda-forge fftw pyfftw
 
    The second line is only necessary to run simulations on the GeForce GTX GPUs.
    (NB: The ``accelerate`` package is not free, but there is a 30-day free

--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -56,10 +56,10 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install numba spicy h5py
+       conda install numba scipy h5py
        conda install -c conda-forge mpi4py
        conda install -c numba cudatoolkit
-       conda install —-no-debs accelerate accelerate_cudalib
+       conda install —-no-deps accelerate accelerate_cudalib
        conda install —-no-deps -c conda-forge fftw pyfftw
 
    The second line is only necessary to run simulations on the GeForce GTX GPUs.

--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -41,13 +41,13 @@ below:
 
    ::
 
-       bash Miniconda-latest3-Linux-x86_64.sh -p /global/scratch/<yourUsername>/miniconda3
+       bash Miniconda3-latest-Linux-x86_64.sh -p /global/scratch/<yourUsername>/miniconda3
 
    where the bracketed text should be replaced by your username. Then type
 
   ::
 
-     source .bashrc
+       source .bashrc
 
 Installation of FBPIC and its dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -273,7 +273,7 @@ class MovingWindow(object):
             float_buffer[6,:] = new_ptcl.inv_gamma
             float_buffer[7,:] = new_ptcl.w
             if species.ionizer is not None:
-                float_buffer[8,:] = new_ptcl.ionizer.neutral_weight
+                float_buffer[8,:] = new_ptcl.ionizer.w_times_level
             # - Integer buffer
             uint_buffer = np.empty( (n_int, new_ptcl.Ntot), dtype=np.uint64 )
             i_int = 0

--- a/fbpic/particles/ionization/numba_methods.py
+++ b/fbpic/particles/ionization/numba_methods.py
@@ -70,6 +70,9 @@ def ionize_ions_numba( N_batch, batch_size, Ntot, level_max,
             # Increment ip
             ip = ip + 1
 
+    return( n_ionized, is_ionized, ionization_level, w_times_level )
+
+
 @njit_parallel
 def copy_ionized_electrons_numba(
     N_batch, batch_size, elec_old_Ntot, ion_Ntot,
@@ -95,6 +98,10 @@ def copy_ionized_electrons_numba(
             ion_x, ion_y, ion_z, ion_inv_gamma,
             ion_ux, ion_uy, ion_uz, ion_w,
             ion_Ex, ion_Ey, ion_Ez, ion_Bx, ion_By, ion_Bz )
+
+    return( elec_x, elec_y, elec_z, elec_inv_gamma,
+        elec_ux, elec_uy, elec_uz, elec_w,
+        elec_Ex, elec_Ey, elec_Ez, elec_Bx, elec_By, elec_Bz )
 
 @njit_parallel
 def copy_particle_data_numba( Ntot, old_array, new_array ):

--- a/fbpic/particles/ionization/numba_methods.py
+++ b/fbpic/particles/ionization/numba_methods.py
@@ -108,3 +108,4 @@ def copy_particle_data_numba( Ntot, old_array, new_array ):
     # Loop over single particles (in parallel if threading is enabled)
     for ip in prange( Ntot ):
         new_array[ip] = old_array[ip]
+    return( new_array )

--- a/fbpic/particles/ionization/numba_methods.py
+++ b/fbpic/particles/ionization/numba_methods.py
@@ -30,7 +30,7 @@ def ionize_ions_numba( N_batch, batch_size, Ntot, level_max,
     of the ionized ions, and `n_ionized` (one element per batch) counts
     the total number of ionized particles in the current batch.
     """
-    # Loop over batches of particles
+    # Loop over batches of particles (in parallel, if threading is enabled)
     for i_batch in prange( N_batch ):
 
         # Set the count of ionized particles in the batch to 0
@@ -84,7 +84,7 @@ def copy_ionized_electrons_numba(
     Create the new electrons by copying the properties (position, momentum,
     etc) of the ions that they originate from.
     """
-    # Select the current batch
+    #  Loop over batches of particles (in parallel, if threading is enabled)
     for i_batch in prange( N_batch ):
         copy_ionized_electrons_batch_numba(
             i_batch, batch_size, elec_old_Ntot, ion_Ntot,
@@ -95,3 +95,9 @@ def copy_ionized_electrons_numba(
             ion_x, ion_y, ion_z, ion_inv_gamma,
             ion_ux, ion_uy, ion_uz, ion_w,
             ion_Ex, ion_Ey, ion_Ez, ion_Bx, ion_By, ion_Bz )
+
+@njit_parallel
+def copy_particle_data_numba( Ntot, old_array, new_array ):
+    # Loop over single particles (in parallel if threading is enabled)
+    for ip in prange( Ntot ):
+        new_array[ip] = old_array[ip]


### PR DESCRIPTION
This pull request introduces threading in some of the used by the ionization routines.

In addition, I also bundled to small changes:
- A correction of a bug related to PR #98 (missing replacement of `neutral_weight` by `w_times_level`)
- An update of the install instructions on Lawrencium
