### PR TITLE
Allow FBPIC to run without MPI

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -7,7 +7,7 @@ It defines the structure necessary to implement the boundary exchanges.
 """
 import numpy as np
 from scipy.constants import c
-from mpi4py import MPI as mpi
+from fbpic.mpi_utils import comm, mpi_type_dict, mpi_installed
 from fbpic.fields.fields import InterpolationGrid
 from fbpic.fields.utility_methods import get_stencil_reach
 from fbpic.particles.particles import Particles
@@ -19,14 +19,6 @@ from fbpic.cuda_utils import cuda_installed
 if cuda_installed:
     from fbpic.cuda_utils import cuda, cuda_tpb_bpg_2d
     from .cuda_methods import cuda_damp_EB_left, cuda_damp_EB_right
-
-# Dictionary of correspondance between numpy types and mpi types
-# (Necessary when calling Gatherv)
-mpi_type_dict = { 'float32': mpi.REAL4,
-                  'float64': mpi.REAL8,
-                  'complex64': mpi.COMPLEX8,
-                  'complex128': mpi.COMPLEX16,
-                  'uint64': mpi.UINT64_T }
 
 class BoundaryCommunicator(object):
     """
@@ -123,8 +115,8 @@ class BoundaryCommunicator(object):
         self.dz = (zmax - zmin)/self.Nz
 
         # MPI Setup
-        if use_all_mpi_ranks:
-            self.mpi_comm = mpi.COMM_WORLD
+        if use_all_mpi_ranks and mpi_installed:
+            self.mpi_comm = comm
             self.rank = self.mpi_comm.rank
             self.size = self.mpi_comm.size
         else:

--- a/fbpic/cuda_utils.py
+++ b/fbpic/cuda_utils.py
@@ -149,16 +149,19 @@ def print_current_gpu( mpi ):
     mpi: an mpi4py.MPI object
     """
     gpu = cuda.gpus.current
-    rank = mpi.COMM_WORLD.rank
-    node = mpi.Get_processor_name()
     # Convert bytestring to actual string
     try:
         gpu_name = gpu.name.decode()
     except AttributeError:
         gpu_name = gpu.name
     # Print the GPU that is being used
-    message = "MPI rank %d selected a %s GPU with id %s on node %s" %(
-        rank, gpu_name, gpu.id, node)
+    if mpi.COMM_WORLD.size > 1:
+        rank = mpi.COMM_WORLD.rank
+        node = mpi.Get_processor_name()
+        message = "MPI rank %d selected a %s GPU with id %s on node %s" %(
+            rank, gpu_name, gpu.id, node)
+    else:
+        message = "FBPIC selected a %s GPU with id %s" %( gpu_name, gpu.id )
     print(message)
 
 def mpi_select_gpus(mpi):

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -9,7 +9,7 @@ This file steers and controls the simulation.
 # When cuda is available, select one GPU per mpi process
 # (This needs to be done before the other imports,
 # as it sets the cuda context)
-from mpi4py import MPI
+from fbpic.mpi_utils import MPI
 import numba
 # Check if threading is available
 from .threading_utils import threading_enabled

--- a/fbpic/mpi_utils.py
+++ b/fbpic/mpi_utils.py
@@ -3,9 +3,11 @@
 # License: 3-Clause-BSD-LBNL
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
-It defines a set of generic functions for MPI execution
+It imports a set of MPI objects - or a set of dummy replacements when MPI
+is not installed
 """
 try:
+    # Try to import MPI objects
     from mpi4py import MPI
     from mpi4py.MPI import COMM_WORLD as comm
     # Dictionary of correspondance between numpy types and mpi types
@@ -18,11 +20,13 @@ try:
     mpi_installed = True
 
 except ImportError:
+    # If MPI is not installed, define dummy replacements
     print("*** MPI is not properly installed.")
     print("*** In order to diagnose the problem, type:")
     print("*** `mpirun -np 2 python -c `from mpi4py.MPI import COMM_WORLD`")
 
     class DummyCommunicator(object):
+        """Dummy replacement for COMM_WORLD when mpi4py is not installed."""
 
         def __init__(self):
             self.rank = 0
@@ -32,14 +36,12 @@ except ImportError:
             pass
 
     class DummyMPI(object):
+        """Dummy replacement for mpi4py.MPI when mpi4py is not installed."""
 
         def __init__(self):
             self.COMM_WORLD = DummyCommunicator()
 
-        def Get_processor_name(self):
-            return( '"Unknown"' )
-
     MPI = DummyMPI()
-    comm = None
+    comm = DummyCommunicator()
     mpi_type_dict = {}
     mpi_installed = False

--- a/fbpic/mpi_utils.py
+++ b/fbpic/mpi_utils.py
@@ -28,6 +28,9 @@ except ImportError:
             self.rank = 0
             self.size = 1
 
+        def barrier(self):
+            pass
+
     class DummyMPI(object):
 
         def __init__(self):

--- a/fbpic/mpi_utils.py
+++ b/fbpic/mpi_utils.py
@@ -1,0 +1,42 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines a set of generic functions for MPI execution
+"""
+try:
+    from mpi4py import MPI
+    from mpi4py.MPI import COMM_WORLD as comm
+    # Dictionary of correspondance between numpy types and mpi types
+    # (Necessary when calling Gatherv)
+    mpi_type_dict = { 'float32': MPI.REAL4,
+                      'float64': MPI.REAL8,
+                      'complex64': MPI.COMPLEX8,
+                      'complex128': MPI.COMPLEX16,
+                      'uint64': MPI.UINT64_T }
+    mpi_installed = True
+
+except ImportError:
+    print("*** MPI is not properly installed.")
+    print("*** In order to diagnose the problem, type:")
+    print("*** `mpirun -np 2 python -c `from mpi4py.MPI import COMM_WORLD`")
+
+    class DummyCommunicator(object):
+
+        def __init__(self):
+            self.rank = 0
+            self.size = 1
+
+    class DummyMPI(object):
+
+        def __init__(self):
+            self.COMM_WORLD = DummyCommunicator()
+
+        def Get_processor_name(self):
+            return( '"Unknown"' )
+
+    MPI = DummyMPI()
+    comm = None
+    mpi_type_dict = {}
+    mpi_installed = False

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -11,7 +11,7 @@ import os, re
 import numpy as np
 from .field_diag import FieldDiagnostic
 from .particle_diag import ParticleDiagnostic
-from mpi4py.MPI import COMM_WORLD as comm
+from fbpic.mpi_utils import comm
 
 def set_periodic_checkpoint( sim, period ):
     """

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -40,7 +40,7 @@ def set_periodic_checkpoint( sim, period ):
     if comm.rank == 0:
         if os.path.exists('./checkpoints') is False:
             os.mkdir('./checkpoints')
-    comm.Barrier()
+    comm.barrier()
 
     # Choose the name of the directory: one directory per processor
     write_dir = 'checkpoints/proc%d/' %comm.rank
@@ -101,7 +101,7 @@ def restart_from_checkpoint( sim, iteration=None ):
     # so that this also works for `use_all_ranks=False`)
     if comm.rank == 0:
         check_restart( sim, iteration )
-    comm.Barrier()
+    comm.barrier()
 
     # Choose the name of the directory from which to restart:
     # one directory per processor

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ numpy
 scipy
 numba
 h5py
-mpi4py
 python-dateutil


### PR DESCRIPTION
In many use cases, FBPIC does not really require MPI (MPI is only required for parallel simulations or parallel parameter scans). Therefore, it might be good to allow FBPIC to run without mpi4y (in case some users experience issues with installing mpi4py.)

This pull request removes `mpi4py` from the requirements, and defines a dummy replacement for the places in the code where an MPI communicator is explicitly used. By default, the documentation still recommends that mpi4py be installed, since most users will not experience issues with this.

Feel free to comment/suggest alternatives, as I am not sure that this is the most elegant solution...