### PR TITLE
Improve scaling of 3rd order gathering with number of threads

### DIFF
--- a/fbpic/particles/gathering/threading_methods.py
+++ b/fbpic/particles/gathering/threading_methods.py
@@ -383,16 +383,25 @@ def gather_field_numba_cubic(x, y, z,
     Bx, By, Bz : 1darray of floats
         The magnetic fields acting on the particles
         (is modified by this function)
+
+    nthreads : int
+        Number of CPU threads used with numba prange
+
+    ptcl_chunk_indices : array of int, of size nthreads+1
+        The indices (of the particle array) between which each thread
+        should loop. (i.e. divisions of particle array between threads)
     """
     # Gather the field per cell in parallel
-    # (for threads < number of particles)
     for nt in prange( nthreads ):
 
+        # Create private arrays for each thread
+        # to store the particle index and shape
         ir = np.empty( 4, dtype=int64)
         Sr = np.empty( 4 )
         iz = np.empty( 4, dtype=int64)
         Sz = np.empty( 4 )
 
+        # Loop over all particles in thread chunk
         for i in range( ptcl_chunk_indices[nt],
                             ptcl_chunk_indices[nt+1] ):
 
@@ -476,8 +485,10 @@ def gather_field_numba_cubic(x, y, z,
             while index_r < 4:
                 index_z = 0
                 while index_z < 4:
-                    Fr_m += Sz[index_z]*Sr[index_r]*Er_m0[iz[index_z], ir[index_r]]
-                    Ft_m += Sz[index_z]*Sr[index_r]*Et_m0[iz[index_z], ir[index_r]]
+                    Fr_m += Sz[index_z]*Sr[index_r] * \
+                        Er_m0[iz[index_z], ir[index_r]]
+                    Ft_m += Sz[index_z]*Sr[index_r] * \
+                        Et_m0[iz[index_z], ir[index_r]]
                     if Sz[index_z]*Sr[index_r] < 0:
                         Fz_m += (-1.)*Sz[index_z]*Sr[index_r]* \
                             Ez_m0[iz[index_z], ir[index_r]]
@@ -513,7 +524,8 @@ def gather_field_numba_cubic(x, y, z,
                                     Er_m1[iz[index_z], ir[index_r]]
                         Ft_m += Sz[index_z]*Sr[index_r]* \
                                     Et_m1[iz[index_z], ir[index_r]]
-                    Fz_m += Sz[index_z]*Sr[index_r]*Ez_m1[iz[index_z], ir[index_r]]
+                    Fz_m += Sz[index_z]*Sr[index_r] * \
+                        Ez_m1[iz[index_z], ir[index_r]]
                     index_z += 1
                 index_r += 1
 

--- a/fbpic/particles/gathering/threading_methods.py
+++ b/fbpic/particles/gathering/threading_methods.py
@@ -24,7 +24,7 @@ def gather_field_numba_linear(x, y, z,
                     Br_m0, Bt_m0, Bz_m0,
                     Br_m1, Bt_m1, Bz_m1,
                     Ex, Ey, Ez,
-                    Bx, By, Bz):
+                    Bx, By, Bz ):
     """
     Gathering of the fields (E and B) using numba with multi-threading.
     Iterates over the particles, calculates the weighted amount
@@ -339,7 +339,8 @@ def gather_field_numba_cubic(x, y, z,
                     Br_m0, Bt_m0, Bz_m0,
                     Br_m1, Bt_m1, Bz_m1,
                     Ex, Ey, Ez,
-                    Bx, By, Bz):
+                    Bx, By, Bz,
+                    nthreads, ptcl_chunk_indices):
     """
     Gathering of the fields (E and B) using numba with multi-threading.
     Iterates over the particles, calculates the weighted amount
@@ -383,219 +384,223 @@ def gather_field_numba_cubic(x, y, z,
         The magnetic fields acting on the particles
         (is modified by this function)
     """
-    # Deposit the field per cell in parallel
+    ir = np.zeros( (nthreads, 4), dtype=int64) #[0,0,0,0]
+    Sr = np.zeros( (nthreads, 4) )
+    iz = np.zeros( (nthreads, 4), dtype=int64) #[0,0,0,0]
+    Sz = np.zeros( (nthreads, 4) )
+    
+    # Gather the field per cell in parallel
     # (for threads < number of particles)
-    for i in prange(x.shape[0]):
-        # Preliminary arrays for the cylindrical conversion
-        # --------------------------------------------
-        # Position
-        xj = x[i]
-        yj = y[i]
-        zj = z[i]
+    for nt in prange( nthreads ):
+        for i in range( ptcl_chunk_indices[nt],
+                            ptcl_chunk_indices[nt+1] ):
 
-        # Cylindrical conversion
-        rj = math.sqrt(xj**2 + yj**2)
-        if (rj != 0.):
-            invr = 1./rj
-            cos = xj*invr  # Cosine
-            sin = yj*invr  # Sine
-        else:
-            cos = 1.
-            sin = 0.
-        exptheta_m0 = 1.
-        exptheta_m1 = cos - 1.j*sin
+            # Preliminary arrays for the cylindrical conversion
+            # --------------------------------------------
+            # Position
+            xj = x[i]
+            yj = y[i]
+            zj = z[i]
 
-        # Get weights for the deposition
-        # --------------------------------------------
-        # Positions of the particle, in the cell unit
-        r_cell = invdr*(rj - rmin) - 0.5
-        z_cell = invdz*(zj - zmin) - 0.5
+            # Cylindrical conversion
+            rj = math.sqrt(xj**2 + yj**2)
+            if (rj != 0.):
+                invr = 1./rj
+                cos = xj*invr  # Cosine
+                sin = yj*invr  # Sine
+            else:
+                cos = 1.
+                sin = 0.
+            exptheta_m0 = 1.
+            exptheta_m1 = cos - 1.j*sin
 
-        # Calculate the shape factors
-        ir = np.zeros(4, dtype=int64) #[0,0,0,0]
-        Sr = np.zeros(4) #[0.,0.,0.,0.]
-        ir[0] = int64(math.floor(r_cell)) - 1
-        ir[1] = ir[0] + 1
-        ir[2] = ir[1] + 1
-        ir[3] = ir[2] + 1
-        Sr[0] = -1./6. * ((r_cell-ir[0])-2)**3
-        Sr[1] = 1./6. * (3*((r_cell-ir[1])**3)-6*((r_cell-ir[1])**2)+4)
-        Sr[2] = 1./6. * (3*((ir[2]-r_cell)**3)-6*((ir[2]-r_cell)**2)+4)
-        Sr[3] = -1./6. * ((ir[3]-r_cell)-2)**3
-        iz = np.zeros(4, dtype=int64) #[0,0,0,0]
-        Sz = np.zeros(4) #[0.,0.,0.,0.]
-        iz[0] = int64(math.floor(z_cell)) - 1
-        iz[1] = iz[0] + 1
-        iz[2] = iz[1] + 1
-        iz[3] = iz[2] + 1
-        Sz[0] = -1./6. * ((z_cell-iz[0])-2)**3
-        Sz[1] = 1./6. * (3*((z_cell-iz[1])**3)-6*((z_cell-iz[1])**2)+4)
-        Sz[2] = 1./6. * (3*((iz[2]-z_cell)**3)-6*((iz[2]-z_cell)**2)+4)
-        Sz[3] = -1./6. * ((iz[3]-z_cell)-2)**3
-        # Lower and upper periodic boundary for z
-        index_z = 0
-        while index_z < 4:
-            if iz[index_z] < 0:
-                iz[index_z] += Nz
-            if iz[index_z] > Nz - 1:
-                iz[index_z] -= Nz
-            index_z += 1
-        # Lower and upper boundary for r
-        index_r = 0
-        while index_r < 4:
-            if ir[index_r] < 0:
-                ir[index_r] = abs(ir[index_r])-1
-                Sr[index_r] = (-1.)*Sr[index_r]
-            if ir[index_r] > Nr - 1:
-                ir[index_r] = Nr - 1
-            index_r += 1
+            # Get weights for the deposition
+            # --------------------------------------------
+            # Positions of the particle, in the cell unit
+            r_cell = invdr*(rj - rmin) - 0.5
+            z_cell = invdz*(zj - zmin) - 0.5
 
-        # E-Field
-        # ----------------------------
-        # Define the initial placeholders for the
-        # gathered field for each coordinate
-        Fr = 0.
-        Ft = 0.
-        Fz = 0.
-
-        # Mode 0
-        # ----------------------------
-        # Create temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-        # Add the fields for mode 0
-        index_r = 0
-        while index_r < 4:
+            # Calculate the shape factors
+            ir[nt,0] = int64(math.floor(r_cell)) - 1
+            ir[nt,1] = ir[nt,0] + 1
+            ir[nt,2] = ir[nt,1] + 1
+            ir[nt,3] = ir[nt,2] + 1
+            Sr[nt,0] = -1./6. * ((r_cell-ir[nt,0])-2)**3
+            Sr[nt,1] = 1./6. * (3*((r_cell-ir[nt,1])**3)-6*((r_cell-ir[nt,1])**2)+4)
+            Sr[nt,2] = 1./6. * (3*((ir[nt,2]-r_cell)**3)-6*((ir[nt,2]-r_cell)**2)+4)
+            Sr[nt,3] = -1./6. * ((ir[nt,3]-r_cell)-2)**3
+            iz[nt,0] = int64(math.floor(z_cell)) - 1
+            iz[nt,1] = iz[nt,0] + 1
+            iz[nt,2] = iz[nt,1] + 1
+            iz[nt,3] = iz[nt,2] + 1
+            Sz[nt,0] = -1./6. * ((z_cell-iz[nt,0])-2)**3
+            Sz[nt,1] = 1./6. * (3*((z_cell-iz[nt,1])**3)-6*((z_cell-iz[nt,1])**2)+4)
+            Sz[nt,2] = 1./6. * (3*((iz[nt,2]-z_cell)**3)-6*((iz[nt,2]-z_cell)**2)+4)
+            Sz[nt,3] = -1./6. * ((iz[nt,3]-z_cell)-2)**3
+            # Lower and upper periodic boundary for z
             index_z = 0
             while index_z < 4:
-                Fr_m += Sz[index_z]*Sr[index_r]*Er_m0[iz[index_z], ir[index_r]]
-                Ft_m += Sz[index_z]*Sr[index_r]*Et_m0[iz[index_z], ir[index_r]]
-                if Sz[index_z]*Sr[index_r] < 0:
-                    Fz_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                        Ez_m0[iz[index_z], ir[index_r]]
-                else:
-                    Fz_m += Sz[index_z]*Sr[index_r]* \
-                        Ez_m0[iz[index_z], ir[index_r]]
+                if iz[nt,index_z] < 0:
+                    iz[nt,index_z] += Nz
+                if iz[nt,index_z] > Nz - 1:
+                    iz[nt,index_z] -= Nz
                 index_z += 1
-            index_r += 1
+            # Lower and upper boundary for r
+            index_r = 0
+            while index_r < 4:
+                if ir[nt,index_r] < 0:
+                    ir[nt,index_r] = abs(ir[nt,index_r])-1
+                    Sr[nt,index_r] = (-1.)*Sr[nt,index_r]
+                if ir[nt,index_r] > Nr - 1:
+                    ir[nt,index_r] = Nr - 1
+                index_r += 1
 
-        Fr += (Fr_m*exptheta_m0).real
-        Ft += (Ft_m*exptheta_m0).real
-        Fz += (Fz_m*exptheta_m0).real
+            # E-Field
+            # ----------------------------
+            # Define the initial placeholders for the
+            # gathered field for each coordinate
+            Fr = 0.
+            Ft = 0.
+            Fz = 0.
 
-        # Mode 1
-        # ----------------------------
-        # Clear the temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-        # Add the fields for mode 1
-        index_r = 0
-        while index_r < 4:
-            index_z = 0
-            while index_z < 4:
-                if Sz[index_z]*Sr[index_r] < 0:
-                    Fr_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                                Er_m1[iz[index_z], ir[index_r]]
-                    Ft_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                                Et_m1[iz[index_z], ir[index_r]]
-                else:
-                    Fr_m += Sz[index_z]*Sr[index_r]* \
-                                Er_m1[iz[index_z], ir[index_r]]
-                    Ft_m += Sz[index_z]*Sr[index_r]* \
-                                Et_m1[iz[index_z], ir[index_r]]
-                Fz_m += Sz[index_z]*Sr[index_r]*Ez_m1[iz[index_z], ir[index_r]]
-                index_z += 1
-            index_r += 1
+            # Mode 0
+            # ----------------------------
+            # Create temporary variables
+            # for the "per mode" gathering
+            Fr_m = 0.j
+            Ft_m = 0.j
+            Fz_m = 0.j
+            # Add the fields for mode 0
+            index_r = 0
+            while index_r < 4:
+                index_z = 0
+                while index_z < 4:
+                    Fr_m += Sz[nt,index_z]*Sr[nt,index_r]*Er_m0[iz[nt,index_z], ir[nt,index_r]]
+                    Ft_m += Sz[nt,index_z]*Sr[nt,index_r]*Et_m0[iz[nt,index_z], ir[nt,index_r]]
+                    if Sz[nt,index_z]*Sr[nt,index_r] < 0:
+                        Fz_m += (-1.)*Sz[nt,index_z]*Sr[nt,index_r]* \
+                            Ez_m0[iz[nt,index_z], ir[nt,index_r]]
+                    else:
+                        Fz_m += Sz[nt,index_z]*Sr[nt,index_r]* \
+                            Ez_m0[iz[nt,index_z], ir[nt,index_r]]
+                    index_z += 1
+                index_r += 1
 
-        # Add the fields from the mode 1
-        Fr += 2*(Fr_m*exptheta_m1).real
-        Ft += 2*(Ft_m*exptheta_m1).real
-        Fz += 2*(Fz_m*exptheta_m1).real
+            Fr += (Fr_m*exptheta_m0).real
+            Ft += (Ft_m*exptheta_m0).real
+            Fz += (Fz_m*exptheta_m0).real
 
-        # Convert to Cartesian coordinates
-        # and write to particle field arrays
-        Ex[i] = (cos*Fr - sin*Ft)
-        Ey[i] = (sin*Fr + cos*Ft)
-        Ez[i] = Fz
+            # Mode 1
+            # ----------------------------
+            # Clear the temporary variables
+            # for the "per mode" gathering
+            Fr_m = 0.j
+            Ft_m = 0.j
+            Fz_m = 0.j
+            # Add the fields for mode 1
+            index_r = 0
+            while index_r < 4:
+                index_z = 0
+                while index_z < 4:
+                    if Sz[nt,index_z]*Sr[nt,index_r] < 0:
+                        Fr_m += (-1.)*Sz[nt,index_z]*Sr[nt,index_r]* \
+                                    Er_m1[iz[nt,index_z], ir[nt,index_r]]
+                        Ft_m += (-1.)*Sz[nt,index_z]*Sr[nt,index_r]* \
+                                    Et_m1[iz[nt,index_z], ir[nt,index_r]]
+                    else:
+                        Fr_m += Sz[nt,index_z]*Sr[nt,index_r]* \
+                                    Er_m1[iz[nt,index_z], ir[nt,index_r]]
+                        Ft_m += Sz[nt,index_z]*Sr[nt,index_r]* \
+                                    Et_m1[iz[nt,index_z], ir[nt,index_r]]
+                    Fz_m += Sz[nt,index_z]*Sr[nt,index_r]*Ez_m1[iz[nt,index_z], ir[nt,index_r]]
+                    index_z += 1
+                index_r += 1
 
-        # B-Field
-        # ----------------------------
-        # Clear the placeholders for the
-        # gathered field for each coordinate
-        Fr = 0.
-        Ft = 0.
-        Fz = 0.
+            # Add the fields from the mode 1
+            Fr += 2*(Fr_m*exptheta_m1).real
+            Ft += 2*(Ft_m*exptheta_m1).real
+            Fz += 2*(Fz_m*exptheta_m1).real
 
-        # Mode 0
-        # ----------------------------
-        # Create temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-        # Add the fields for mode 0
-        index_r = 0
-        while index_r < 4:
-            index_z = 0
-            while index_z < 4:
-                Fr_m += Sz[index_z]*Sr[index_r]* \
-                    Br_m0[iz[index_z], ir[index_r]]
-                Ft_m += Sz[index_z]*Sr[index_r]* \
-                    Bt_m0[iz[index_z], ir[index_r]]
-                if Sz[index_z]*Sr[index_r] < 0:
-                    Fz_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                        Bz_m0[iz[index_z], ir[index_r]]
-                else:
-                    Fz_m += Sz[index_z]*Sr[index_r]* \
-                        Bz_m0[iz[index_z], ir[index_r]]
-                index_z += 1
-            index_r += 1
+            # Convert to Cartesian coordinates
+            # and write to particle field arrays
+            Ex[i] = (cos*Fr - sin*Ft)
+            Ey[i] = (sin*Fr + cos*Ft)
+            Ez[i] = Fz
 
-        # Add the fields from the mode 0
-        Fr += (Fr_m*exptheta_m0).real
-        Ft += (Ft_m*exptheta_m0).real
-        Fz += (Fz_m*exptheta_m0).real
+            # B-Field
+            # ----------------------------
+            # Clear the placeholders for the
+            # gathered field for each coordinate
+            Fr = 0.
+            Ft = 0.
+            Fz = 0.
 
-        # Mode 1
-        # ----------------------------
-        # Clear the temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
+            # Mode 0
+            # ----------------------------
+            # Create temporary variables
+            # for the "per mode" gathering
+            Fr_m = 0.j
+            Ft_m = 0.j
+            Fz_m = 0.j
+            # Add the fields for mode 0
+            index_r = 0
+            while index_r < 4:
+                index_z = 0
+                while index_z < 4:
+                    Fr_m += Sz[nt,index_z]*Sr[nt,index_r]* \
+                        Br_m0[iz[nt,index_z], ir[nt,index_r]]
+                    Ft_m += Sz[nt,index_z]*Sr[nt,index_r]* \
+                        Bt_m0[iz[nt,index_z], ir[nt,index_r]]
+                    if Sz[nt,index_z]*Sr[nt,index_r] < 0:
+                        Fz_m += (-1.)*Sz[nt,index_z]*Sr[nt,index_r]* \
+                            Bz_m0[iz[nt,index_z], ir[nt,index_r]]
+                    else:
+                        Fz_m += Sz[nt,index_z]*Sr[nt,index_r]* \
+                            Bz_m0[iz[nt,index_z], ir[nt,index_r]]
+                    index_z += 1
+                index_r += 1
 
-        # Add the fields for mode 1
-        index_r = 0
-        while index_r < 4:
-            index_z = 0
-            while index_z < 4:
-                if Sz[index_z]*Sr[index_r] < 0:
-                    Fr_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                        Br_m1[iz[index_z], ir[index_r]]
-                    Ft_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                        Bt_m1[iz[index_z], ir[index_r]]
-                else:
-                    Fr_m += Sz[index_z]*Sr[index_r]* \
-                        Br_m1[iz[index_z], ir[index_r]]
-                    Ft_m += Sz[index_z]*Sr[index_r]* \
-                        Bt_m1[iz[index_z], ir[index_r]]
-                Fz_m += Sz[index_z]*Sr[index_r]*Bz_m1[iz[index_z], ir[index_r]]
-                index_z += 1
-            index_r += 1
+            # Add the fields from the mode 0
+            Fr += (Fr_m*exptheta_m0).real
+            Ft += (Ft_m*exptheta_m0).real
+            Fz += (Fz_m*exptheta_m0).real
 
-        # Add the fields from the mode 1
-        Fr += 2*(Fr_m*exptheta_m1).real
-        Ft += 2*(Ft_m*exptheta_m1).real
-        Fz += 2*(Fz_m*exptheta_m1).real
+            # Mode 1
+            # ----------------------------
+            # Clear the temporary variables
+            # for the "per mode" gathering
+            Fr_m = 0.j
+            Ft_m = 0.j
+            Fz_m = 0.j
 
-        # Convert to Cartesian coordinates
-        # and write to particle field arrays
-        Bx[i] = cos*Fr - sin*Ft
-        By[i] = sin*Fr + cos*Ft
-        Bz[i] = Fz
+            # Add the fields for mode 1
+            index_r = 0
+            while index_r < 4:
+                index_z = 0
+                while index_z < 4:
+                    if Sz[nt,index_z]*Sr[nt,index_r] < 0:
+                        Fr_m += (-1.)*Sz[nt,index_z]*Sr[nt,index_r]* \
+                            Br_m1[iz[nt,index_z], ir[nt,index_r]]
+                        Ft_m += (-1.)*Sz[nt,index_z]*Sr[nt,index_r]* \
+                            Bt_m1[iz[nt,index_z], ir[nt,index_r]]
+                    else:
+                        Fr_m += Sz[nt,index_z]*Sr[nt,index_r]* \
+                            Br_m1[iz[nt,index_z], ir[nt,index_r]]
+                        Ft_m += Sz[nt,index_z]*Sr[nt,index_r]* \
+                            Bt_m1[iz[nt,index_z], ir[nt,index_r]]
+                    Fz_m += Sz[nt,index_z]*Sr[nt,index_r]*Bz_m1[iz[nt,index_z], ir[nt,index_r]]
+                    index_z += 1
+                index_r += 1
+
+            # Add the fields from the mode 1
+            Fr += 2*(Fr_m*exptheta_m1).real
+            Ft += 2*(Ft_m*exptheta_m1).real
+            Fz += 2*(Fz_m*exptheta_m1).real
+
+            # Convert to Cartesian coordinates
+            # and write to particle field arrays
+            Bx[i] = cos*Fr - sin*Ft
+            By[i] = sin*Fr + cos*Ft
+            Bz[i] = Fz
 
     return Ex, Ey, Ez, Bx, By, Bz


### PR DESCRIPTION
This pull request allows the 3rd order gathering to scale much better with the number of threads by avoiding the creation **for each particle** of small-sized arrays (that contain e.g. the particle shape).

Instead, these arrays are created only once for each thread (and are private to this thread), and then each thread loops over the particles in its chunk.

This uses a very similar chunking as for the deposition functions. As a consequence, I created a helper function in `threading_utils.py` which returns the array of chunk indices. (used both for the deposition, and for the 3rd gathering)

Here is the scaling with the current PR:
<img width="507" alt="screen shot 2017-08-09 at 4 30 04 pm" src="https://user-images.githubusercontent.com/6685781/29148243-f8481046-7d20-11e7-99c7-758f86eed77e.png">
By contrast, here is the scaling with the current `dev` branch:
![current_dev](https://user-images.githubusercontent.com/6685781/29148265-20a878fa-7d21-11e7-8d85-38f48d38ff0d.png)
(Please disregard the curve for the Hankel transform on this last one.)