### PR TITLE
Generalize Hankel transform for azimuthal modes m>1

### DIFF
--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -121,7 +121,7 @@ class DHT(object):
             self.invM[:, :] = num[:, :] / denom[:, np.newaxis]
 
         # Calculate the matrix M
-        self.M = np.empty((N, N))
+        self.M = np.empty((Nr, Nr))
         if m !=0 and p != m-1 :
             self.M[:, 1:] = np.linalg.pinv( self.invM[1:, :] )
             self.M[:, 0] = 0.

--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -107,6 +107,12 @@ class DHT(object):
         # Get the inverse matrix
         if m!=0:
             self.invM[1:, :] = num[1:, :] / denom[1:, np.newaxis]
+            # In this case, the functions are represented by Bessel functions
+            # *and* an additional mode (below) which satisfies the same
+            # algebric relations for curl/div/grad as the regular Bessel modes,
+            # with the value kperp=0.
+            # The normalization of this mode is arbitrary, and is chosen
+            # so that the condition number of invM is close to 1
             if p==m-1:
                 self.invM[0, :] = self.r**(m-1) * 1./( np.pi * rmax**(m+1) )
             else:

--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -105,18 +105,21 @@ class DHT(object):
         denom = np.pi * rmax**2 * jn( p_denom, alphas)**2
         num = jn( p, 2*np.pi* self.r[np.newaxis,:]*self.nu[:,np.newaxis] )
         # Get the inverse matrix
-        if m!=0 and p!=0:
-            self.invM[1:,:] = num[1:,:] / denom[1:, np.newaxis]
-            self.invM[0,:] = 0.
-        else:
-            self.invM[:,:] = num[:,:] / denom[:, np.newaxis]
+        if m!=0:
+            self.invM[1:, :] = num[1:, :] / denom[1:, np.newaxis]
+            if p==m-1:
+                self.invM[0, :] = self.r**(m-1) * 1./( np.pi * rmax**(m+1) )
+            else:
+                self.invM[0, :] = 0.
+        else :
+            self.invM[:, :] = num[:, :] / denom[:, np.newaxis]
 
-        # Calculate the matrix M by inverting invM
-        self.M = np.empty((Nr, Nr))
-        if m !=0 and p != 0:
-            self.M[:, 1:] = np.linalg.pinv( self.invM[1:,:] )
+        # Calculate the matrix M
+        self.M = np.empty((N, N))
+        if m !=0 and p != m-1 :
+            self.M[:, 1:] = np.linalg.pinv( self.invM[1:, :] )
             self.M[:, 0] = 0.
-        else:
+        else :
             self.M = np.linalg.inv( self.invM )
 
         # Copy the arrays to the GPU if needed

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -79,23 +79,14 @@ def test_laser_periodic(show=False):
     # Choose a very long timestep to check the absence of Courant limit
     dt = L_prop*1./c/N_diag
 
-    print('')
-    print('Testing mode m=0 with an annular beam')
-    propagate_pulse( Nz, Nr, 1, zmin, zmax, Lr, L_prop, zf, dt,
-                      N_diag, w0, ctau, k0, E0, 0, N_show, n_order,
-                      rtol, boundaries='periodic', v_window=0, show=show )
+    # Test modes up to m=2
+    for m in range(3):
 
-    print('')
-    print('Testing mode m=1 with an gaussian beam')
-    propagate_pulse(Nz, Nr, 2, zmin, zmax, Lr, L_prop, zf, dt,
-                     N_diag, w0, ctau, k0, E0, 1, N_show, n_order,
-                     rtol, boundaries='periodic', v_window=0, show=show )
-
-    print('')
-    print('Testing mode m=2 with an Laguerre-Gaussian beam')
-    propagate_pulse(Nz, Nr, 3, zmin, zmax, Lr, L_prop, zf, dt,
-                     N_diag, w0, ctau, k0, E0, 2, N_show, n_order,
-                     rtol, boundaries='periodic', v_window=0, show=show )
+        print('')
+        print('Testing mode m=%d' %m)
+        propagate_pulse( Nz, Nr, m+1, zmin, zmax, Lr, L_prop, zf, dt,
+                          N_diag, w0, ctau, k0, E0, m, N_show, n_order,
+                          rtol, boundaries='periodic', v_window=0, show=show )
 
     print('')
 
@@ -107,17 +98,14 @@ def test_laser_moving_window(show=False):
     # Choose the regular timestep (required by moving window)
     dt = (zmax-zmin)*1./c/Nz
 
-    print('')
-    print('Testing mode m=0 with an annular beam')
-    propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
-                      N_diag, w0, ctau, k0, E0, 0, N_show, n_order,
-                      rtol, boundaries='open', v_window=c, show=show )
+    # Test modes up to m=2
+    for m in range(3):
 
-    print('')
-    print('Testing mode m=1 with an gaussian beam')
-    propagate_pulse(Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
-                     N_diag, w0, ctau, k0, E0, 1, N_show, n_order,
-                     rtol, boundaries='open', v_window=c, show=show )
+        print('')
+        print('Testing mode m=%d' %m)
+        propagate_pulse( Nz, Nr, m+1, zmin, zmax, Lr, L_prop, zf, dt,
+                          N_diag, w0, ctau, k0, E0, m, N_show, n_order,
+                          rtol, boundaries='open', v_window=c, show=show )
 
     print('')
 
@@ -129,19 +117,15 @@ def test_laser_galilean(show=False):
     # Choose the regular timestep (required by moving window)
     dt = L_prop*1./c/N_diag
 
-    print('')
-    print('Testing mode m=0 with an annular beam')
-    propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
-                      N_diag, w0, ctau, k0, E0, 0, N_show, n_order,
+    # Test modes up to m=2
+    for m in range(3):
+
+        print('')
+        print('Testing mode m=%d' %m)
+        propagate_pulse( Nz, Nr, m+1, zmin, zmax, Lr, L_prop, zf, dt,
+                      N_diag, w0, ctau, k0, E0, m, N_show, n_order,
                       rtol, boundaries='open',
                       use_galilean=True, v_comoving=0.999*c, show=show )
-
-    print('')
-    print('Testing mode m=1 with an gaussian beam')
-    propagate_pulse(Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
-                     N_diag, w0, ctau, k0, E0, 1, N_show, n_order,
-                     rtol, boundaries='open',
-                     use_galilean=True, v_comoving=0.999*c, show=show )
 
     print('')
 

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -273,12 +273,12 @@ def propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
     # Get the analytical solution
     z_prop = c*dt*N_step*np.arange(N_diag)
     ZR = 0.5*k0*w0**2
-    if m == 0 : # zf is not implemented for m = 0
-        w_analytic = w0*np.sqrt( 1 + z_prop**2/ZR**2 )
-        E_analytic = E0/( 1 + z_prop**2/ZR**2 )**(1./2)
-    else :
+    if m == 1:
         w_analytic = w0*np.sqrt( 1 + (z_prop-zf)**2/ZR**2 )
         E_analytic = E0/( 1 + (z_prop-zf)**2/ZR**2 )**(1./2)
+    else : # zf is not implemented for the other modes
+        w_analytic = w0*np.sqrt( 1 + z_prop**2/ZR**2 )
+        E_analytic = E0/( 1 + z_prop**2/ZR**2 )**(1./2)
 
     # Either plot the results and check them manually
     if show is True:
@@ -355,12 +355,10 @@ def init_fields( sim, w, ctau, k0, z0, zf, E0, m=1 ) :
             fld.interp[m].Br[:,:] = -1./c*profile
         if m == 2:
             # Laguerre-Gaussian pulse: contributions on mode 0 and 2
-            fld.interp[0].Er[:,:] = profile
             fld.interp[2].Er[:,:] = profile
-            fld.interp[2].Et[:,:] = 1.j*profile
-            fld.interp[0].Bt[:,:] = -1./c*profile
-            fld.interp[2].Bt[:,:] = -1./c*profile
-            fld.interp[2].Bt[:,:] = -1./c*1.j*profile
+            fld.interp[2].Et[:,:] = -1.j*profile
+            fld.interp[2].Bt[:,:] = 1./c*profile
+            fld.interp[2].Br[:,:] = 1./c*1.j*profile
 
 
 def gaussian_transverse_profile( r, w, E ) :

--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -32,6 +32,8 @@ $$ \phi =
 \epsilon \,\frac{m c^2}{e}
     \exp\left(-\frac{r^2}{w_0^2}\right) \sin(k_0 z) \sin(\omega_p t)
 + \epsilon_1 \,\frac{m c^2}{e} \frac{2\,r\cos(\theta)}{w_0}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)
++ \epsilon_2 \,\frac{m c^2}{e} \frac{4\,r^2\cos(2\theta)}{w_0^2}
     \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)$$
 
 $$ E_r = -\partial_r \phi =
@@ -40,17 +42,47 @@ $$ E_r = -\partial_r \phi =
 - \epsilon_1 \,\frac{m c^2}{e} \frac{2\cos(\theta)}{w_0}
     \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)
 + \epsilon_1 \,\frac{m c^2}{e} \frac{4\,r^2\cos(\theta)}{w_0^3}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)
+- \epsilon_2 \,\frac{m c^2}{e} \frac{8\,r\cos(2\theta)}{w_0^2}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)
++ \epsilon_2 \,\frac{m c^2}{e} \frac{8\,r^3\cos(2\theta)}{w_0^4}
     \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t) $$
 
-$$ E_theta = - \frac{1}{r} \partial_\theta \phi =
+$$ E_\theta = - \frac{1}{r} \partial_\theta \phi =
  \epsilon_1 \,\frac{m c^2}{e} \frac{2\,\sin(\theta)}{w_0}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)
++ \epsilon_2 \,\frac{m c^2}{e} \frac{8\,r\sin(2\theta)}{w_0^2}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t) $$
+
+$$ E_x = \cos(\theta)E_r - \sin(\theta)E_\theta =
+\epsilon \,\frac{mc^2}{e}\frac{2\,x}{w_0^2}
+    \exp\left(-\frac{r^2}{w_0^2}\right) \sin(k_0 z) \sin(\omega_p t)
+- \epsilon_1 \,\frac{m c^2}{e} \frac{2}{w_0}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)
++ \epsilon_1 \,\frac{m c^2}{e} \frac{4\,x^2}{w_0^3}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)
+- \epsilon_2 \,\frac{m c^2}{e} \frac{8\,x}{w_0^2}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)
++ \epsilon_2 \,\frac{m c^2}{e} \frac{8\,x(x^2-y^2)}{w_0^4}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t) $$
+
+$$ E_y = \sin(\theta)E_r + \cos(\theta)E_\theta =
+\epsilon \,\frac{mc^2}{e}\frac{2\,y}{w_0^2}
+    \exp\left(-\frac{r^2}{w_0^2}\right) \sin(k_0 z) \sin(\omega_p t)
++ \epsilon_1 \,\frac{m c^2}{e} \frac{4\,x y}{w_0^3}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)
++ \epsilon_2 \,\frac{m c^2}{e} \frac{8\,y}{w_0^2}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t)
++ \epsilon_2 \,\frac{m c^2}{e} \frac{8\,y(x^2-y^2)}{w_0^4}
     \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \sin(\omega_p t) $$
 
 $$ E_z = -\partial_z \phi =
  - \epsilon \,\frac{mc^2}{e} k_0
     \exp\left(-\frac{r^2}{w_0^2}\right) \cos(k_0 z) \sin(\omega_p t)
  - \epsilon_1 \,\frac{m c^2}{e} \frac{2\,r\cos(\theta)}{w_0} k_0
-    \exp\left(-\frac{r^2}{w_0^2}\right)\cos(k_0 z) \sin(\omega_p t)$$
+    \exp\left(-\frac{r^2}{w_0^2}\right)\cos(k_0 z) \sin(\omega_p t)
+ - \epsilon_2 \, \frac{m c^2}{e} \frac{4\,r^2\cos(\theta)}{w_0^2} k_0
+    \exp\left(-\frac{r^2}{w_0^2}\right)\cos(k_0 z) \sin(\omega_p t) $$
 
 $$ v_x/c =
  \epsilon \, \frac{c}{\omega_p} \, \frac{2\,x}{w_0^2}
@@ -58,22 +90,32 @@ $$ v_x/c =
  - \epsilon_1 \,\frac{c}{\omega_p} \frac{2}{w_0}
     \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \cos(\omega_p t)
  + \epsilon_1 \,\frac{c}{\omega_p} \frac{4\,x^2}{w_0^3})
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \cos(\omega_p t)
+- \epsilon_2 \,\frac{c}{\omega_p} \frac{8\,x}{w_0^2}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \cos(\omega_p t)
++ \epsilon_2 \,\frac{c}{\omega_p} \frac{8\,x(x^2-y^2)}{w_0^4}
     \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \cos(\omega_p t) $$
 
 $$ v_y/c =
  \epsilon \, \frac{c}{\omega_p} \, \frac{2\,y}{w_0^2}
     \exp\left(-\frac{r^2}{w_0^2}\right) \sin(k_0 z) \cos(\omega_p t)
  + \epsilon_1 \,\frac{c}{\omega_p} \frac{4\,x y}{w_0^3})
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \cos(\omega_p t)
++ \epsilon_2 \,\frac{c}{\omega_p} \frac{8\,y}{w_0^2}
+    \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \cos(\omega_p t)
++ \epsilon_2 \,\frac{c}{\omega_p} \frac{8\,y(x^2-y^2)}{w_0^4}
     \exp\left(-\frac{r^2}{w_0^2}\right)\sin(k_0 z) \cos(\omega_p t) $$
 
 $$ v_z/c =
  - \epsilon \, \frac{c}{\omega_p} \, k_0
     \exp\left(-\frac{r^2}{w_0^2}\right) \cos(k_0 z) \cos(\omega_p t)
  - \epsilon_1 \,\frac{c}{\omega_p} \frac{2\,x}{w_0} k_0
-    \exp\left(-\frac{r^2}{w_0^2}\right) \cos(k_0 z) \cos(\omega_p t) $$
+    \exp\left(-\frac{r^2}{w_0^2}\right) \cos(k_0 z) \cos(\omega_p t)
+ - \epsilon_2 \,\frac{c}{\omega_p} \frac{4\,(x^2-y^2)}{w_0^2} k_0
+    \exp\left(-\frac{r^2}{w_0^2}\right) \cos(k_0 z) \cos(\omega_p t)$$
 
 where $\epsilon$ is the dimensionless amplitude of the mode 0 and
-$\epsilon_1$ is the dimensionless amplitude of the mode 1.
+$\epsilon_1$, $\epsilon_2$ are the dimensionless amplitudes of modes 1 and 2.
 """
 import numpy as np
 import matplotlib.pyplot as plt
@@ -94,7 +136,7 @@ Nz = 200         # Number of gridpoints along z
 zmax = 40.e-6    # Length of the box along z (meters)
 Nr = 64          # Number of gridpoints along r
 rmax = 20.e-6    # Length of the box along r (meters)
-Nm = 2           # Number of modes used
+Nm = 3           # Number of modes used
 n_order = 16     # Order of the finite stencil
 # The simulation timestep
 dt = zmax/Nz/c   # Timestep (seconds)
@@ -112,6 +154,7 @@ p_nt = 4         # Number of particles per cell along theta
 # The plasma wave
 epsilon = 0.001    # Dimensionless amplitude of the wave in mode 0
 epsilon_1 = 0.001  # Dimensionless amplitude of the wave in mode 1
+epsilon_2 = 0.     # Dimensionless amplitude of the wave in mode 2
 w0 = 5.e-6      # The transverse size of the plasma wave
 N_periods = 3   # Number of periods in the box
 # Calculated quantities
@@ -152,7 +195,7 @@ def simulate_periodic_plasma_wave( particle_shape, show=False ):
     # Impart velocities to the electrons
     # (The electrons are initially homogeneous, but have an
     # intial non-zero velocity that develops into a plasma wave)
-    impart_momenta( sim.ptcl[0], epsilon, epsilon_1, k0, w0, wp )
+    impart_momenta( sim.ptcl[0], epsilon, epsilon_1, epsilon_2, k0, w0, wp )
 
     # Run the simulation
     sim.step( N_step, correct_currents=True )
@@ -177,6 +220,10 @@ def Er( z, r, epsilon, epsilon_1, k0, w0, wp, t) :
         - epsilon_1 * m_e*c**2/e * 2/w0 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.sin( wp*t ) \
         + epsilon_1 * m_e*c**2/e * 4*r**2/w0**3 * \
+            np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.sin( wp*t ) \
+        - epsilon_2 * m_e*c**2/e * 8*r/w0**2 * \
+            np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.sin( wp*t ) \
+        + epsilon_2 * m_e*c**2/e * 8*r**3/w0**4 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.sin( wp*t )
     return( Er_array )
 
@@ -189,6 +236,8 @@ def Ez( z, r, epsilon, epsilon_1, k0, w0, wp, t) :
         - epsilon * m_e*c**2/e * k0 * \
             np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.sin( wp*t ) \
         - epsilon_1 * m_e*c**2/e * k0 * 2*r/w0 * \
+            np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.sin( wp*t ) \
+        - epsilon_2 * m_e*c**2/e * k0 * 4*r**2/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.sin( wp*t )
     return( Ez_array )
 
@@ -203,6 +252,10 @@ def ux( z, r, x, y, epsilon, epsilon_1, k0, w0, wp, t) :
         - epsilon_1 * c/wp * 2/w0 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
         + epsilon_1 * c/wp * 4*x**2/w0**3 * \
+            np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
+        - epsilon_2 * c/wp * 8*x/w0**2 * \
+            np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
+        + epsilon_2 * c/wp * 8*x*(x**2-y**2)/w0**4 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t )
     return( ux_array )
 
@@ -215,6 +268,10 @@ def uy( z, r, x, y, epsilon, epsilon_1, k0, w0, wp, t) :
         epsilon * c/wp * 2*y/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
         + epsilon_1 * c/wp * 4*x*y/w0**3 * \
+            np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
+        + epsilon_2 * c/wp * 8*y/w0**2 * \
+            np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
+        + epsilon_2 * c/wp * 8*y*(x**2-y**2)/w0**4 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t )
     return( uy_array )
 
@@ -227,6 +284,8 @@ def uz( z, r, x, y, epsilon, epsilon_1, k0, w0, wp, t) :
         - epsilon * c/wp * k0 * \
             np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.cos( wp*t ) \
         - epsilon_1 * c/wp * k0 * 2*x/w0 * \
+            np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.cos( wp*t ) \
+        - epsilon_2 * c/wp * k0 * 4*(x**2-y**2)/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.cos( wp*t )
     return( uz_array )
 

--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -155,6 +155,7 @@ p_nt = 4         # Number of particles per cell along theta
 epsilon = 0.001    # Dimensionless amplitude of the wave in mode 0
 epsilon_1 = 0.001  # Dimensionless amplitude of the wave in mode 1
 epsilon_2 = 0.     # Dimensionless amplitude of the wave in mode 2
+epsilons = [ epsilon, epsilon_1, epsilon_2 ]
 w0 = 5.e-6      # The transverse size of the plasma wave
 N_periods = 3   # Number of periods in the box
 # Calculated quantities
@@ -195,7 +196,7 @@ def simulate_periodic_plasma_wave( particle_shape, show=False ):
     # Impart velocities to the electrons
     # (The electrons are initially homogeneous, but have an
     # intial non-zero velocity that develops into a plasma wave)
-    impart_momenta( sim.ptcl[0], epsilon, epsilon_1, epsilon_2, k0, w0, wp )
+    impart_momenta( sim.ptcl[0], epsilons, k0, w0, wp )
 
     # Run the simulation
     sim.step( N_step, correct_currents=True )
@@ -209,83 +210,83 @@ def simulate_periodic_plasma_wave( particle_shape, show=False ):
 # Analytical solutions for the plasma wave
 # -----------------------------------------
 
-def Er( z, r, epsilon, epsilon_1, k0, w0, wp, t) :
+def Er( z, r, epsilons, k0, w0, wp, t) :
     """
     Return the radial electric field as an array
     of the same length as z and r, in the half-plane theta=0
     """
     Er_array = \
-        epsilon * m_e*c**2/e * 2*r/w0**2 * \
+        epsilons[0] * m_e*c**2/e * 2*r/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.sin( wp*t ) \
-        - epsilon_1 * m_e*c**2/e * 2/w0 * \
+        - epsilons[1] * m_e*c**2/e * 2/w0 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.sin( wp*t ) \
-        + epsilon_1 * m_e*c**2/e * 4*r**2/w0**3 * \
+        + epsilons[1] * m_e*c**2/e * 4*r**2/w0**3 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.sin( wp*t ) \
-        - epsilon_2 * m_e*c**2/e * 8*r/w0**2 * \
+        - epsilons[2] * m_e*c**2/e * 8*r/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.sin( wp*t ) \
-        + epsilon_2 * m_e*c**2/e * 8*r**3/w0**4 * \
+        + epsilons[2] * m_e*c**2/e * 8*r**3/w0**4 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.sin( wp*t )
     return( Er_array )
 
-def Ez( z, r, epsilon, epsilon_1, k0, w0, wp, t) :
+def Ez( z, r, epsilons, k0, w0, wp, t) :
     """
     Return the longitudinal electric field as an array
     of the same length as z and r, in the half-plane theta=0
     """
     Ez_array = \
-        - epsilon * m_e*c**2/e * k0 * \
+        - epsilons[0] * m_e*c**2/e * k0 * \
             np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.sin( wp*t ) \
-        - epsilon_1 * m_e*c**2/e * k0 * 2*r/w0 * \
+        - epsilons[1] * m_e*c**2/e * k0 * 2*r/w0 * \
             np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.sin( wp*t ) \
-        - epsilon_2 * m_e*c**2/e * k0 * 4*r**2/w0**2 * \
+        - epsilons[2] * m_e*c**2/e * k0 * 4*r**2/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.sin( wp*t )
     return( Ez_array )
 
-def ux( z, r, x, y, epsilon, epsilon_1, k0, w0, wp, t) :
+def ux( z, r, x, y, epsilons, k0, w0, wp, t) :
     """
     Return the radial normalized velocity as an array
     of the same length as z, r, x, y
     """
     ux_array = \
-        epsilon * c/wp * 2*x/w0**2 * \
+        epsilons[0] * c/wp * 2*x/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
-        - epsilon_1 * c/wp * 2/w0 * \
+        - epsilons[1] * c/wp * 2/w0 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
-        + epsilon_1 * c/wp * 4*x**2/w0**3 * \
+        + epsilons[1] * c/wp * 4*x**2/w0**3 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
-        - epsilon_2 * c/wp * 8*x/w0**2 * \
+        - epsilons[2] * c/wp * 8*x/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
-        + epsilon_2 * c/wp * 8*x*(x**2-y**2)/w0**4 * \
+        + epsilons[2] * c/wp * 8*x*(x**2-y**2)/w0**4 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t )
     return( ux_array )
 
-def uy( z, r, x, y, epsilon, epsilon_1, k0, w0, wp, t) :
+def uy( z, r, x, y, epsilons, k0, w0, wp, t) :
     """
     Return the radial normalized velocity as an array
     of the same length as z, r, x, y
     """
     uy_array = \
-        epsilon * c/wp * 2*y/w0**2 * \
+        epsilons[0] * c/wp * 2*y/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
-        + epsilon_1 * c/wp * 4*x*y/w0**3 * \
+        + epsilons[1] * c/wp * 4*x*y/w0**3 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
-        + epsilon_2 * c/wp * 8*y/w0**2 * \
+        + epsilons[2] * c/wp * 8*y/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t ) \
-        + epsilon_2 * c/wp * 8*y*(x**2-y**2)/w0**4 * \
+        + epsilons[2] * c/wp * 8*y*(x**2-y**2)/w0**4 * \
             np.exp( -r**2/w0**2 ) * np.sin( k0*z ) * np.cos( wp*t )
     return( uy_array )
 
-def uz( z, r, x, y, epsilon, epsilon_1, k0, w0, wp, t) :
+def uz( z, r, x, y, epsilons, k0, w0, wp, t) :
     """
     Return the longitudinal normalized velocity as an array
     of the same length as z and r
     """
     uz_array = \
-        - epsilon * c/wp * k0 * \
+        - epsilons[0] * c/wp * k0 * \
             np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.cos( wp*t ) \
-        - epsilon_1 * c/wp * k0 * 2*x/w0 * \
+        - epsilons[1] * c/wp * k0 * 2*x/w0 * \
             np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.cos( wp*t ) \
-        - epsilon_2 * c/wp * k0 * 4*(x**2-y**2)/w0**2 * \
+        - epsilons[2] * c/wp * k0 * 4*(x**2-y**2)/w0**2 * \
             np.exp( -r**2/w0**2 ) * np.cos( k0*z ) * np.cos( wp*t )
     return( uz_array )
 
@@ -293,16 +294,16 @@ def uz( z, r, x, y, epsilon, epsilon_1, k0, w0, wp, t) :
 # Functions for initialization of the momenta
 # --------------------------------------------
 
-def impart_momenta( ptcl, epsilon, epsilon_1, k0, w0, wp) :
+def impart_momenta( ptcl, epsilons, k0, w0, wp) :
     """
     Modify the momenta of the input particle object,
     so that they correspond to a plasma wave at t=0
     """
     r = np.sqrt( ptcl.x**2 + ptcl.y**2 )
     # Impart the momenta
-    ptcl.ux = ux(ptcl.z, r, ptcl.x, ptcl.y, epsilon, epsilon_1, k0, w0, wp, 0)
-    ptcl.uy = uy(ptcl.z, r, ptcl.x, ptcl.y, epsilon, epsilon_1, k0, w0, wp, 0)
-    ptcl.uz = uz(ptcl.z, r, ptcl.x, ptcl.y, epsilon, epsilon_1, k0, w0, wp, 0)
+    ptcl.ux = ux(ptcl.z, r, ptcl.x, ptcl.y, epsilons, k0, w0, wp, 0)
+    ptcl.uy = uy(ptcl.z, r, ptcl.x, ptcl.y, epsilons, k0, w0, wp, 0)
+    ptcl.uz = uz(ptcl.z, r, ptcl.x, ptcl.y, epsilons, k0, w0, wp, 0)
     # Get the corresponding inverse gamma
     ptcl.inv_gamma = 1./np.sqrt( 1 + ptcl.ux**2 + ptcl.uy**2 + ptcl.uz**2 )
 
@@ -348,14 +349,14 @@ def compare_fields( sim, show ) :
         zgrid = gathered_grid0.z
         # Check the Ez field
         Ez_simulated = (gathered_grid0.Ez + 2*gathered_grid1.Ez).real
-        check_E_field( Ez_simulated, rgrid, zgrid, epsilon, epsilon_1,
+        check_E_field( Ez_simulated, rgrid, zgrid, epsilons,
                     k0, w0, wp, sim.time, field='Ez', show=show )
         # Check the Er field
         Er_simulated = (gathered_grid0.Er + 2*gathered_grid1.Er).real
-        check_E_field( Er_simulated, rgrid, zgrid, epsilon, epsilon_1,
+        check_E_field( Er_simulated, rgrid, zgrid, epsilons,
                     k0, w0, wp, sim.time, field='Er', show=show )
 
-def check_E_field( E_simulation, rgrid, zgrid, epsilon, epsilon_1,
+def check_E_field( E_simulation, rgrid, zgrid, epsilons,
                     k0, w0, wp, t, field='Ez', show=False ):
     """
     Compare the longitudinal and radial field with the
@@ -367,9 +368,9 @@ def check_E_field( E_simulation, rgrid, zgrid, epsilon, epsilon_1,
     # 2D maps of the field
     r, z = np.meshgrid( rgrid, zgrid )
     if field == 'Ez' :
-        E_analytical = Ez( z, r, epsilon, epsilon_1, k0, w0, wp, t )
+        E_analytical = Ez( z, r, epsilons, k0, w0, wp, t )
     if field == 'Er' :
-        E_analytical = Er( z, r, epsilon, epsilon_1, k0, w0, wp, t )
+        E_analytical = Er( z, r, epsilons, k0, w0, wp, t )
 
     if show is False:
         # Automatically check that the fields agree,

--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -149,7 +149,7 @@ p_rmax = 18.e-6  # Maximal radial position of the plasma (meters)
 n_e = 2.e24      # Density (electrons.meters^-3)
 p_nz = 2         # Number of particles per cell along z
 p_nr = 2         # Number of particles per cell along r
-p_nt = 4         # Number of particles per cell along theta
+p_nt = 8         # Number of particles per cell along theta
 
 # The plasma wave
 epsilon = 0.001    # Dimensionless amplitude of the wave in mode 0

--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -341,18 +341,22 @@ def compare_fields( sim, show ) :
     Gathers the fields and compare them with the analytical theory
     """
     # Get the fields in the half-plane theta=0 (Sum mode 0 and mode 1)
-    gathered_grid0 = sim.comm.gather_grid(sim.fld.interp[0])
-    gathered_grid1 = sim.comm.gather_grid(sim.fld.interp[1])
+    gathered_grids = [ sim.comm.gather_grid(sim.fld.interp[m]) \
+                           for m in range(Nm) ]
 
     if sim.comm.rank == 0:
-        rgrid = gathered_grid0.r
-        zgrid = gathered_grid0.z
+        rgrid = gathered_grids[0].r
+        zgrid = gathered_grids[0].z
         # Check the Ez field
-        Ez_simulated = (gathered_grid0.Ez + 2*gathered_grid1.Ez).real
+        Ez_simulated = gathered_grids[0].Ez.real
+        for m in range(1,Nm):
+            Ez_simulated += 2*gathered_grids[m].Ez.real
         check_E_field( Ez_simulated, rgrid, zgrid, epsilons,
                     k0, w0, wp, sim.time, field='Ez', show=show )
         # Check the Er field
-        Er_simulated = (gathered_grid0.Er + 2*gathered_grid1.Er).real
+        Er_simulated = gathered_grids[0].Er.real
+        for m in range(1,Nm):
+            Er_simulated += 2*gathered_grids[m].Er.real
         check_E_field( Er_simulated, rgrid, zgrid, epsilons,
                     k0, w0, wp, sim.time, field='Er', show=show )
 

--- a/tests/unautomated/test_hankel.py
+++ b/tests/unautomated/test_hankel.py
@@ -262,26 +262,27 @@ if __name__ == '__main__' :
     pmax = 2
     rmax = 4
 
-    restricted_methods = \
-      [ method for method in available_methods if method != 'MDHT(m-1,m)']
-    methods = [ available_methods, restricted_methods ]
+    # Get the available methods for each value of p
+    # For p==0, the method MDHT(m+1,m) corresponds to m=-1; never used in FBPIC
+    methods = [ available_methods for p in range(pmax+1) ]
+    methods[0] = \
+      [ method for method in available_methods if method != 'MDHT(m+1,m)']
 
-    for p in range(pmax+1) :        compare_power_p( p, 1, Nr, rmax, Nz=Nz, methods=methods[p] )
-
-        compare_power_p( p, 1, Nr, rmax, Nz=Nz, methods=available_methods, **kw )
+    for p in range(pmax+1) :
+        compare_power_p( p, 1, Nr, rmax, Nz=Nz, methods=methods[p], **kw )
 
     for p in range(pmax+1) :
         for n in range(2) :
-            compare_laguerre_gauss( p, n, Nr, rmax, methods=available_methods, Nz=Nz)
+            compare_laguerre_gauss( p, n, Nr, rmax, methods=methods[p], Nz=Nz)
 
     for p in range(pmax+1) :
         compare_bessel( p, p, int(Nr*0.3), Nr, rmax,
-                        methods=available_methods, Nz=Nz, **kw )
+                        methods=methods[p], Nz=Nz, **kw )
         compare_bessel( p, p, int(Nr*0.9), Nr, rmax,
-                        methods=available_methods, Nz=Nz, **kw )
+                        methods=methods[p], Nz=Nz, **kw )
 
     for p in range(pmax+1) :
         compare_bessel( p, p+1, int(Nr*0.3), Nr, rmax,
-                        methods=available_methods, Nz=Nz, **kw )
+                        methods=methods[p], Nz=Nz, **kw )
         compare_bessel( p, p+1, int(Nr*0.9), Nr, rmax,
-                        methods=available_methods, Nz=Nz, **kw )
+                        methods=methods[p], Nz=Nz, **kw )

--- a/tests/unautomated/test_hankel.py
+++ b/tests/unautomated/test_hankel.py
@@ -174,7 +174,7 @@ def compare_Hankel_methods( f_analytic, g_analytic, p, Nz, Nr,
 
     plt.show()
 
-def compare_power_p( p, rcut, N, rmax, Nz=1, **kw ) :
+def compare_power_p( p, rcut, N, rmax, Nz=1) :
     """
     Test the Hankel transforms for the test function :
     x -> (x/rcut)^p for x < rcut
@@ -200,9 +200,9 @@ def compare_power_p( p, rcut, N, rmax, Nz=1, **kw ) :
            ans =  rcut*jn( p+1, 2*np.pi*rcut*x) / x
         return( ans )
 
-    compare_Hankel_methods( power_p, power_p_trans, p, Nz, N, rmax, **kw )
+    compare_Hankel_methods( power_p, power_p_trans, p, Nz, N, rmax)
 
-def compare_laguerre_gauss( p, n, N, rmax, Nz=1, **kw ) :
+def compare_laguerre_gauss( p, n, N, rmax, Nz=1) :
     """
     Test the Hankel transforms for the test function :
     x -> x^p L_n^p(x^2) exp(-x^2/2)
@@ -227,9 +227,9 @@ def compare_laguerre_gauss( p, n, N, rmax, Nz=1, **kw ) :
                 np.exp(-(2*np.pi*x)**2/2) )
 
     compare_Hankel_methods( laguerre_n_p, laguerre_n_p_trans, p,
-                            Nz, N, rmax, **kw )
+                            Nz, N, rmax)
 
-def compare_bessel( p, m, n, N, rmax, Nz=1, **kw ) :
+def compare_bessel( p, m, n, N, rmax, Nz=1) :
     """
     Test the Hankel transforms for the test function :
     x -> J_p( k_n^{m} x )
@@ -253,7 +253,7 @@ def compare_bessel( p, m, n, N, rmax, Nz=1, **kw ) :
             return( np.where( abs(x - k/(2*np.pi)) < 0.1,
                           np.pi*rmax**2*jn(p, k*rmax)**2 , 0.) )
 
-    compare_Hankel_methods( bessel_n_p, delta, p, Nz, N, rmax, **kw )
+    compare_Hankel_methods( bessel_n_p, delta, p, Nz, N, rmax)
 
 if __name__ == '__main__' :
 
@@ -269,7 +269,7 @@ if __name__ == '__main__' :
       [ method for method in available_methods if method != 'MDHT(m+1,m)']
 
     for p in range(pmax+1) :
-        compare_power_p( p, 1, Nr, rmax, Nz=Nz, methods=methods[p], **kw )
+        compare_power_p( p, 1, Nr, rmax, Nz=Nz, methods=methods[p])
 
     for p in range(pmax+1) :
         for n in range(2) :
@@ -277,12 +277,12 @@ if __name__ == '__main__' :
 
     for p in range(pmax+1) :
         compare_bessel( p, p, int(Nr*0.3), Nr, rmax,
-                        methods=methods[p], Nz=Nz, **kw )
+                        methods=methods[p], Nz=Nz)
         compare_bessel( p, p, int(Nr*0.9), Nr, rmax,
-                        methods=methods[p], Nz=Nz, **kw )
+                        methods=methods[p], Nz=Nz)
 
     for p in range(pmax+1) :
         compare_bessel( p, p+1, int(Nr*0.3), Nr, rmax,
-                        methods=methods[p], Nz=Nz, **kw )
+                        methods=methods[p], Nz=Nz)
         compare_bessel( p, p+1, int(Nr*0.9), Nr, rmax,
-                        methods=methods[p], Nz=Nz, **kw )
+                        methods=methods[p], Nz=Nz)

--- a/tests/unautomated/test_hankel.py
+++ b/tests/unautomated/test_hankel.py
@@ -259,28 +259,29 @@ if __name__ == '__main__' :
 
     Nr = 200
     Nz = 1000
-    pmax = 1
+    pmax = 2
     rmax = 4
 
     restricted_methods = \
       [ method for method in available_methods if method != 'MDHT(m-1,m)']
     methods = [ available_methods, restricted_methods ]
 
-    for p in range(pmax+1) :
-        compare_power_p( p, 1, Nr, rmax, Nz=Nz, methods=methods[p] )
+    for p in range(pmax+1) :        compare_power_p( p, 1, Nr, rmax, Nz=Nz, methods=methods[p] )
+
+        compare_power_p( p, 1, Nr, rmax, Nz=Nz, methods=available_methods, **kw )
 
     for p in range(pmax+1) :
         for n in range(2) :
-            compare_laguerre_gauss( p, n, Nr, rmax, methods=methods[p], Nz=Nz)
+            compare_laguerre_gauss( p, n, Nr, rmax, methods=available_methods, Nz=Nz)
 
     for p in range(pmax+1) :
         compare_bessel( p, p, int(Nr*0.3), Nr, rmax,
-                        methods=methods[p], Nz=Nz )
+                        methods=available_methods, Nz=Nz, **kw )
         compare_bessel( p, p, int(Nr*0.9), Nr, rmax,
-                        methods=methods[p], Nz=Nz )
+                        methods=available_methods, Nz=Nz, **kw )
 
     for p in range(pmax+1) :
         compare_bessel( p, p+1, int(Nr*0.3), Nr, rmax,
-                        methods=methods[p], Nz=Nz )
+                        methods=available_methods, Nz=Nz, **kw )
         compare_bessel( p, p+1, int(Nr*0.9), Nr, rmax,
-                        methods=methods[p], Nz=Nz )
+                        methods=available_methods, Nz=Nz, **kw )


### PR DESCRIPTION
This pull request modifies the calculation of the matrix that represent the Hankel transform, for the modes m>1. This is done by allowing the fields in real space to be projected onto Bessel modes (as usual) **and** one additional mode which has the same algebraic properties (for curl, grad, div) as the Bessel modes.

The following tests have been updated:
- `test_laser.py`: now tests mode m=2 in addition to m=0 and m=1
- `test_periodic_plasma_wave.py`: adds a plasma wave in the mode m=2. For now, however, this amplitude is set to 0 since the gathering has not been implemented yet.
- `test_hankel.py` now uses higher modes too.