### PR TITLE
Correct MPI exchange pattern of J and rho

### DIFF
--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -189,5 +189,5 @@ if __name__ == '__main__':
                     ]
 
     ### Run the simulation
-    sim.step( N_step, use_true_rho=True )
+    sim.step( N_step )
     print('')

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -286,7 +286,7 @@ class Simulation(object):
             Whether to correct the divergence of E in spectral space
 
         use_true_rho: bool, optional
-            Wether to use the true rho deposited on the grid for the
+            Whether to use the true rho deposited on the grid for the
             field push or not. (requires initialize_ions = True)
 
         move_positions: bool, optional
@@ -301,6 +301,11 @@ class Simulation(object):
         # Shortcuts
         ptcl = self.ptcl
         fld = self.fld
+        # Sanity check
+        if self.comm.size > 1 and use_true_rho:
+            raise ValueError('use_true_rho cannot be used in multi-proc mode.')
+            # This is because the guard cells of rho are never exchanged.
+
         # Measure the time taken by the PIC cycle
         measured_start = time.time()
 
@@ -385,7 +390,8 @@ class Simulation(object):
                 self.shift_galilean_boundaries()
 
             # Get the current at t = (n+1/2) dt
-            self.deposit('J')
+            # (Guard cell exchange done either now or after current correction)
+            self.deposit('J', exchange_J=(correct_currents is False))
 
             # Handle elementary processes at t = (n + 1/2)dt
             # i.e. when the particles' velocity and position are synchronized
@@ -411,6 +417,8 @@ class Simulation(object):
                 fld.correct_currents()
                 if self.comm.size > 1:
                     # Exchange the corrected J between domains
+                    # (If correct_currents is False, the exchange of J
+                    # is done in the function `deposit`)
                     fld.spect2interp('J')
                     self.comm.exchange_fields(fld.interp, 'J', 'add')
                     fld.interp2spect('J')
@@ -460,7 +468,7 @@ class Simulation(object):
             h, m = divmod(m, 60)
             print('\n Time taken by the loop: %d:%02d:%02d\n' % (h, m, s))
 
-    def deposit( self, fieldtype ):
+    def deposit( self, fieldtype, exchange_J=False ):
         """
         Deposit the charge or the currents to the interpolation grid
         and then to the spectral grid.
@@ -471,6 +479,9 @@ class Simulation(object):
             The designation of the spectral field that
             should be changed by the deposition
             Either 'rho_prev', 'rho_next' or 'J'
+
+        exchange_J: bool
+            When depositing J, whether to do the guard cells exchange now
         """
         # Shortcut
         fld = self.fld
@@ -488,6 +499,8 @@ class Simulation(object):
                 antenna.deposit( fld, 'rho', self.comm )
             # Divide by cell volume
             fld.divide_by_volume('rho')
+            # The guard cells of rho are not exchanged (except for diagnostics)
+            # This is because rho is only used for current correction.
 
         # Currents
         elif fieldtype == 'J':
@@ -500,6 +513,9 @@ class Simulation(object):
                 antenna.deposit( fld, 'J', self.comm )
             # Divide by cell volume
             fld.divide_by_volume('J')
+            # Exchange guard cells
+            if exchange_J and self.comm.size > 1:
+                self.comm.exchange_fields(fld.interp, 'J', 'add')
 
         else:
             raise ValueError('Unknown fieldtype: %s' %fieldtype)

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -138,6 +138,9 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
             # Get 'rho_prev', since it correspond to rho at time n
             self.fld.spect2interp('rho_prev')
             self.fld.spect2interp('J')
+            # Exchange rho in real space
+            # (rho is never exchanged during the PIC loop, while J is)
+            self.comm.exchange_fields(self.fld.interp, 'rho', 'add')
 
         # Find the limits of the local subdomain at this iteration
         zmin_boost = self.fld.interp[0].zmin

--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -72,6 +72,9 @@ class FieldDiagnostic(OpenPMDDiagnostic):
         if "rho" in self.fieldtypes:
             # Get 'rho_prev', since it correspond to rho at time n
             self.fld.spect2interp('rho_prev')
+            # Exchange rho in real space
+            # (rho is never exchanged during the PIC loop, while J is)
+            self.comm.exchange_fields(self.fld.interp, 'rho', 'add')
         if "J" in self.fieldtypes:
             self.fld.spect2interp('J')
 


### PR DESCRIPTION
This pull request modifies the branch `mpi_refactor`:

- During the diagnostics, it takes into account the fact that `rho` is never exchanged during the PIC loop.
- It corrects the exchange of J in the case where correct_currents is False (In the previous version, J was not exchange in this case, whereas it should, for the purpose of pushing the Maxwell equations)
- It prevents the use of `use_true_rho` with MPI.