### PR TITLE
Make the exchange of guard cells (for rho and J) more robust

### DIFF
--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -166,6 +166,11 @@ class Fields(object) :
                                 use_galilean=self.use_galilean,
                                 use_cuda=self.use_cuda ) )
 
+        # Record flags that indicates whether, for the sources *in
+        # spectral space*, the guard cells have been exchanged via MPI
+        self.exchanged_source = \
+            {'J': False, 'rho_prev': False, 'rho_new': False}
+
         # Initialize the needed prefix sum array for sorting
         if self.use_cuda:
             # Shift in the indices, induced by the moving window

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -224,6 +224,12 @@ class Fields(object) :
         Correct the currents so that they satisfy the
         charge conservation equation
         """
+        # Ensure consistency (charge and current should
+        # not be exchanged via MPI before correction)
+        assert self.exchanged_source['rho_prev'] == False
+        assert self.exchanged_source['rho_next'] == False
+        assert self.exchanged_source['J'] == False
+
         # Correct each azimuthal grid individually
         for m in range(self.Nm) :
             self.spect[m].correct_currents( self.dt, self.psatd[m] )

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -481,7 +481,7 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
     # For consistency and diagnostics, redeposit the charge and current
     # of the full simulation (since the last step erased these quantities)
     sim.deposit('rho_prev')
-    sim.deposit('J', exchange_J=True)
+    sim.deposit('J', exchange=True)
 
     print("Done.")
 

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -533,7 +533,7 @@ class Simulation(object):
         if self.filter_currents:
             fld.filter_spect( fieldtype )
         # Set the flag to indicate whether these fields have been exchanged
-        fld.exchanged_fields[ fieldtype ] = (exchange and self.comm.size > 1)
+        fld.exchanged_source[ fieldtype ] = (exchange and self.comm.size > 1)
 
     def shift_galilean_boundaries(self):
         """

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -363,8 +363,9 @@ class Simulation(object):
 
                 # Reproject the charge on the interpolation grid
                 # (Since particles have been removed / added to the simulation;
-                # otherwise rho_prev is obtained from the previous iteration)
-                self.deposit('rho_prev')
+                # otherwise rho_prev is obtained from the previous iteration.
+                # Note that the guard cells of rho are never exchanged.)
+                self.deposit('rho_prev', exchange=False)
 
             # Main PIC iteration
             # ------------------
@@ -393,7 +394,7 @@ class Simulation(object):
 
             # Get the current at t = (n+1/2) dt
             # (Guard cell exchange done either now or after current correction)
-            self.deposit('J', exchange_J=(correct_currents is False))
+            self.deposit('J', exchange=(correct_currents is False))
 
             # Handle elementary processes at t = (n + 1/2)dt
             # i.e. when the particles' velocity and position are synchronized
@@ -413,17 +414,18 @@ class Simulation(object):
                 self.shift_galilean_boundaries()
 
             # Get the charge density at t = (n+1) dt
-            self.deposit('rho_next')
+            self.deposit('rho_next', exchange=False)
             # Correct the currents (requires rho at t = (n+1) dt )
             if correct_currents:
                 fld.correct_currents()
                 if self.comm.size > 1:
-                    # Exchange the corrected J between domains
+                    # Exchange the guard cells of corrected J between domains
                     # (If correct_currents is False, the exchange of J
                     # is done in the function `deposit`)
                     fld.spect2interp('J')
                     self.comm.exchange_fields(fld.interp, 'J', 'add')
                     fld.interp2spect('J')
+                    fld.exchanged_source['J'] = True
 
             # Damp the fields in the guard cells
             self.comm.damp_guard_EB( fld.interp )
@@ -471,7 +473,7 @@ class Simulation(object):
             h, m = divmod(m, 60)
             print('\n Time taken by the loop: %d:%02d:%02d\n' % (h, m, s))
 
-    def deposit( self, fieldtype, exchange_J=False ):
+    def deposit( self, fieldtype, exchange=False ):
         """
         Deposit the charge or the currents to the interpolation grid
         and then to the spectral grid.
@@ -483,8 +485,10 @@ class Simulation(object):
             should be changed by the deposition
             Either 'rho_prev', 'rho_next' or 'J'
 
-        exchange_J: bool
-            When depositing J, whether to do the guard cells exchange now
+        exchange: bool
+            Whether to exchange guard cells via MPI before transforming
+            the fields to the spectral grid. (The corresponding flag in
+            fld.exchanged_source is set accordingly.)
         """
         # Shortcut
         fld = self.fld
@@ -502,8 +506,9 @@ class Simulation(object):
                 antenna.deposit( fld, 'rho', self.comm )
             # Divide by cell volume
             fld.divide_by_volume('rho')
-            # The guard cells of rho are not exchanged (except for diagnostics)
-            # This is because rho is only used for current correction.
+            # Exchange guard cells if requested by the user
+            if exchange and self.comm.size > 1:
+                self.comm.exchange_fields(fld.interp, 'rho', 'add')
 
         # Currents
         elif fieldtype == 'J':
@@ -516,8 +521,8 @@ class Simulation(object):
                 antenna.deposit( fld, 'J', self.comm )
             # Divide by cell volume
             fld.divide_by_volume('J')
-            # Exchange guard cells
-            if exchange_J and self.comm.size > 1:
+            # Exchange guard cells if requested by the user
+            if exchange and self.comm.size > 1:
                 self.comm.exchange_fields(fld.interp, 'J', 'add')
 
         else:
@@ -527,6 +532,8 @@ class Simulation(object):
         fld.interp2spect( fieldtype )
         if self.filter_currents:
             fld.filter_spect( fieldtype )
+        # Set the flag to indicate whether these fields have been exchanged
+        fld.exchanged_fields[ fieldtype ] = (exchange and self.comm.size > 1)
 
     def shift_galilean_boundaries(self):
         """
@@ -546,6 +553,7 @@ class Simulation(object):
             self.fld.interp[m].zmin += shift_distance
             self.fld.interp[m].zmax += shift_distance
             self.fld.interp[m].z += shift_distance
+
 
     def set_moving_window( self, v=c, ux_m=0., uy_m=0., uz_m=0.,
                   ux_th=0., uy_th=0., uz_th=0., gamma_boost=None ):

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -459,8 +459,11 @@ class Simulation(object):
         # Finalize PIC loop
         # Get the charge density and the current from spectral space.
         fld.spect2interp('J')
+        if (not fld.exchanged_source['J']) and (self.comm.size > 1):
+            self.comm.exchange_fields(self.fld.interp, 'J', 'add')
         fld.spect2interp('rho_prev')
-        self.comm.exchange_fields(self.fld.interp, 'rho', 'add')
+        if (not fld.exchanged_source['rho_prev']) and (self.comm.size > 1):
+            self.comm.exchange_fields(self.fld.interp, 'rho', 'add')
 
         # Receive simulation data from GPU (if CUDA is used)
         if self.use_cuda:

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -138,9 +138,12 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
             # Get 'rho_prev', since it correspond to rho at time n
             self.fld.spect2interp('rho_prev')
             self.fld.spect2interp('J')
-            # Exchange rho in real space
-            # (rho is never exchanged during the PIC loop, while J is)
-            self.comm.exchange_fields(self.fld.interp, 'rho', 'add')
+            # Exchange rho and J if needed
+            if (self.comm is not None) and (self.comm.size > 1):
+                if not self.fld.exchanged_source['J']:
+                    self.comm.exchange_fields(self.fld.interp, 'J', 'add')
+                if not self.fld.exchanged_source['rho_prev']:
+                    self.comm.exchange_fields(self.fld.interp, 'rho', 'add')
 
         # Find the limits of the local subdomain at this iteration
         if self.comm is None:

--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -72,11 +72,16 @@ class FieldDiagnostic(OpenPMDDiagnostic):
         if "rho" in self.fieldtypes:
             # Get 'rho_prev', since it correspond to rho at time n
             self.fld.spect2interp('rho_prev')
-            # Exchange rho in real space
-            # (rho is never exchanged during the PIC loop, while J is)
-            self.comm.exchange_fields(self.fld.interp, 'rho', 'add')
+            # Exchange rho in real space if needed
+            if (self.comm is not None) and (self.comm.size > 1) \
+                and (not self.fld.exchanged_source['rho_prev']):
+                    self.comm.exchange_fields(self.fld.interp, 'rho', 'add')
         if "J" in self.fieldtypes:
             self.fld.spect2interp('J')
+            # Exchange J in real space if needed
+            if (self.comm is not None) and (self.comm.size > 1) \
+                and (not self.fld.exchanged_source['J']):
+                    self.comm.exchange_fields(self.fld.interp, 'J', 'add')
 
         # If needed: Receive data from the GPU
         if self.fld.use_cuda :


### PR DESCRIPTION
Right now some of the code relies explicitly on the fact that rho is never exchanged. While this works, it is not very robust (e.g. if at some point, or in some configuration, we decide to modify the exchange pattern).

Therefore, I introduced a set of flags that record whether the fields have been exchanged. I also modified the function `deposit` so that there is an option to automatically exchange the fields (even for `rho`, although it is not used right now): I think it makes things a bit clearer in the main PIC loop.