### PR TITLE
Remove function signatures on GPU

### DIFF
--- a/fbpic/boundaries/cuda_methods.py
+++ b/fbpic/boundaries/cuda_methods.py
@@ -7,12 +7,7 @@ It defines a set of generic functions that operate on a GPU.
 """
 from numba import cuda
 
-@cuda.jit('void( complex128[:,:,:], complex128[:,:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 int32, int32, int32 )')
+@cuda.jit
 def copy_EB_to_gpu_buffers( EB_left, EB_right,
                             Er0, Et0, Ez0, Br0, Bt0, Bz0,
                             Er1, Et1, Ez1, Br1, Bt1, Bz1,
@@ -88,12 +83,7 @@ def copy_EB_to_gpu_buffers( EB_left, EB_right,
                 EB_right[5+offset, iz, ir] = Bz1[ iz_right, ir ]
 
 
-@cuda.jit('void( complex128[:,:,:], complex128[:,:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 int32, int32, int32 )')
+@cuda.jit
 def copy_EB_from_gpu_buffers( EB_left, EB_right,
                             Er0, Et0, Ez0, Br0, Bt0, Bz0,
                             Er1, Et1, Ez1, Br1, Bt1, Bz1,
@@ -169,10 +159,7 @@ def copy_EB_from_gpu_buffers( EB_left, EB_right,
                 Bz1[ iz_right, ir ] = EB_right[5+offset, iz, ir]
 
 
-@cuda.jit('void( complex128[:,:,:], complex128[:,:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 int32, int32, int32 )')
+@cuda.jit
 def copy_J_to_gpu_buffers( J_left, J_right,
                             Jr0, Jt0, Jz0, Jr1, Jt1, Jz1,
                             copy_left, copy_right, ng ):
@@ -232,10 +219,7 @@ def copy_J_to_gpu_buffers( J_left, J_right,
                 J_right[2+offset, iz, ir] = Jz1[ iz_right, ir ]
 
 
-@cuda.jit('void( complex128[:,:,:], complex128[:,:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 complex128[:,:], complex128[:,:], complex128[:,:], \
-                 int32, int32, int32 )')
+@cuda.jit
 def add_J_from_gpu_buffers( J_left, J_right,
                             Jr0, Jt0, Jz0, Jr1, Jt1, Jz1,
                             copy_left, copy_right, ng ):
@@ -294,9 +278,7 @@ def add_J_from_gpu_buffers( J_left, J_right,
                 Jz1[ iz_right, ir ] += J_right[2+offset, iz, ir]
 
 
-@cuda.jit('void( complex128[:,:,:], complex128[:,:,:], \
-                 complex128[:,:], complex128[:,:], \
-                 int32, int32, int32 )')
+@cuda.jit
 def copy_rho_to_gpu_buffers( rho_left, rho_right, rho0, rho1,
                             copy_left, copy_right, ng ):
     """
@@ -347,9 +329,7 @@ def copy_rho_to_gpu_buffers( rho_left, rho_right, rho0, rho1,
                 rho_right[0+offset, iz, ir] = rho1[ iz_right, ir ]
 
 
-@cuda.jit('void( complex128[:,:,:], complex128[:,:,:], \
-                 complex128[:,:], complex128[:,:], \
-                 int32, int32, int32 )')
+@cuda.jit
 def add_rho_from_gpu_buffers( rho_left, rho_right, rho0, rho1,
                             copy_left, copy_right, ng ):
     """
@@ -400,11 +380,7 @@ def add_rho_from_gpu_buffers( rho_left, rho_right, rho0, rho1,
 
 # CUDA damping kernels:
 # --------------------
-@cuda.jit('void(complex128[:,:], complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:], complex128[:,:], \
-                float64[:], int32, int32)')
+@cuda.jit
 def cuda_damp_EB_left( Er0, Et0, Ez0, Br0, Bt0, Bz0,
                   Er1, Et1, Ez1, Br1, Bt1, Bz1,
                   damp_array, n_guard, n_damp ) :
@@ -455,11 +431,7 @@ def cuda_damp_EB_left( Er0, Et0, Ez0, Br0, Bt0, Bz0,
             Bt1[iz, ir] *= damp_factor_left
             Bz1[iz, ir] *= damp_factor_left
 
-@cuda.jit('void(complex128[:,:], complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:], complex128[:,:], \
-                float64[:], int32, int32)')
+@cuda.jit
 def cuda_damp_EB_right( Er0, Et0, Ez0, Br0, Bt0, Bz0,
                   Er1, Et1, Ez1, Br1, Bt1, Bz1,
                   damp_array, n_guard, n_damp ) :

--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -499,7 +499,7 @@ def shift_spect_array_cpu( field_array, shift_factor, n_move ):
 
 if cuda_installed:
 
-    @cuda.jit('void(complex128[:,:], complex128[:,:], int32)')
+    @cuda.jit
     def shift_interp_array_gpu( field_array, field_buffer, n_move ):
         """
         Shift a field array by reading the values from the field_array
@@ -529,7 +529,7 @@ if cuda_installed:
             if (iz+n_move) >= field_array.shape[0] or (iz+n_move) < 0:
                 field_buffer[iz, ir] = 0.
 
-    @cuda.jit('void(complex128[:,:], complex128[:], int32)')
+    @cuda.jit
     def shift_spect_array_gpu( field_array, shift_factor, n_move ):
         """
         Shift the field 'field_array' by n_move cells on the GPU.

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -637,7 +637,7 @@ if cuda_installed:
         elif i < n_left + n_stay + n_right:
             particle_array[i] = right_buffer[i-n_left-n_stay]
 
-    @cuda.jit('void(float64[:], float64, float64)')
+    @cuda.jit
     def shift_particles_periodic_cuda( z, zmin, zmax ):
         """
         Shift the particle positions by an integer number of box length,

--- a/fbpic/fields/cuda_methods.py
+++ b/fbpic/fields/cuda_methods.py
@@ -13,7 +13,7 @@ c2 = c**2
 # Erasing functions
 # ------------------
 
-@cuda.jit('void(complex128[:,:], complex128[:,:])')
+@cuda.jit
 def cuda_erase_scalar( mode0, mode1 ) :
     """
     Set the two input arrays to 0
@@ -36,9 +36,7 @@ def cuda_erase_scalar( mode0, mode1 ) :
         mode0[iz, ir] = 0
         mode1[iz, ir] = 0
 
-@cuda.jit('void(complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:])')
+@cuda.jit
 def cuda_erase_vector(mode0r, mode1r, mode0t, mode1t, mode0z, mode1z) :
     """
     Set the two input arrays to 0
@@ -69,8 +67,7 @@ def cuda_erase_vector(mode0r, mode1r, mode0t, mode1t, mode0z, mode1z) :
 # Divide by volume functions
 # ---------------------------
 
-@cuda.jit('void(complex128[:,:], complex128[:,:], \
-           float64[:], float64[:] )')
+@cuda.jit
 def cuda_divide_scalar_by_volume( mode0, mode1, invvol0, invvol1 ) :
     """
     Multiply the input arrays by the corresponding invvol
@@ -98,10 +95,7 @@ def cuda_divide_scalar_by_volume( mode0, mode1, invvol0, invvol1 ) :
         mode1[iz, ir] = mode1[iz, ir] * invvol1[ir]
 
 
-@cuda.jit('void(complex128[:,:], complex128[:,:], \
-           complex128[:,:], complex128[:,:], \
-           complex128[:,:], complex128[:,:], \
-           float64[:], float64[:])')
+@cuda.jit
 def cuda_divide_vector_by_volume( mode0r, mode1r, mode0t, mode1t,
                     mode0z, mode1z, invvol0, invvol1 ) :
     """
@@ -137,10 +131,7 @@ def cuda_divide_vector_by_volume( mode0r, mode1r, mode0t, mode1t,
 # Methods of the SpectralGrid object
 # -----------------------------------
 
-@cuda.jit('void(complex128[:,:], complex128[:,:], \
-           complex128[:,:], complex128[:,:], complex128[:,:], \
-           float64[:,:], float64[:,:], float64[:,:], \
-           float64, int32, int32)')
+@cuda.jit
 def cuda_correct_currents_standard( rho_prev, rho_next, Jp, Jm, Jz,
                             kz, kr, inv_k2, inv_dt, Nz, Nr ):
     """
@@ -189,13 +180,7 @@ def cuda_correct_currents_comoving( rho_prev, rho_next, Jp, Jm, Jz,
         Jm[iz, ir] += -0.5 * kr[iz, ir] * F
         Jz[iz, ir] += -1.j * kz[iz, ir] * F
 
-@cuda.jit('void(complex128[:,:], complex128[:,:], complex128[:,:], \
-           complex128[:,:], complex128[:,:], complex128[:,:], \
-           complex128[:,:], complex128[:,:], complex128[:,:], \
-           complex128[:,:], complex128[:,:], \
-           float64[:,:], float64[:,:], float64[:,:], \
-           float64[:,:], float64[:,:], float64[:,:], float64[:,:], float64, \
-           int8, int32, int32)')
+@cuda.jit
 def cuda_push_eb_standard( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                        rho_prev, rho_next,
                        rho_prev_coef, rho_next_coef, j_coef,
@@ -344,7 +329,7 @@ def cuda_push_eb_comoving( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
             + j_coef[iz, ir]*( 1.j*kr[iz, ir]*Jp[iz, ir] \
                         + 1.j*kr[iz, ir]*Jm[iz, ir] )
 
-@cuda.jit('void(complex128[:,:], complex128[:,:], int32, int32)')
+@cuda.jit
 def cuda_push_rho( rho_prev, rho_next, Nz, Nr ) :
     """
     Transfer the values of rho_next to rho_prev,
@@ -368,7 +353,7 @@ def cuda_push_rho( rho_prev, rho_next, Nz, Nr ) :
         rho_prev[iz, ir] = rho_next[iz, ir]
         rho_next[iz, ir] = 0.
 
-@cuda.jit('void(complex128[:,:], float64[:,:], int32, int32)')
+@cuda.jit
 def cuda_filter_scalar( field, filter_array, Nz, Nr) :
     """
     Multiply the input field by the filter_array
@@ -393,8 +378,7 @@ def cuda_filter_scalar( field, filter_array, Nz, Nr) :
 
         field[iz, ir] = filter_array[iz, ir]*field[iz, ir]
 
-@cuda.jit('void(complex128[:,:], complex128[:,:], complex128[:,:], \
-           float64[:,:], int32, int32)')
+@cuda.jit
 def cuda_filter_vector( fieldr, fieldt, fieldz, filter_array, Nz, Nr) :
     """
     Multiply the input field by the filter_array

--- a/fbpic/fields/spectral_transform/cuda_methods.py
+++ b/fbpic/fields/spectral_transform/cuda_methods.py
@@ -12,7 +12,7 @@ from numba import cuda
 # Copying functions
 # ------------------
 
-@cuda.jit('void(complex128[:,:], complex128[:,:])')
+@cuda.jit
 def cuda_copy_2d_to_2d( array_in, array_out ) :
     """
     Copy array_in to array_out, on the GPU
@@ -35,7 +35,7 @@ def cuda_copy_2d_to_2d( array_in, array_out ) :
     if (iz < array_in.shape[0]) and (ir < array_in.shape[1]) :
         array_out[iz, ir] = array_in[iz, ir]
 
-@cuda.jit('void(complex128[:,:], complex128[:])')
+@cuda.jit
 def cuda_copy_2d_to_1d( array_2d, array_1d ) :
     """
     Copy array_2d to array_1d, so that the first axis of array_2d
@@ -61,7 +61,7 @@ def cuda_copy_2d_to_1d( array_2d, array_1d ) :
         i = iz + array_2d.shape[0]*ir
         array_1d[i] = array_2d[iz, ir]
 
-@cuda.jit('void(complex128[:], complex128[:,:])')
+@cuda.jit
 def cuda_copy_1d_to_2d( array_1d, array_2d ) :
     """
     Copy array_1d to array_2d, so that the first axis of array_2d
@@ -91,8 +91,7 @@ def cuda_copy_1d_to_2d( array_1d, array_2d ) :
 # Functions that combine components in spectral space
 # ----------------------------------------------------
 
-@cuda.jit('void(complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:])')
+@cuda.jit
 def cuda_rt_to_pm( buffer_r, buffer_t, buffer_p, buffer_m ) :
     """
     Combine the arrays buffer_r and buffer_t to produce the
@@ -113,8 +112,7 @@ def cuda_rt_to_pm( buffer_r, buffer_t, buffer_p, buffer_m ) :
         buffer_m[iz, ir] = 0.5*( value_r + 1.j*value_t )
 
 
-@cuda.jit('void(complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:])')
+@cuda.jit
 def cuda_pm_to_rt( buffer_p, buffer_m, buffer_r, buffer_t ) :
     """
     Combine the arrays buffer_p and buffer_m to produce the

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -718,13 +718,7 @@ class SliceHandler:
 
 if cuda_installed:
 
-    @cuda.jit('void( int32, int32, float64, float64[:,:,:], \
-        complex128[:,:], complex128[:,:], complex128[:,:], \
-        complex128[:,:], complex128[:,:], complex128[:,:], \
-        complex128[:,:], complex128[:,:], complex128[:,:], complex128[:,:], \
-        complex128[:,:], complex128[:,:], complex128[:,:], \
-        complex128[:,:], complex128[:,:], complex128[:,:], \
-        complex128[:,:], complex128[:,:], complex128[:,:], complex128[:,:])')
+    @cuda.jit
     def extract_slice_cuda( Nr, iz, Sz, slice_arr,
         Er0, Et0, Ez0, Br0, Bt0, Bz0, Jr0, Jt0, Jz0, rho0,
         Er1, Et1, Ez1, Br1, Bt1, Bz1, Jr1, Jt1, Jz1, rho1 ):

--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -73,11 +73,7 @@ def r_shape_cubic(cell_position, index):
 # Field deposition - linear - rho
 # -------------------------------
 
-@cuda.jit('void(float64[:], float64[:], float64[:], float64[:], \
-                float64, float64, float64, int32, \
-                float64, float64, int32, \
-                complex128[:,:], complex128[:,:], \
-                int32[:], int32[:])')
+@cuda.jit
 def deposit_rho_gpu_linear(x, y, z, w, q, 
                            invdz, zmin, Nz,
                            invdr, rmin, Nr,
@@ -250,14 +246,7 @@ def deposit_rho_gpu_linear(x, y, z, w, q,
 # Field deposition - linear - J
 # -------------------------------
 
-@cuda.jit('void(float64[:], float64[:], float64[:], float64[:], \
-                float64, float64[:], float64[:], float64[:], float64[:], \
-                float64, float64, int32, \
-                float64, float64, int32, \
-                complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:],\
-                int32[:], int32[:])')
+@cuda.jit
 def deposit_J_gpu_linear(x, y, z, w, q,
                          ux, uy, uz, inv_gamma,
                          invdz, zmin, Nz,
@@ -531,11 +520,7 @@ def deposit_J_gpu_linear(x, y, z, w, q,
 # Field deposition - cubic - rho
 # -------------------------------
 
-@cuda.jit('void(float64[:], float64[:], float64[:], float64[:], \
-                float64, float64, float64, int32, \
-                float64, float64, int32, \
-                complex128[:,:], complex128[:,:], \
-                int32[:], int32[:])')
+@cuda.jit
 def deposit_rho_gpu_cubic(x, y, z, w, q,
                           invdz, zmin, Nz,
                           invdr, rmin, Nr,
@@ -901,14 +886,7 @@ def deposit_rho_gpu_cubic(x, y, z, w, q,
 # Field deposition - cubic - J
 # -------------------------------
 
-@cuda.jit('void(float64[:], float64[:], float64[:], float64[:], \
-                float64, float64[:], float64[:], float64[:], float64[:], \
-                float64, float64, int32, \
-                float64, float64, int32, \
-                complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:], \
-                complex128[:,:], complex128[:,:],\
-                int32[:], int32[:])')
+@cuda.jit
 def deposit_J_gpu_cubic(x, y, z, w, q,
                         ux, uy, uz, inv_gamma,
                         invdz, zmin, Nz,

--- a/fbpic/particles/gathering/cuda_methods.py
+++ b/fbpic/particles/gathering/cuda_methods.py
@@ -13,15 +13,7 @@ import math
 # Field gathering linear
 # -----------------------
 
-@cuda.jit('void(float64[:], float64[:], float64[:], \
-            float64, float64, int32, \
-            float64, float64, int32, \
-            complex128[:,:], complex128[:,:], complex128[:,:], \
-            complex128[:,:], complex128[:,:], complex128[:,:], \
-            complex128[:,:], complex128[:,:], complex128[:,:], \
-            complex128[:,:], complex128[:,:], complex128[:,:], \
-            float64[:], float64[:], float64[:], \
-            float64[:], float64[:], float64[:])')
+@cuda.jit
 def gather_field_gpu_linear(x, y, z,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
@@ -337,15 +329,7 @@ def gather_field_gpu_linear(x, y, z,
 # Field gathering cubic
 # -----------------------
 
-@cuda.jit('void(float64[:], float64[:], float64[:], \
-            float64, float64, int32, \
-            float64, float64, int32, \
-            complex128[:,:], complex128[:,:], complex128[:,:], \
-            complex128[:,:], complex128[:,:], complex128[:,:], \
-            complex128[:,:], complex128[:,:], complex128[:,:], \
-            complex128[:,:], complex128[:,:], complex128[:,:], \
-            float64[:], float64[:], float64[:], \
-            float64[:], float64[:], float64[:])')
+@cuda.jit
 def gather_field_gpu_cubic(x, y, z,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,

--- a/fbpic/particles/push/cuda_methods.py
+++ b/fbpic/particles/push/cuda_methods.py
@@ -50,9 +50,7 @@ def push_p_vay( ux_i, uy_i, uz_i, inv_gamma_i,
     return( ux_f, uy_f, uz_f, inv_gamma_f )
 
 
-@cuda.jit('void(float64[:], float64[:], float64[:], \
-            float64[:], float64[:], float64[:], \
-            float64[:], float64)')
+@cuda.jit
 def push_x_gpu( x, y, z, ux, uy, uz, inv_gamma, dt ) :
     """
     Advance the particles' positions over one half-timestep
@@ -87,10 +85,7 @@ def push_x_gpu( x, y, z, ux, uy, uz, inv_gamma, dt ) :
         y[i] += chdt*inv_g*uy[i]
         z[i] += chdt*inv_g*uz[i]
 
-@cuda.jit('void(float64[:], float64[:], float64[:], float64[:], \
-            float64[:], float64[:], float64[:], \
-            float64[:], float64[:], float64[:], \
-            float64, float64, int32, float64)')
+@cuda.jit
 def push_p_gpu( ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz,
                 q, m, Ntot, dt ) :
@@ -137,10 +132,7 @@ def push_p_gpu( ux, uy, uz, inv_gamma,
             ux[ip], uy[ip], uz[ip], inv_gamma[ip],
             Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip], econst, bconst)
 
-@cuda.jit('void(float64[:], float64[:], float64[:], float64[:], \
-            float64[:], float64[:], float64[:], \
-            float64[:], float64[:], float64[:], \
-            float64, int32, float64, int16[:])')
+@cuda.jit
 def push_p_ioniz_gpu( ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz,
                 m, Ntot, dt, ionization_level ) :

--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -14,10 +14,7 @@ import numpy as np
 # Sorting utilities - get_cell_idx / sort / prefix_sum
 # -----------------------------------------------------
 
-@cuda.jit('void(int32[:], uint32[:], \
-                float64[:], float64[:], float64[:], \
-                float64, float64, int32, \
-                float64, float64, int32)')
+@cuda.jit
 def get_cell_idx_per_particle(cell_idx, sorted_idx,
                               x, y, z,
                               invdz, zmin, Nz,
@@ -104,7 +101,7 @@ def sort_particles_per_cell(cell_idx, sorted_idx):
         sorter = sorting.RadixSort(Ntot, dtype = np.int32)
         sorter.sort(cell_idx, vals = sorted_idx)
 
-@cuda.jit('void(int32[:], int32[:])')
+@cuda.jit
 def incl_prefix_sum(cell_idx, prefix_sum):
     """
     Perform an inclusive parallel prefix sum on the sorted
@@ -137,7 +134,7 @@ def incl_prefix_sum(cell_idx, prefix_sum):
             ci += 1
 
 
-@cuda.jit('void(int32[:], int32[:], int64)')
+@cuda.jit
 def prefill_prefix_sum(cell_idx, prefix_sum, Ntot):
     """
     Prefill the prefix sum array so that:
@@ -172,7 +169,7 @@ def prefill_prefix_sum(cell_idx, prefix_sum, Ntot):
             # If this species has no particles, fill all cells with 0
             prefix_sum[i] = 0
 
-@cuda.jit('void(uint32[:], float64[:], float64[:])')
+@cuda.jit
 def write_sorting_buffer(sorted_idx, val, buf):
     """
     Writes the values of a particle array to a buffer,


### PR DESCRIPTION
This pull request removes all the function signatures for the cuda methods.

The main aim of this is to reduce the compilation time at the beginning of the simulation: I recently realized that all the functions that have signatures get compiled **when they are imported**. By contrast, the functions that do not have signatures get compiled **when they are first called**.

This means that, in the current dev branch, the deposition and gathering function for **both 1st order and 3rd order** get compiled before the simulation even starts, even though we usually only use one type of shape factor. The corresponding compilation time slows down a lot the startup time for an FBPIC GPU simulation. 

The aim of this pull request is that only the GPU functions that we do need get compiled. 

I did a few tests with a 2000x400 box filled with plasma, performing 10 steps first (this includes just-in-time compilation) and then 100 steps (without compilation, since all functions have already been compiled).

- with the current `dev` branch, here is the output:
```
Running FBPIC on GPU with 1 proc.
[--------------------------------------------------] 9/10, 0:00:00 left
 Time taken by the loop: 0:00:12
[--------------------------------------------------] 99/100, 0:00:00 left
 Time taken by the loop: 0:00:48
```
but the total time taken by the test is `0:03:30`! (measured separately) This is very likely due to the compilation even before the first 10 steps start.

- with this pull request:
```
Running FBPIC on GPU with 1 proc.
[--------------------------------------------------] 9/10, 0:00:00 left
 Time taken by the loop: 0:00:32
[--------------------------------------------------] 99/100, 0:00:00 left
 Time taken by the loop: 0:00:48
```
and the total time is `0:01:52`.

Conclusions:
- The first 10 steps takes more time because **all** the required functions get compiled during the first step.
- But overall, we save more than 1min30 (`0:03:30` vs `0:01:52`), very likely because we do not compile unneeded functions anymore.
- The time taken by the next 100 steps does not depend on whether the functions signatures are present or not.