### PR TITLE
Set threads per block of deposition and gathering kernels to 64

### DIFF
--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -619,7 +619,7 @@ class Particles(object) :
             # Get the threads per block and the blocks per grid
             dim_grid_2d_flat, dim_block_2d_flat = cuda_tpb_bpg_1d(
                                                     grid[0].Nz*grid[0].Nr,
-                                                    TPB = 64 )
+                                                    TPB=64 )
             dim_grid_2d, dim_block_2d = cuda_tpb_bpg_2d(
                                           grid[0].Nz, grid[0].Nr )
 

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -512,7 +512,7 @@ class Particles(object) :
         # GPU (CUDA) version
         if self.use_cuda:
             # Get the threads per block and the blocks per grid
-            dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( self.Ntot )
+            dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( self.Ntot, TPB=64 )
             # Call the CUDA Kernel for the gathering of E and B Fields
             # for Mode 0 and 1 only.
             if self.particle_shape == 'linear':
@@ -618,7 +618,8 @@ class Particles(object) :
         if self.use_cuda:
             # Get the threads per block and the blocks per grid
             dim_grid_2d_flat, dim_block_2d_flat = cuda_tpb_bpg_1d(
-                                                    grid[0].Nz*grid[0].Nr )
+                                                    grid[0].Nz*grid[0].Nr,
+                                                    TPB = 64 )
             dim_grid_2d, dim_block_2d = cuda_tpb_bpg_2d(
                                           grid[0].Nz, grid[0].Nr )
 


### PR DESCRIPTION
As discussed in issue #129 the run time of the GPU deposit and gathering kernels can be improved by reducing the number of threads per block.
This is the minimal effort fix by just hardcoding the number of threads in the `deposit` and `gather` method to 64. 
Note, that the benchmarks in #129 show the unexpected behaviour that `deposit_rho` performs best with 48 threads per block, this is ignored in this PR.