### PR TITLE
Add Invite link for slack to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![License](https://img.shields.io/pypi/l/fbpic.svg)](LICENSE.txt)
 [![DOI](https://zenodo.org/badge/69215997.svg)](https://zenodo.org/badge/latestdoi/69215997)
 
-Online documentation: [http://fbpic.github.io](http://fbpic.github.io)
-
+Online documentation: [http://fbpic.github.io](http://fbpic.github.io)<br/> 
+Support: [Join slack](https://slack-fbpic.herokuapp.com)
 ## Overview
 
 FBPIC is a


### PR DESCRIPTION
Hi,
I used [this](https://github.com/outsideris/slack-invite-automation#issue-token) slack app to make an invite link to our slack channels. This way users can invite themselves if they need some support from us.
It's just a suggestion, so if you want to stay in "control" reject it and I will remove the app again from our slack. 