### PR TITLE
Fixed a bug in the new `prefill_prefix_sum`

### DIFF
--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -804,7 +804,7 @@ class Particles(object) :
         # Reset the old prefix sum
         fld.prefix_sum_shift = 0
         prefill_prefix_sum[dim_grid_2d_flat, dim_block_2d_flat](
-            self.cell_idx, self.prefix_sum)
+            self.cell_idx, self.prefix_sum, self.Ntot )
         # Perform the inclusive parallel prefix sum
         incl_prefix_sum[dim_grid_1d, dim_block_1d](
             self.cell_idx, self.prefix_sum)


### PR DESCRIPTION
The recent pull request on `prefix_sum` (PR #110) introduced a bug. 
(I thought I had successfully run the automated tests but it turns out I looked at the wrong log file.)

The bug comes up when no particles are present in a given species. In that case, the new `prefill_prefix_sum` tries to access elements of `cell_idx` which are non-existent. 

The current PR fixes this bug. I ran the automated tests on GPU and checked (and double-checked again!) that they pass successfully.