### PR TITLE
Correct space-charge calculations for multi-proc simulation

### DIFF
--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -12,7 +12,7 @@ from fbpic.particles import Particles
 
 def add_elec_bunch( sim, gamma0, n_e, p_zmin, p_zmax, p_rmin, p_rmax,
                 p_nr=2, p_nz=2, p_nt=4, dens_func=None, boost=None,
-                direction='forward', filter_currents=True ) :
+                direction='forward' ) :
     """
     Introduce a simple relativistic electron bunch in the simulation,
     along with its space charge field.
@@ -62,9 +62,6 @@ def add_elec_bunch( sim, gamma0, n_e, p_zmin, p_zmax, p_rmin, p_rmax,
         A BoostConverter object defining the Lorentz boost of
         the simulation.
 
-    filter_currents : bool, optional
-        Whether to filter the currents in k space (True by default)
-
     direction : string, optional
         Can be either "forward" or "backward".
         Propagation direction of the beam.
@@ -106,12 +103,10 @@ def add_elec_bunch( sim, gamma0, n_e, p_zmin, p_zmax, p_rmin, p_rmax,
     sim.ptcl.append( relat_elec )
 
     # Get the corresponding space-charge fields
-    get_space_charge_fields( sim.fld, [relat_elec], gamma0,
-                             filter_currents, direction=direction)
+    get_space_charge_fields( sim, [relat_elec], gamma0, direction=direction)
 
 def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0, sig_gamma,
-                        Q, N, tf=0., zf=0., boost=None,
-                        filter_currents=True, save_beam=None ):
+                        Q, N, tf=0., zf=0., boost=None, save_beam=None ):
     """
     Introduce a relativistic Gaussian electron bunch in the simulation,
     along with its space charge field.
@@ -157,9 +152,6 @@ def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0, sig_gamma,
         A BoostConverter object defining the Lorentz boost of
         the simulation.
 
-    filter_currents : bool, optional
-        Whether to filter the currents in k space (True by default)
-
     save_beam : string, optional
         Saves the generated beam distribution as an .npz file "string".npz
     """
@@ -202,12 +194,11 @@ def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0, sig_gamma,
             inv_gamma=inv_gamma, w=w)
 
     # Add the electrons to the simulation
-    add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
-        boost=boost, filter_currents=filter_currents )
+    add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w, boost=boost )
 
 
 def add_elec_bunch_file( sim, filename, Q_tot, z_off=0., boost=None,
-                    filter_currents=True, direction='forward' ):
+                        direction='forward' ):
     """
     Introduce a relativistic electron bunch in the simulation,
     along with its space charge field, loading particles from text file.
@@ -232,9 +223,6 @@ def add_elec_bunch_file( sim, filename, Q_tot, z_off=0., boost=None,
         A BoostConverter object defining the Lorentz boost of
         the simulation.
 
-    filter_currents : bool, optional
-        Whether to filter the currents in k space (True by default)
-
     direction : string, optional
         Can be either "forward" or "backward".
         Propagation direction of the beam.
@@ -256,11 +244,11 @@ def add_elec_bunch_file( sim, filename, Q_tot, z_off=0., boost=None,
 
     # Add the electrons to the simulation
     add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
-        boost=boost, filter_currents=filter_currents, direction=direction )
+        boost=boost, direction=direction )
 
 
 def add_elec_bunch_openPMD( sim, ts_path, z_off=0., species=None, select=None,
-                            iteration=None, boost=None, filter_currents=True):
+                            iteration=None, boost=None ):
     """
     Introduce a relativistic electron bunch in the simulation,
     along with its space charge field, loading particles from an openPMD
@@ -299,9 +287,6 @@ def add_elec_bunch_openPMD( sim, ts_path, z_off=0., species=None, select=None,
     boost : a BoostConverter object, optional
         A BoostConverter object defining the Lorentz boost of
         the simulation.
-
-    filter_currents : bool, optional
-        Whether to filter the currents in k space (True by default)
     """
     # Import openPMD viewer
     try:
@@ -324,12 +309,11 @@ def add_elec_bunch_openPMD( sim, ts_path, z_off=0., species=None, select=None,
     z = z - (np.amax(z) + np.amin(z)) / 2 + z_off
 
     # Add the electrons to the simulation, and calculate the space charge
-    add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
-                                boost=boost, filter_currents=filter_currents)
+    add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w, boost=boost)
 
 
 def add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
-                    boost=None, filter_currents=True, direction='forward' ):
+                    boost=None, direction='forward' ):
     """
     Introduce a relativistic electron bunch in the simulation,
     along with its space charge field, loading particles from numpy arrays.
@@ -352,9 +336,6 @@ def add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
     boost : a BoostConverter object, optional
         A BoostConverter object defining the Lorentz boost of
         the simulation.
-
-    filter_currents : bool, optional
-        Whether to filter the currents in k space (True by default)
 
     direction : string, optional
         Can be either "forward" or "backward".
@@ -406,11 +387,11 @@ def add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
     # include a larger tolerance of the deviation of inv_gamma from 1./gamma0
     # to allow for energy spread
     gamma0 = 1. / np.mean(relat_elec.inv_gamma)
-    get_space_charge_fields( sim.fld, [relat_elec], gamma0,
-      filter_currents=filter_currents, check_gaminv=False, direction=direction)
+    get_space_charge_fields( sim, [relat_elec], gamma0,
+                            check_gaminv=False, direction=direction)
 
-def get_space_charge_fields( fld, ptcl, gamma, filter_currents=True,
-                             check_gaminv=True, direction='forward' ) :
+def get_space_charge_fields( sim, ptcl, gamma, check_gaminv=True,
+                            direction='forward' ) :
     """
     Calculate the space charge field on the grid
 
@@ -419,8 +400,8 @@ def get_space_charge_fields( fld, ptcl, gamma, filter_currents=True,
 
     Parameters
     ----------
-    fld : a Fields object
-        Contains the values of the fields
+    sim : a Simulation object
+        Contains the values of the fields, and the MPI communicator
 
     ptcl : a list of Particles object
         (one element per species)
@@ -430,9 +411,6 @@ def get_space_charge_fields( fld, ptcl, gamma, filter_currents=True,
 
     gamma : float
         The Lorentz factor of the particles
-
-    filter_currents : bool, optional
-       Whether to filter the currents (in k space by default)
 
     check_gaminv : bool, optional
         Explicitly check that all particles have the same
@@ -451,32 +429,32 @@ def get_space_charge_fields( fld, ptcl, gamma, filter_currents=True,
                             "that they have been properly initialized.")
 
     # Project the charge and currents onto the grid
-    fld.erase('rho')
-    fld.erase('J')
+    sim.fld.erase('rho')
+    sim.fld.erase('J')
     for species in ptcl :
-        species.deposit( fld, 'rho' )
-        species.deposit( fld, 'J' )
-    fld.divide_by_volume('rho')
-    fld.divide_by_volume('J')
+        species.deposit( sim.fld, 'rho' )
+        species.deposit( sim.fld, 'J' )
+    sim.fld.divide_by_volume('rho')
+    sim.fld.divide_by_volume('J')
     # Convert to the spectral grid
-    fld.interp2spect('rho_next')
-    fld.interp2spect('J')
+    sim.fld.interp2spect('rho_next')
+    sim.fld.interp2spect('J')
     # Filter the currents
-    if filter_currents :
-        fld.filter_spect('rho_next')
-        fld.filter_spect('J')
+    if sim.filter_currents:
+        sim.fld.filter_spect('rho_next')
+        sim.fld.filter_spect('J')
 
     # Get the space charge field in spectral space
-    for m in range(fld.Nm) :
-        get_space_charge_spect( fld.spect[m], gamma, direction )
+    for m in range(sim.fld.Nm) :
+        get_space_charge_spect( sim.fld.spect[m], gamma, direction )
 
     # Convert to the interpolation grid
-    fld.spect2interp( 'E' )
-    fld.spect2interp( 'B' )
+    sim.fld.spect2interp( 'E' )
+    sim.fld.spect2interp( 'B' )
 
     # Move the charge density to rho_prev
-    for m in range(fld.Nm) :
-        fld.spect[m].push_rho()
+    for m in range(sim.fld.Nm) :
+        sim.fld.spect[m].push_rho()
 
 
 def get_space_charge_spect( spect, gamma, direction='forward' ) :

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -479,7 +479,7 @@ def get_space_charge_fields( sim, ptcl, gamma, direction='forward') :
 
     # For consistency and diagnostics, redeposit the charge and current
     # of the full simulation (since the last step erased these quantities)
-    sim.deposit('rho')
+    sim.deposit('rho_prev')
     sim.deposit('J', exchange_J=True)
 
     print("Done.")

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -414,6 +414,8 @@ def get_space_charge_fields( sim, ptcl, gamma, direction='forward') :
         Can be either "forward" or "backward".
         Propagation direction of the beam.
     """
+    print("Calculating initial space charge field...")
+
     # Project the charge and currents onto the local subdomain
     sim.fld.erase('rho')
     sim.fld.erase('J')
@@ -474,6 +476,13 @@ def get_space_charge_fields( sim, ptcl, gamma, direction='forward') :
             # Add it to the fields of sim.fld
             local_field = getattr( sim.fld.interp[m], field )
             local_field[ i_min_local:i_max_local, : ] += local_array
+
+    # For consistency and diagnostics, redeposit the charge and current
+    # of the full simulation (since the last step erased these quantities)
+    sim.deposit('rho')
+    sim.deposit('J', exchange_J=True)
+
+    print("Done.")
 
 
 def get_space_charge_spect( spect, gamma, direction='forward' ) :

--- a/tests/test_space_charge.py
+++ b/tests/test_space_charge.py
@@ -93,5 +93,5 @@ def test_bunch_gaussian():
     run_sim_serial_and_parallel( 'test_space_charge_gaussian.py')
 
 if __name__ == '__main__':
-    test_bunch_from_file()
     test_bunch_gaussian()
+    test_bunch_from_file()

--- a/tests/test_space_charge.py
+++ b/tests/test_space_charge.py
@@ -68,17 +68,16 @@ def check_identical_fields( folder1, folder2 ):
     ts1 = OpenPMDTimeSeries( folder1 )
     ts2 = OpenPMDTimeSeries( folder2 )
     # Check the vector fields
-    for field in ["J", "E", "B"]:
-        for coord in ["r", "t", "z"]:
-            print("Checking %s%s" %(field, coord))
-            field1, info = ts1.get_field(field, coord, iteration=0)
-            field2, info = ts2.get_field(field, coord, iteration=0)
-            # For 0 fields, do not use allclose
-            if abs(field1).max() == 0:
-                assert abs(field2).max() == 0
-            else:
-                assert np.allclose(
-                    field1/abs(field1).max(), field2/abs(field2).max() )
+    for field, coord in [("J", "z"), ("E","r"), ("E","z"), ("B","t")]:
+        print("Checking %s%s" %(field, coord))
+        field1, info = ts1.get_field(field, coord, iteration=0)
+        field2, info = ts2.get_field(field, coord, iteration=0)
+        # For 0 fields, do not use allclose
+        if abs(field1).max() == 0:
+            assert abs(field2).max() == 0
+        else:
+            assert np.allclose(
+                field1/abs(field1).max(), field2/abs(field2).max() )
     # Check the rho field
     print("Checking rho")
     field1, info = ts1.get_field("rho", iteration=0)

--- a/tests/test_space_charge.py
+++ b/tests/test_space_charge.py
@@ -20,7 +20,10 @@ import numpy as np
 from opmd_viewer import OpenPMDTimeSeries
 
 def run_sim_serial_and_parallel( script_file, data_file=None ):
-    "TODO"
+    """Copy the script `script_file` from the `unautomated directory`
+    and run the simulation both in serial and paralllel. 
+
+    Then compare the results."""
 
     temporary_dir = './tests/tmp_test_dir'
     origin_dir = './tests/unautomated'
@@ -62,21 +65,29 @@ def run_sim_serial_and_parallel( script_file, data_file=None ):
     shutil.rmtree( temporary_dir )
 
 def check_identical_fields( folder1, folder2 ):
-    "TODO"
     ts1 = OpenPMDTimeSeries( folder1 )
     ts2 = OpenPMDTimeSeries( folder2 )
     # Check the vector fields
     for field in ["J", "E", "B"]:
-        print("Checking %s" %field)
         for coord in ["r", "t", "z"]:
+            print("Checking %s%s" %(field, coord))
             field1, info = ts1.get_field(field, coord, iteration=0)
             field2, info = ts2.get_field(field, coord, iteration=0)
-            assert np.allclose( field1, field2 )
+            # For 0 fields, do not use allclose
+            if abs(field1).max() == 0:
+                assert abs(field2).max() == 0
+            else:
+                assert np.allclose( 
+                    field1/abs(field1).max(), field2/abs(field2).max() )
     # Check the rho field
     print("Checking rho")
     field1, info = ts1.get_field("rho", iteration=0)
     field2, info = ts2.get_field("rho", iteration=0)
-    assert np.allclose( field1, field2 )
+    assert np.allclose( field1/abs(field1).max(), field2/abs(field2).max() )
+
+def test_bunch_from_file():
+    run_sim_serial_and_parallel( 'test_space_charge_file.py',
+                                'test_space_charge_file_data.txt')
 
 def test_bunch_from_file():
     run_sim_serial_and_parallel( 'test_space_charge_file.py',

--- a/tests/test_space_charge.py
+++ b/tests/test_space_charge.py
@@ -1,0 +1,86 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This test file is part of FB-PIC (Fourier-Bessel Particle-In-Cell).
+
+It tests the space charge initialization routines, and makes sure that these
+routines produce identical results for both serial and parallel simulations.
+
+Usage:
+This file is meant to be run from the top directory of fbpic,
+by any of the following commands
+$ python tests/test_example_docs_scripts.py
+$ py.test -q tests/test_example_docs_scripts.py
+$ python setup.py test
+"""
+import os
+import shutil
+import numpy as np
+from opmd_viewer import OpenPMDTimeSeries
+
+def run_sim_serial_and_parallel( script_file, data_file=None ):
+    "TODO"
+
+    temporary_dir = './tests/tmp_test_dir'
+    origin_dir = './tests/unautomated'
+
+    # Create a temporary directory for the simulation
+    # and copy the testing script into this directory
+    if os.path.exists( temporary_dir ):
+        shutil.rmtree( temporary_dir )
+    os.mkdir( temporary_dir )
+    shutil.copy( os.path.join(origin_dir, script_file),
+                os.path.join(temporary_dir, script_file) )
+    if data_file is not None:
+        shutil.copy( os.path.join(origin_dir, data_file),
+                os.path.join(temporary_dir, data_file) )
+
+    # Launch the script from the OS, in serial
+    response = os.system(
+        'cd %s; python %s' %(temporary_dir, script_file) )
+    assert response==0
+    # Rename the diags folder
+    shutil.move( os.path.join(temporary_dir, 'diags/'),
+                os.path.join(temporary_dir, 'diags_serial/') )
+
+    # Launch the script from the OS, in parallel
+    response = os.system(
+        'cd %s; mpirun -np 2 python %s' %(temporary_dir, script_file) )
+    assert response==0
+    # Rename the diags folder
+    shutil.move( os.path.join(temporary_dir, 'diags/'),
+                os.path.join(temporary_dir, 'diags_parallel/') )
+
+    # Check that the results of the initial space charge
+    # calculation are identical
+    check_identical_fields(
+        os.path.join(temporary_dir, 'diags_serial/hdf5/'),
+        os.path.join(temporary_dir, 'diags_parallel/hdf5/') )
+
+    # Suppress the temporary directory
+    shutil.rmtree( temporary_dir )
+
+def check_identical_fields( folder1, folder2 ):
+    "TODO"
+    ts1 = OpenPMDTimeSeries( folder1 )
+    ts2 = OpenPMDTimeSeries( folder2 )
+    # Check the vector fields
+    for field in ["J", "E", "B"]:
+        print("Checking %s" %field)
+        for coord in ["r", "t", "z"]:
+            field1, info = ts1.get_field(field, coord, iteration=0)
+            field2, info = ts2.get_field(field, coord, iteration=0)
+            assert np.allclose( field1, field2 )
+    # Check the rho field
+    print("Checking rho")
+    field1, info = ts1.get_field("rho", iteration=0)
+    field2, info = ts2.get_field("rho", iteration=0)
+    assert np.allclose( field1, field2 )
+
+def test_bunch_from_file():
+    run_sim_serial_and_parallel( 'test_space_charge_file.py',
+                                'test_space_charge_file_data.txt')
+
+if __name__ == '__main__':
+    test_bunch_from_file()

--- a/tests/test_space_charge.py
+++ b/tests/test_space_charge.py
@@ -21,7 +21,7 @@ from opmd_viewer import OpenPMDTimeSeries
 
 def run_sim_serial_and_parallel( script_file, data_file=None ):
     """Copy the script `script_file` from the `unautomated directory`
-    and run the simulation both in serial and paralllel. 
+    and run the simulation both in serial and paralllel.
 
     Then compare the results."""
 
@@ -77,7 +77,7 @@ def check_identical_fields( folder1, folder2 ):
             if abs(field1).max() == 0:
                 assert abs(field2).max() == 0
             else:
-                assert np.allclose( 
+                assert np.allclose(
                     field1/abs(field1).max(), field2/abs(field2).max() )
     # Check the rho field
     print("Checking rho")
@@ -89,9 +89,9 @@ def test_bunch_from_file():
     run_sim_serial_and_parallel( 'test_space_charge_file.py',
                                 'test_space_charge_file_data.txt')
 
-def test_bunch_from_file():
-    run_sim_serial_and_parallel( 'test_space_charge_file.py',
-                                'test_space_charge_file_data.txt')
+def test_bunch_gaussian():
+    run_sim_serial_and_parallel( 'test_space_charge_gaussian.py')
 
 if __name__ == '__main__':
     test_bunch_from_file()
+    test_bunch_gaussian()

--- a/tests/unautomated/test_gaussian_bunch_evolution.py
+++ b/tests/unautomated/test_gaussian_bunch_evolution.py
@@ -1,0 +1,122 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file tests the space charge initialization implemented
+in lpa_utils.py, by initializing a charged bunch and propagating
+it for a few steps
+
+Usage :
+from the top-level directory of FBPIC run
+$ python tests/test_space_charge.py
+"""
+import matplotlib.pyplot as plt
+from scipy.constants import c
+import numpy as np
+# Import the relevant structures in FBPIC
+from fbpic.main import Simulation
+from fbpic.lpa_utils.boosted_frame import BoostConverter
+from fbpic.lpa_utils.bunch import add_elec_bunch_gaussian
+
+# The simulation box
+Nz = 400         # Number of gridpoints along z
+zmin = -40.e-6   # Start of the box in z (meters)
+zmax = 0.e-6     # End of the box in z (meters)
+Nr = 100         # Number of gridpoints along r
+rmax = 100.e-6   # Length of the box along r (meters)
+Nm = 2           # Number of modes used
+n_order = -1     # The order of the stencil in z
+
+# The simulation timestep
+dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
+N_step = 800     # Number of iterations to perform
+N_show = 40     # Number of timestep between every plot
+show_fields = False
+l_boost = False
+
+if l_boost:
+    # Boosted frame
+    gamma_boost = 15.
+    boost = BoostConverter(gamma_boost)
+else:
+    gamma_boost = 1.
+    boost = None
+
+# Initialize the simulation object
+sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
+    -1.e-6, 0., -1.e-6, 0., 1, 1, 1, 1.e18,
+    zmin=zmin, n_order=n_order, boundaries='open',
+    gamma_boost=gamma_boost )
+
+# Configure the moving window
+sim.set_moving_window(v=c, gamma_boost=gamma_boost)
+
+# Suppress the particles that were intialized by default and add the bunch
+sim.ptcl = [ ]
+
+# Bunch parameters
+sig_r = 3.e-6
+sig_z = 3.e-6
+n_emit = 1.e-6
+gamma0 = 100.
+sig_gamma = 1.
+Q = 10.e-12
+N = 100000
+tf = 40.e-6 / (np.sqrt(1.-1./gamma0**2)*c)
+zf = 20.e-6
+
+# Add gaussian electron bunch
+add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0, sig_gamma,
+                         Q, N, tf, zf, boost=boost )
+
+if show_fields:
+    # Show the initial fields
+    plt.figure(0)
+    sim.fld.interp[0].show('Ez')
+    plt.figure(1)
+    sim.fld.interp[0].show('Er')
+    plt.show()
+    print( 'Done' )
+
+# Create empty arrays for saving rms bunch sizes
+sig_zp = np.zeros(int(N_step/N_show)+1)
+sig_xp = np.zeros(int(N_step/N_show)+1)
+sig_yp = np.zeros(int(N_step/N_show)+1)
+
+# Set initial bunch sizes
+sig_zp[0] = np.std(sim.ptcl[0].z)
+sig_xp[0] = np.std(sim.ptcl[0].x)
+sig_yp[0] = np.std(sim.ptcl[0].y)
+
+# Create array corresponding to the propagation distance of the bunch
+z_prop  = np.arange(int(N_step/N_show)+1) * ((zmax-zmin)/Nz) * N_show
+z_prop += -20.e-6
+if l_boost:
+    z_prop, = boost.copropag_length([z_prop], beta_object = boost.beta0)
+
+# Carry out the simulation
+for k in range(int(N_step/N_show)) :
+    sim.step(N_show)
+    sig_zp[k+1] = np.std(sim.ptcl[0].z)
+    sig_xp[k+1] = np.std(sim.ptcl[0].x)
+    sig_yp[k+1] = np.std(sim.ptcl[0].y)
+    if show_fields:
+        # Show the fields
+        plt.figure(0)
+        plt.clf()
+        sim.fld.interp[0].show('Ez')
+        plt.figure(1)
+        plt.clf()
+        sim.fld.interp[0].show('Er')
+        plt.show()
+
+# Plot the evolution of the rms bunch size
+plt.figure(0)
+plt.clf()
+plt.plot(z_prop*1.e6, sig_zp*1.e6, label = 'sig_z')
+plt.plot(z_prop*1.e6, sig_xp*1.e6, label = 'sig_x')
+plt.plot(z_prop*1.e6, sig_yp*1.e6, label = 'sig_y')
+plt.xlabel('Propagation distance [mu]')
+plt.ylabel('rms of bunch size [mu]')
+plt.legend()
+plt.show()

--- a/tests/unautomated/test_space_charge_file.py
+++ b/tests/unautomated/test_space_charge_file.py
@@ -2,66 +2,40 @@
 # Authors: Remi Lehe, Manuel Kirchen
 # License: 3-Clause-BSD-LBNL
 """
-This file tests the space charge initialization of a beam 
+This file tests the space charge initialization of a beam
 defined in an external text file, implemented
-in lpa_utils.py, by initializing a charged bunch and propagating
-it for a few steps
+in lpa_utils.py, by initializing a charged bunch.
 
-Usage :
-from the top-level directory of FBPIC run
-$ python tests/test_space_charge_file.py
+This file is used by the automated test `test_space_charge.py`
 """
-import matplotlib.pyplot as plt
 from scipy.constants import c
-# Import the relevant structures in FBPIC                                       
+# Import the relevant structures in FBPIC
 from fbpic.main import Simulation
+from fbpic.openpmd_diag import FieldDiagnostic
 from fbpic.lpa_utils.bunch import add_elec_bunch_file
 
-# The simulation box                                                            
+# The simulation box
 Nz = 400         # Number of gridpoints along z
 zmax = 40.e-6    # Length of the box along z (meters)
-Nr = 100         # Number of gridpoints along r 
+Nr = 100         # Number of gridpoints along r
 rmax = 100.e-6   # Length of the box along r (meters)
 Nm = 2           # Number of modes used
-n_order = -1     # Order of the stencil
+n_order = 32     # Order of the stencil
 
-# The simulation timestep                                             
-dt = zmax/Nz/c   # Timestep (seconds)                                           
-N_step = 100     # Number of iterations to perform
-
-# The particles
-gamma0 = 25.                                                            
-p_zmin = 15.e-6  # Position of the beginning of the bunch (meters)
-p_zmax = 25.e-6  # Position of the end of the bunch (meters)                   
-p_rmin = 0.      # Minimal radial position of the bunch (meters)               
-p_rmax = 5.e-6   # Maximal radial position of the bunch (meters)               
-n_e = 4.e18*1.e6 # Density (electrons.meters^-3)                                
-p_nz = 2         # Number of particles per cell along z                         
-p_nr = 2         # Number of particles per cell along r                         
-p_nt = 4         # Number of particles per cell along theta 
+# The simulation timestep
+dt = zmax/Nz/c   # Timestep (seconds)
 
 # Initialize the simulation object
 sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-    p_zmin, p_zmax, p_rmin, p_rmax, p_nz, p_nr, p_nt, n_e,
+    0, 0, 0, 0, 2, 2, 4, 0.,
     n_order=n_order, boundaries='open' )
-
 # Configure the moving window
 sim.set_moving_window( v=c )
-
 # Suppress the particles that were intialized by default and add the bunch
 sim.ptcl = [ ]
-add_elec_bunch_file( sim, filename = 'test_space_charge_file_data.txt',
-                     Q_tot = 1.e-12, z_off = 20.e-6 )
-
-
-# Carry out 100 step, and show the fields
-sim.step(100)
-
-plt.figure(0)
-sim.fld.interp[0].show('Ez')
-plt.figure(1)
-sim.fld.interp[0].show('Er')
-
-plt.show()
-
-
+add_elec_bunch_file( sim, filename='test_space_charge_file_data.txt',
+                     Q_tot=1.e-12, z_off=20.e-6 )
+# Set the diagnostics
+sim.diags = [ FieldDiagnostic(10, sim.fld, comm=sim.comm) ]
+# Perform one simulation step (essentially in order to write the diags)
+sim.step(1)

--- a/tests/unautomated/test_space_charge_gaussian.py
+++ b/tests/unautomated/test_space_charge_gaussian.py
@@ -20,7 +20,8 @@ np.random.seed(0)
 
 # The simulation box
 Nz = 400         # Number of gridpoints along z
-zmax = 40.e-6    # Length of the box along z (meters)
+zmax = 0.e-6     # Length of the box along z (meters)
+zmin = -40.e-6
 Nr = 100         # Number of gridpoints along r
 rmax = 100.e-6   # Length of the box along r (meters)
 Nm = 2           # Number of modes used
@@ -38,11 +39,11 @@ tf = 0
 zf = -20.e-6
 
 # The simulation timestep
-dt = zmax/Nz/c   # Timestep (seconds)
+dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
 
 # Initialize the simulation object
 sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-    0, 0, 0, 0, 2, 2, 4, 0.,
+    0, 0, 0, 0, 2, 2, 4, 0., zmin=zmin,
     n_order=n_order, boundaries='open' )
 # Configure the moving window
 sim.set_moving_window( v=c )

--- a/tests/unautomated/test_space_charge_gaussian.py
+++ b/tests/unautomated/test_space_charge_gaussian.py
@@ -2,121 +2,54 @@
 # Authors: Remi Lehe, Manuel Kirchen
 # License: 3-Clause-BSD-LBNL
 """
-This file tests the space charge initialization implemented
-in lpa_utils.py, by initializing a charged bunch and propagating
-it for a few steps
+This file tests the space charge initialization of a beam
+defined in an external text file, implemented
+in lpa_utils.py, by initializing a charged bunch.
 
-Usage :
-from the top-level directory of FBPIC run
-$ python tests/test_space_charge.py
+This file is used by the automated test `test_space_charge.py`
 """
-import matplotlib.pyplot as plt
 from scipy.constants import c
 import numpy as np
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
-from fbpic.lpa_utils.boosted_frame import BoostConverter
+from fbpic.openpmd_diag import FieldDiagnostic
 from fbpic.lpa_utils.bunch import add_elec_bunch_gaussian
+
+np.random.seed(0)
 
 # The simulation box
 Nz = 400         # Number of gridpoints along z
-zmin = -40.e-6   # Start of the box in z (meters)
-zmax = 0.e-6     # End of the box in z (meters)
+zmax = 40.e-6    # Length of the box along z (meters)
 Nr = 100         # Number of gridpoints along r
 rmax = 100.e-6   # Length of the box along r (meters)
 Nm = 2           # Number of modes used
-n_order = -1     # The order of the stencil in z
-
-# The simulation timestep
-dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
-N_step = 800     # Number of iterations to perform
-N_show = 40     # Number of timestep between every plot
-show_fields = False
-l_boost = False
-
-if l_boost:
-    # Boosted frame
-    gamma_boost = 15.
-    boost = BoostConverter(gamma_boost)
-else:
-    gamma_boost = 1.
-    boost = None
-
-# Initialize the simulation object
-sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-    -1.e-6, 0., -1.e-6, 0., 1, 1, 1, 1.e18,
-    zmin=zmin, n_order=n_order, boundaries='open',
-    gamma_boost=gamma_boost )
-
-# Configure the moving window
-sim.set_moving_window(v=c, gamma_boost=gamma_boost)
-
-# Suppress the particles that were intialized by default and add the bunch
-sim.ptcl = [ ]
+n_order = 32     # Order of the stencil
 
 # Bunch parameters
 sig_r = 3.e-6
 sig_z = 3.e-6
 n_emit = 1.e-6
-gamma0 = 100.
+gamma0 = 5.
 sig_gamma = 1.
 Q = 10.e-12
 N = 100000
-tf = 40.e-6 / (np.sqrt(1.-1./gamma0**2)*c)
-zf = 20.e-6
+tf = 0
+zf = -20.e-6
 
-# Add gaussian electron bunch
+# The simulation timestep
+dt = zmax/Nz/c   # Timestep (seconds)
+
+# Initialize the simulation object
+sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
+    0, 0, 0, 0, 2, 2, 4, 0.,
+    n_order=n_order, boundaries='open' )
+# Configure the moving window
+sim.set_moving_window( v=c )
+# Suppress the particles that were intialized by default and add the bunch
+sim.ptcl = [ ]
 add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0, sig_gamma,
-                         Q, N, tf, zf, boost=boost )
-
-if show_fields:
-    # Show the initial fields
-    plt.figure(0)
-    sim.fld.interp[0].show('Ez')
-    plt.figure(1)
-    sim.fld.interp[0].show('Er')
-    plt.show()
-    print( 'Done' )
-
-# Create empty arrays for saving rms bunch sizes
-sig_zp = np.zeros(int(N_step/N_show)+1)
-sig_xp = np.zeros(int(N_step/N_show)+1)
-sig_yp = np.zeros(int(N_step/N_show)+1)
-
-# Set initial bunch sizes
-sig_zp[0] = np.std(sim.ptcl[0].z)
-sig_xp[0] = np.std(sim.ptcl[0].x)
-sig_yp[0] = np.std(sim.ptcl[0].y)
-
-# Create array corresponding to the propagation distance of the bunch
-z_prop  = np.arange(int(N_step/N_show)+1) * ((zmax-zmin)/Nz) * N_show
-z_prop += -20.e-6
-if l_boost:
-    z_prop, = boost.copropag_length([z_prop], beta_object = boost.beta0)
-
-# Carry out the simulation
-for k in range(int(N_step/N_show)) :
-    sim.step(N_show)
-    sig_zp[k+1] = np.std(sim.ptcl[0].z)
-    sig_xp[k+1] = np.std(sim.ptcl[0].x)
-    sig_yp[k+1] = np.std(sim.ptcl[0].y)
-    if show_fields:
-        # Show the fields
-        plt.figure(0)
-        plt.clf()
-        sim.fld.interp[0].show('Ez')
-        plt.figure(1)
-        plt.clf()
-        sim.fld.interp[0].show('Er')
-        plt.show()
-
-# Plot the evolution of the rms bunch size
-plt.figure(0)
-plt.clf()
-plt.plot(z_prop*1.e6, sig_zp*1.e6, label = 'sig_z')
-plt.plot(z_prop*1.e6, sig_xp*1.e6, label = 'sig_x')
-plt.plot(z_prop*1.e6, sig_yp*1.e6, label = 'sig_y')
-plt.xlabel('Propagation distance [mu]')
-plt.ylabel('rms of bunch size [mu]')
-plt.legend()
-plt.show()
+                         Q, N, tf, zf )
+# Set the diagnostics
+sim.diags = [ FieldDiagnostic(10, sim.fld, comm=sim.comm) ]
+# Perform one simulation step (essentially in order to write the diags)
+sim.step(1)

--- a/tests/unautomated/test_space_charge_gaussian.py
+++ b/tests/unautomated/test_space_charge_gaussian.py
@@ -15,6 +15,7 @@ from fbpic.main import Simulation
 from fbpic.openpmd_diag import FieldDiagnostic
 from fbpic.lpa_utils.bunch import add_elec_bunch_gaussian
 
+# Set the seed since the gaussian is drawn randomly
 np.random.seed(0)
 
 # The simulation box
@@ -29,7 +30,7 @@ n_order = 32     # Order of the stencil
 sig_r = 3.e-6
 sig_z = 3.e-6
 n_emit = 1.e-6
-gamma0 = 5.
+gamma0 = 15.
 sig_gamma = 1.
 Q = 10.e-12
 N = 100000


### PR DESCRIPTION
This pull request corrects two short-comings of the space-charge calculation in FBPIC:
- the fact that it erased any other pre-existing field on the grid
- the fact that it was not exact when performing MPI simulations

In the new implementation, a temporary new grid, having the size of **whole physical domain** is created on the proc 0, and space-charge is calculated on this grid, using global FFT (fixes the 2nd issue). The result is then distributed to the other MPI ranks and **added** to their local grid (fixes the 1st issue).

I also added an automated test ensuring that space-charge calculation gives the same result in MPI and non-MPI simulations.