### PR TITLE
Prevent threading for other version of numba than 0.34

### DIFF
--- a/fbpic/threading_utils.py
+++ b/fbpic/threading_utils.py
@@ -23,10 +23,13 @@ if threading_enabled:
     try:
         # Try to import the threading function prange
         from numba import prange as numba_prange
-    except ImportError:
+        # (Temporarily) check that numba is version 0.34 (other versions fail)
+        import numba; assert numba.__version__.startswith('0.34')
+    except (ImportError, AssertionError):
         threading_enabled = False
         print('*** Threading not available for the simulation.')
-        print('*** (Please make sure that numba>0.34 is installed)')
+        print('*** (Please make sure that numba 0.34 is installed,')
+        print('***  e.g. by typing `conda install numba=0.34` in a terminal)')
 
 # Set the function njit_parallel and prange to the correct object
 if not threading_enabled:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-numba<0.35
+numba
 h5py
 mpi4py
 pyfftw


### PR DESCRIPTION
With the current version of FBPIC, if a new user downloads the code and installs the latest numba (i.e. 0.35), the code will likely crash when they first try it.

This is because threading is enabled by default but fails with numba 0.35. The current `requirements.txt` will force numba 0.34 to be installed, but using `pip` instead of `conda`, and so if numba 0.35 is preinstalled with conda, it is unclear which version will be used when the user runs FBPIC.

Therefore, this pull request reverts the `requirements.txt` to its previous state, and instead disables threading for any other versions of numba than 0.34. 