### PR TITLE
Recomend numba 0.34 in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ it from [here](https://www.continuum.io/downloads).
 
 - Install the dependencies of FBPIC. This can be done in two lines:
 ```
-conda install numba scipy h5py
+conda install numba=0.34 scipy h5py
 conda install -c conda-forge mpi4py pyfftw
 ```
 - Download and install FBPIC:

--- a/docs/source/install/install_cori_edison.rst
+++ b/docs/source/install/install_cori_edison.rst
@@ -60,7 +60,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install numba scipy h5py
+       conda install numba=0.34 scipy h5py
        conda install -c conda-forge pyfftw mpi4py
 
 -  Install ``fbpic``

--- a/docs/source/install/install_jureca.rst
+++ b/docs/source/install/install_jureca.rst
@@ -44,7 +44,7 @@ In order to download and install `Anaconda <https://www.continuum.io/downloads>`
 Then install the dependencies of FBPIC:
 ::
 
-   conda install numba
+   conda install numba=0.34
    conda install -c numba pyculib
    conda install -c conda-forge pyfftw
 

--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -56,7 +56,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install -c conda-forge numba scipy h5py pyfftw mpi4py
+       conda install -c conda-forge numba=0.34 scipy h5py pyfftw mpi4py
        conda install -c numba pyculib
 
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -14,7 +14,7 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
   ::
 
-     conda install numba scipy h5py
+     conda install numba=0.34 scipy h5py
      conda install -c conda-forge mpi4py pyfftw
 
 -  Install ``fbpic``

--- a/docs/source/install/install_titan.rst
+++ b/docs/source/install/install_titan.rst
@@ -57,7 +57,7 @@ Installation of FBPIC and its dependencies
 
   ::
 
-    conda install numba
+    conda install numba=0.34
     conda install -c conda-forge pyfftw
     conda install -c numba pyculib
 


### PR DESCRIPTION
With the current dev branch, if someone tries to install FBPIC according to the documentation, they will get runtime errors because they will have numba 0.35 by default, which fails with FBPIC when trying to use threading.

This PR corrects the documentation accordingly.