### PR TITLE
Close #102 Experiment with MKL fft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes numba==0.34 scipy h5py
-  - conda install --yes -c conda-forge pyfftw mpi4py
+  - conda install --yes numba==0.34 scipy h5py mkl
+  - conda install --yes -c conda-forge mpi4py
   - pip install pyflakes
   - python setup.py install
 before_script:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/pypi/l/fbpic.svg)](LICENSE.txt)
 [![DOI](https://zenodo.org/badge/69215997.svg)](https://zenodo.org/badge/latestdoi/69215997)
 
-Online documentation: [http://fbpic.github.io](http://fbpic.github.io)<br/> 
+Online documentation: [http://fbpic.github.io](http://fbpic.github.io)<br/>
 Support: [Join slack](https://slack-fbpic.herokuapp.com)
 
 ## Overview
@@ -67,8 +67,8 @@ it from [here](https://www.continuum.io/downloads).
 
 - Install the dependencies of FBPIC. This can be done in two lines:
 ```
-conda install numba=0.34 scipy h5py
-conda install -c conda-forge mpi4py pyfftw
+conda install numba=0.34 scipy h5py mkl
+conda install -c conda-forge mpi4py
 ```
 - Download and install FBPIC:
 ```
@@ -79,6 +79,12 @@ pip install fbpic
 `pyculib`:
 ```
 conda install -c numba pyculib
+```
+
+- **Optional:** in order to run on a CPU which is **not** an Intel model, you
+need to install `pyfftw`, in order to replace the MKL FFT:
+```
+conda install -c conda-forge pyfftw
 ```
 
 ## Running simulations

--- a/docs/source/install/install_cori_edison.rst
+++ b/docs/source/install/install_cori_edison.rst
@@ -60,8 +60,8 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install numba=0.34 scipy h5py
-       conda install -c conda-forge pyfftw mpi4py
+       conda install numba=0.34 scipy h5py mkl
+       conda install -c conda-forge mpi4py
 
 -  Install ``fbpic``
 

--- a/docs/source/install/install_jureca.rst
+++ b/docs/source/install/install_jureca.rst
@@ -44,9 +44,8 @@ In order to download and install `Anaconda <https://www.continuum.io/downloads>`
 Then install the dependencies of FBPIC:
 ::
 
-   conda install numba=0.34
+   conda install numba=0.34 mkl
    conda install -c numba pyculib
-   conda install -c conda-forge pyfftw
 
 It is important that the following packages are **NOT** installed
 directly with Anaconda: ``mpich``, ``mpi4py``, ``hdf5`` and ``h5py``

--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -56,7 +56,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install -c conda-forge numba=0.34 scipy h5py pyfftw mpi4py
+       conda install -c conda-forge numba=0.34 scipy h5py mpi4py
        conda install -c numba pyculib
 
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -14,8 +14,8 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
   ::
 
-     conda install numba=0.34 scipy h5py
-     conda install -c conda-forge mpi4py pyfftw
+     conda install numba=0.34 scipy h5py mkl
+     conda install -c conda-forge mpi4py
 
 -  Install ``fbpic``
 
@@ -35,6 +35,13 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
        conda install -c numba pyculib
 
+
+-  **Optional:** In order to run on a CPU which is **not** an Intel model, you
+need to install `pyfftw`, in order to replace the MKL FFT:
+
+   ::
+
+      conda install -c conda-forge pyfftw
 
 
 Potential issues

--- a/docs/source/install/install_titan.rst
+++ b/docs/source/install/install_titan.rst
@@ -58,7 +58,7 @@ Installation of FBPIC and its dependencies
   ::
 
     conda install numba=0.34
-    conda install -c conda-forge pyfftw
+    conda install -c conda-forge
     conda install -c numba pyculib
 
 -  Clone and install the ``fbpic`` repository using git

--- a/fbpic/fields/spectral_transform/mkl_fft.py
+++ b/fbpic/fields/spectral_transform/mkl_fft.py
@@ -21,12 +21,14 @@ import ctypes
 import numpy as np
 
 # Load the MKL Library for the current plateform
-if sys.platform == 'linux':
+if sys.platform in ['linux', 'linux2']:
     mkl = ctypes.CDLL('libmkl_rt.so')
 elif sys.platform == 'darwin':
     mkl = ctypes.CDLL('libmkl_rt.dylib')
 elif sys.platform == 'win32':
     mkl = ctypes.CDLL('libmkl_rt.dll')
+else:
+    raise ValueError('Unrecognized plateform: %s' %sys.platform)
 
 # Define a set of flags that are passed to the MKL library
 # The values of these flags are copied from mkl_dfti.h

--- a/fbpic/fields/spectral_transform/mkl_fft.py
+++ b/fbpic/fields/spectral_transform/mkl_fft.py
@@ -1,0 +1,117 @@
+"""
+This file is part of the Fourier-Bessel Partile-In-Cell code (FB-PIC)
+It allows the use of the MKL library for FFT.
+"""
+# Note: this code is partially inspired by https://github.com/LCAV/mkl_fft
+# For this reason, the corresponding copyright is reproduced here:
+
+# Copyright (c) 2016 Ivan Dokmanic, Robin Scheibler
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+import sys
+import ctypes
+import numpy as np
+
+# Load the MKL Library for the current plateform
+if sys.platform == 'linux':
+    mkl = ctypes.CDLL('libmkl_rt.so')
+elif sys.platform == 'darwin':
+    mkl = ctypes.CDLL('libmkl_rt.dylib')
+elif sys.platform == 'win32':
+    mkl = ctypes.CDLL('libmkl_rt.dll')
+
+# Define a set of flags that are passed to the MKL library
+# The values of these flags are copied from mkl_dfti.h
+DFTI_PRECISION              = ctypes.c_int(3)
+DFTI_BACKWARD_SCALE         = ctypes.c_int(5)
+DFTI_NUMBER_OF_TRANSFORMS   = ctypes.c_int(7)
+DFTI_PLACEMENT              = ctypes.c_int(11)
+DFTI_INPUT_STRIDES          = ctypes.c_int(12)
+DFTI_OUTPUT_STRIDES         = ctypes.c_int(13)
+DFTI_INPUT_DISTANCE         = ctypes.c_int(14)
+DFTI_OUTPUT_DISTANCE        = ctypes.c_int(15)
+DFTI_COMPLEX                = ctypes.c_int(32)
+DFTI_SINGLE                 = ctypes.c_int(35)
+DFTI_DOUBLE                 = ctypes.c_int(36)
+DFTI_NOT_INPLACE            = ctypes.c_int(44)
+
+
+class MKLFFT( object ):
+    """
+    TODO
+    """
+
+    def __init__( self, a ):
+        """
+        TODO
+        """
+
+        # Perform a few checks on the array type and shape
+        assert a.ndim == 2
+        assert a.dtype == np.complex128
+        self.shape = a.shape
+
+        # Prepare the descriptor for the FFT:
+        # from complex128 to complex128, along the axis 0 of a 2D array
+        descriptor = ctypes.c_void_p(0)
+        length = ctypes.c_int(a.shape[0])
+        ifft_scale = ctypes.c_double( 1. / a.shape[0] )
+        n_transforms = ctypes.c_int(a.shape[1])
+        distance = ctypes.c_int(a.strides[1] // a.itemsize)
+        # For strides, the C type used *must* be long
+        strides = (ctypes.c_long*2)(0, a.strides[0] // a.itemsize)
+        mkl.DftiCreateDescriptor( ctypes.byref(descriptor),
+            DFTI_DOUBLE, DFTI_COMPLEX, ctypes.c_int(1), length)
+        mkl.DftiSetValue(descriptor, DFTI_NUMBER_OF_TRANSFORMS, n_transforms)
+        mkl.DftiSetValue(descriptor, DFTI_INPUT_DISTANCE, distance)
+        mkl.DftiSetValue(descriptor, DFTI_OUTPUT_DISTANCE, distance)
+        mkl.DftiSetValue(descriptor, DFTI_INPUT_STRIDES, ctypes.byref(strides))
+        mkl.DftiSetValue(descriptor, DFTI_OUTPUT_STRIDES, ctypes.byref(strides))
+        mkl.DftiSetValue(descriptor, DFTI_PLACEMENT, DFTI_NOT_INPLACE)
+        mkl.DftiSetValue(descriptor, DFTI_BACKWARD_SCALE, ifft_scale)
+        mkl.DftiCommitDescriptor(descriptor)
+        self.descriptor = descriptor
+
+    def transform( self, array_in, array_out ):
+        """
+        TODO
+        """
+        # Perform a few checks
+        assert array_in.shape == self.shape
+        assert array_in.dtype == np.complex128
+        assert array_out.shape == self.shape
+        assert array_out.dtype == np.complex128
+
+        # Compute the FFT
+        mkl.DftiComputeForward( self.descriptor,
+            array_in.ctypes.data_as( ctypes.c_void_p ),
+            array_out.ctypes.data_as( ctypes.c_void_p ) )
+
+    def inverse_transform( self, array_in, array_out ):
+        """
+        TODO
+        """
+        # Perform a few checks
+        assert array_in.shape == self.shape
+        assert array_in.dtype == np.complex128
+        assert array_out.shape == self.shape
+        assert array_out.dtype == np.complex128
+
+        # Compute the FFT
+        mkl.DftiComputeBackward( self.descriptor,
+            array_in.ctypes.data_as( ctypes.c_void_p ),
+            array_out.ctypes.data_as( ctypes.c_void_p ) )
+
+    def __del__( self ):
+        """
+        TODO
+        """
+        mkl.DftiFreeDescriptor( ctypes.byref(self.descriptor) )

--- a/fbpic/fields/spectral_transform/mkl_fft.py
+++ b/fbpic/fields/spectral_transform/mkl_fft.py
@@ -7,13 +7,13 @@ It allows the use of the MKL library for FFT.
 
 # Copyright (c) 2016 Ivan Dokmanic, Robin Scheibler
 # Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to 
-# deal in the Software without restriction, including without limitation the 
-# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or 
-# sell copies of the Software, and to permit persons to whom the Software is 
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 
-# The above copyright notice and this permission notice shall be included in 
+# The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 
 import sys
@@ -21,14 +21,12 @@ import ctypes
 import numpy as np
 
 # Load the MKL Library for the current plateform
-if sys.platform in ['linux', 'linux2']:
+if sys.platform == 'linux':
     mkl = ctypes.CDLL('libmkl_rt.so')
 elif sys.platform == 'darwin':
     mkl = ctypes.CDLL('libmkl_rt.dylib')
 elif sys.platform == 'win32':
     mkl = ctypes.CDLL('libmkl_rt.dll')
-else:
-    raise ValueError("Unrecognized platform: %s" %sys.platform)
 
 # Define a set of flags that are passed to the MKL library
 # The values of these flags are copied from mkl_dfti.h
@@ -48,8 +46,8 @@ DFTI_NOT_INPLACE            = ctypes.c_int(44)
 
 class MKLFFT( object ):
     """
-    Minimal MKL FFT class that only performs the type of FFT relevant for FBPIC,
-    i.e. from complex128 to complex128, along the axis 0 of a 2D array
+    Minimal MKL FFT class that only performs the type of FFT relevant for
+    FBPIC, i.e. from complex128 to complex128, along the axis 0 of a 2D array
 
     Note: the number of thread used is determined by the environment variable
     MKL_NUM_THREADS
@@ -67,7 +65,6 @@ class MKLFFT( object ):
             Array of the same shape as the ones that will later be
             passed to the methods `transform` and `inverse_transform`
         """
-
         # Perform a few checks on the array type and shape
         assert a.ndim == 2
         assert a.dtype == np.complex128
@@ -96,7 +93,12 @@ class MKLFFT( object ):
 
     def transform( self, array_in, array_out ):
         """
-        TODO
+        Perform the Fourier transform of array_in,
+        and store the result in array_out
+
+        Parameters
+        ----------
+        array_in, array_out: 2darrays of complex128
         """
         # Perform a few checks
         assert array_in.shape == self.shape
@@ -111,7 +113,12 @@ class MKLFFT( object ):
 
     def inverse_transform( self, array_in, array_out ):
         """
-        TODO
+        Perform the inverse Fourier transform of array_in,
+        and store the result in array_out
+
+        Parameters
+        ----------
+        array_in, array_out: 2darrays of complex128
         """
         # Perform a few checks
         assert array_in.shape == self.shape
@@ -126,6 +133,6 @@ class MKLFFT( object ):
 
     def __del__( self ):
         """
-        TODO
+        Destroy the descriptor of the MKL FFT.
         """
         mkl.DftiFreeDescriptor( ctypes.byref(self.descriptor) )

--- a/fbpic/fields/spectral_transform/mkl_fft.py
+++ b/fbpic/fields/spectral_transform/mkl_fft.py
@@ -6,27 +6,29 @@ It allows the use of the MKL library for FFT.
 # For this reason, the corresponding copyright is reproduced here:
 
 # Copyright (c) 2016 Ivan Dokmanic, Robin Scheibler
-# Permission is hereby granted, free of charge, to any person obtaining a copy of
-# this software and associated documentation files (the "Software"), to deal in
-# the Software without restriction, including without limitation the rights to
-# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-# of the Software, and to permit persons to whom the Software is furnished to do
-# so, subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to 
+# deal in the Software without restriction, including without limitation the 
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or 
+# sell copies of the Software, and to permit persons to whom the Software is 
+# furnished to do so, subject to the following conditions:
 
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in 
+# all copies or substantial portions of the Software.
 
 import sys
 import ctypes
 import numpy as np
 
 # Load the MKL Library for the current plateform
-if sys.platform == 'linux':
+if sys.platform in ['linux', 'linux2']:
     mkl = ctypes.CDLL('libmkl_rt.so')
 elif sys.platform == 'darwin':
     mkl = ctypes.CDLL('libmkl_rt.dylib')
 elif sys.platform == 'win32':
     mkl = ctypes.CDLL('libmkl_rt.dll')
+else:
+    raise ValueError("Unrecognized platform: %s" %sys.platform)
 
 # Define a set of flags that are passed to the MKL library
 # The values of these flags are copied from mkl_dfti.h
@@ -46,12 +48,24 @@ DFTI_NOT_INPLACE            = ctypes.c_int(44)
 
 class MKLFFT( object ):
     """
-    TODO
+    Minimal MKL FFT class that only performs the type of FFT relevant for FBPIC,
+    i.e. from complex128 to complex128, along the axis 0 of a 2D array
+
+    Note: the number of thread used is determined by the environment variable
+    MKL_NUM_THREADS
     """
 
     def __init__( self, a ):
         """
-        TODO
+        Initialize the descriptor of the MKL FFT.
+        The descriptor is then reused for each call to the methods
+        `transform` and `inverse_transform`
+
+        Parameters
+        ----------
+        a: 2darray of complex128
+            Array of the same shape as the ones that will later be
+            passed to the methods `transform` and `inverse_transform`
         """
 
         # Perform a few checks on the array type and shape

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ scipy
 numba
 h5py
 mpi4py
-pyfftw
 python-dateutil


### PR DESCRIPTION
This pull requests adds the option to use the MKL FFT in FBPIC (note that the MKL library was usually automatically downloaded when installing the dependencies of FBPIC, even before this pull request). Because the performance tests are quite favorable (see below), the MKL FFT is used preferentially, and `pyfftw` is only used when MKL is not available. This also means that `pyfftw` is not, strictly speaking, a dependency of FBPIC anymore.

Regarding performance, here are the results of scaling with the number of threads, on a 24-core Intel node:

- with pyfftw:
<img width="500" alt="screen shot 2017-10-23 at 10 45 52 pm" src="https://user-images.githubusercontent.com/6685781/31926548-f7b81e74-b843-11e7-969a-41dc552e5fc0.png">

- with MKL FFT:
<img width="487" alt="screen shot 2017-10-23 at 10 45 13 pm" src="https://user-images.githubusercontent.com/6685781/31926552-fed0f79e-b843-11e7-9f7a-c055e56744f6.png">

The red curve (fft routines) has much lower compute cost, and also much better scaling with the number of threads in the case of MKL!