### PR TITLE
Close #107 : Check that `add_elec` particles are within the local domain

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -326,6 +326,44 @@ class BoundaryCommunicator(object):
                 p_zmin_local_domain, p_zmax_local_domain,
                 self.Nz_enlarged )
 
+    def get_zmin_zmax( self, fld, local=True ):
+        """
+        Return the physical zmin and zmax (i.e. without guard and damp cells)
+        for the global domain (local=False) or local subdomain (local=True)
+
+        Parameters:
+        -----------
+        fld: an fbpic Fields object
+            Contains information about the local bounds
+        local: bool, optional
+            Whether return the global or local bounds
+
+        Returns:
+        --------
+        A tuple with zmin and zmax
+        """
+        # Get the enlarged local zmin and zmax
+        zmin_local_enlarged = fld.interp[0].zmin
+        zmax_local_enlarged = fld.interp[0].zmax
+        dz = fld.interp[0].dz
+
+        # Remove guard cells and damp cells
+        zmin = zmin_local_enlarged + self.n_guard*dz
+        zmax = zmax_local_enlarged - self.n_guard*dz
+        if self.left_proc is None:
+            zmin += self.n_damp*dz
+        if self.right_proc is None:
+            zmax -= self.n_damp*dz
+
+        # Calculate the global bounds if requested
+        if not local:
+            iz_start = self.iz_start_procs[self.rank]
+            zmin = zmin + iz_start*dz
+            zmax = zmin + self.Nz_domain*dz
+
+        return(zmin, zmax)
+
+
     # Exchange routines
     # -----------------
 

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -314,10 +314,10 @@ class BoundaryCommunicator(object):
 
         # Calculate the enlarged boundaries (i.e. including guard cells
         # and damp cells), which are passed to the fields object.
-        self.iz_start_domain = self.n_guard
+        self.nz_start_domain = self.n_guard
         if self.left_proc is None:
-            self.iz_start_domain += self.n_damp
-        zmin_local_enlarged = zmin_local_domain - self.iz_start_domain*dz
+            self.nz_start_domain += self.n_damp
+        zmin_local_enlarged = zmin_local_domain - self.nz_start_domain*dz
         zmax_local_enlarged = zmin_local_enlarged + self.Nz_enlarged*dz
 
         # Return the new boundaries to the simulation object
@@ -346,7 +346,7 @@ class BoundaryCommunicator(object):
 
         # Get the local zmin and zmax without guard cells and damp cells
         dz = fld.interp[0].dz
-        zmin = zmin_local_enlarged + self.iz_start_domain*dz
+        zmin = zmin_local_enlarged + self.nz_start_domain*dz
         zmax = zmin + self.Nz_domain*dz
 
         # Calculate the global bounds if requested
@@ -893,7 +893,7 @@ class BoundaryCommunicator(object):
 
         # Select the physical region of the local box
         local_array = \
-            array[self.iz_start_domain:self.iz_start_domain+self.Nz_domain,:]
+            array[self.nz_start_domain:self.nz_start_domain+self.Nz_domain,:]
 
         # Then send the arrays
         if self.size > 1:

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -358,8 +358,8 @@ class BoundaryCommunicator(object):
         # Calculate the global bounds if requested
         if not local:
             iz_start = self.iz_start_procs[self.rank]
-            zmin = zmin + iz_start*dz
-            zmax = zmin + self.Nz_domain*dz
+            zmin += iz_start*dz
+            zmax = zmin + self.Ltot
 
         return(zmin, zmax)
 

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -360,6 +360,17 @@ def add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
         Can be either "forward" or "backward".
         Propagation direction of the beam.
     """
+    # Select the particles that are in the local subdomain
+    zmin, zmax = sim.comm.get_zmin_zmax( sim.fld, local=True )
+    selected = (z >= zmin) & (z < zmax)
+    x = x[selected]
+    y = y[selected]
+    z = z[selected]
+    ux = ux[selected]
+    uy = uy[selected]
+    uz = uz[selected]
+    w = w[selected]
+
     # Extract the number of macroparticles
     N_part = len(x)
 

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -143,17 +143,13 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
             self.comm.exchange_fields(self.fld.interp, 'rho', 'add')
 
         # Find the limits of the local subdomain at this iteration
-        zmin_boost = self.fld.interp[0].zmin
-        zmax_boost = self.fld.interp[0].zmax
-        # If a communicator is provided, remove the guard cells
-        if self.comm is not None:
-            dz = self.fld.interp[0].dz
-            zmin_boost += dz*self.comm.n_guard
-            if self.comm.left_proc is None:
-                zmin_boost += dz*self.comm.n_damp
-            zmax_boost -= dz*self.comm.n_guard
-            if self.comm.right_proc is None:
-                zmax_boost -= dz*self.comm.n_damp
+        if self.comm is None:
+            zmin_boost = self.fld.interp[0].zmin
+            zmax_boost = self.fld.interp[0].zmax
+        else:
+            # If a communicator is provided, remove guard and damp cells
+            zmin_boost, zmax_boost = \
+                self.comm.get_zmin_zmax(self.fld, local=True)
 
         # Extract the current time in the boosted frame
         time = iteration * self.fld.dt

--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -91,15 +91,7 @@ class FieldDiagnostic(OpenPMDDiagnostic):
             zmin = self.fld.interp[0].zmin
             Nz = self.fld.interp[0].Nz
         else:
-            # Communicator: remove guard cells and combine subdomains
-            if self.comm.left_proc is None:
-                # Additionally remove damping cells
-                n_remove = self.comm.n_guard + self.comm.n_damp
-            else:
-                n_remove = self.comm.n_guard
-            # Calculate minimum z position of physical domain
-            zmin = self.fld.interp[0].zmin \
-                + (n_remove - self.comm.rank*self.comm.Nz)*dz
+            zmin, _ = self.comm.get_zmin_zmax( self.fld, local=False )
             Nz = self.comm.Nz
 
         # Create the file with these attributes


### PR DESCRIPTION
The different versions of the function `add_elec_bunc` (e.g. Gaussian, uniform) were incorrect when used with MPI: in this case each proc initializes the full number of particles, and keeps them even if they are outside of the local physical domain.

This PR corrects this: each proc now retains only the particles that are within the local physical domain.

Note: in order to implement this, I needed a function that gives the zmin and zmax of the local domain. I implemented it as a method of the boundary communicator and used it in several other places in the code.