### PR TITLE
Close #69 Optimize the `incl_prefix_sum` function when particles do not fill the grid

### DIFF
--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -967,7 +967,8 @@ class Particles(object) :
         sort_particles_per_cell(self.cell_idx, self.sorted_idx)
         # Reset the old prefix sum
         fld.prefix_sum_shift = 0
-        prefill_prefix_sum[dim_grid_2d_flat, dim_block_2d_flat](self.prefix_sum)
+        prefill_prefix_sum[dim_grid_2d_flat, dim_block_2d_flat](
+            self.cell_idx, self.prefix_sum)
         # Perform the inclusive parallel prefix sum
         incl_prefix_sum[dim_grid_1d, dim_block_1d](
             self.cell_idx, self.prefix_sum)

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -39,7 +39,7 @@ if cuda_installed:
         gather_field_gpu_cubic
     from .utilities.cuda_sorting import write_sorting_buffer, \
         get_cell_idx_per_particle, sort_particles_per_cell, \
-        reset_prefix_sum, incl_prefix_sum
+        prefill_prefix_sum, incl_prefix_sum
 
 class Particles(object) :
     """
@@ -967,7 +967,7 @@ class Particles(object) :
         sort_particles_per_cell(self.cell_idx, self.sorted_idx)
         # Reset the old prefix sum
         fld.prefix_sum_shift = 0
-        reset_prefix_sum[dim_grid_2d_flat, dim_block_2d_flat](self.prefix_sum)
+        prefill_prefix_sum[dim_grid_2d_flat, dim_block_2d_flat](self.prefix_sum)
         # Perform the inclusive parallel prefix sum
         incl_prefix_sum[dim_grid_1d, dim_block_1d](
             self.cell_idx, self.prefix_sum)


### PR DESCRIPTION
This pull request makes the inclusive prefix sum more efficient, by avoiding that the thread handling the last particle (i.e. the rightmost particle) fills all the cells that are to its right. (see the code for a clearer picture).

This is important when a species (e.g. an electron bunch) fills only a small fraction of the plasma, since then the thread handling the rightmost particle has to fill a significant fraction of the box. But it is also important in regular simulations with guard cells, since then the thread for the rightmost particles needs to fill a significant fraction of the guard cells.

I did a few tests with a 2000x400 box with moving window (and thus guard cells) using nvprof:

- With a plasma filling the valid cells (but not the guard cells):
   
   - Current dev branch: `incl_prefix_sum` takes 3.46% of the kernel time (1.71583s)
   - This PR: `incl_prefix_sum` takes 0.40%  (192.88ms)

- With a bunch filling only a small fraction of the grid:

   - Current dev branch: `incl_prefix_sum` takes 13.64%  (4.64948s)
   - This PR: `incl_prefix_sum` takes 0.40%  (117.90ms)

In all cases, both the old `reset_prefix_sum` and the new `prefill_prefix_sum` take a negligible amount of time.

