### PR TITLE
Make the hankel transform faster, using the fact that matrices are real

### DIFF
--- a/fbpic/fields/spectral_transform/cuda_methods.py
+++ b/fbpic/fields/spectral_transform/cuda_methods.py
@@ -15,19 +15,18 @@ from numba import cuda
 @cuda.jit
 def cuda_copy_2dC_to_2dR( array_in, array_out ) :
     """
-    Copy array_in to array_out, on the GPU
-
-    This is typically done in cases where one of the two
-    arrays is in C-order and the other one is in Fortran order.
-    This conversion from C order to Fortran order is needed
-    before using cuBlas functions.
+    Store the complex Nz x Nr array `array_in`
+    into the real 2Nz x Nr array `array_out`,
+    by storing the real part in the first Nz elements of `array_out` along z,
+    and the imaginary part in the next Nz elements.
 
     Parameters :
     ------------
-    array_in, array_out : 2darray of complexs
-        Arrays of shape (Nz, Nr)
+    array_in: 2darray of complexs
+        Array of shape (Nz, Nr)
+    array_out: 2darray of reals
+        Array of shape (2*Nz, Nr)
     """
-
     # Set up cuda grid
     iz, ir = cuda.grid(2)
     Nz, Nr = array_in.shape
@@ -40,19 +39,18 @@ def cuda_copy_2dC_to_2dR( array_in, array_out ) :
 @cuda.jit
 def cuda_copy_2dR_to_2dC( array_in, array_out ) :
     """
-    Copy array_in to array_out, on the GPU
-
-    This is typically done in cases where one of the two
-    arrays is in C-order and the other one is in Fortran order.
-    This conversion from C order to Fortran order is needed
-    before using cuBlas functions.
+    Reconstruct the complex Nz x Nr array `array_out`,
+    from the real 2Nz x Nr array `array_in`,
+    by interpreting the first Nz elements of `array_in` along z as
+    the real part, and the next Nz elements as the imaginary part.
 
     Parameters :
     ------------
-    array_in, array_out : 2darray of complexs
-        Arrays of shape (Nz, Nr)
+    array_in: 2darray of reals
+        Array of shape (2*Nz, Nr)
+    array_out: 2darray of complexs
+        Array of shape (Nz, Nr)
     """
-
     # Set up cuda grid
     iz, ir = cuda.grid(2)
     Nz, Nr = array_out.shape
@@ -61,7 +59,7 @@ def cuda_copy_2dR_to_2dC( array_in, array_out ) :
     if (iz < Nz) and (ir < Nr) :
         array_out[iz, ir] = array_in[iz, ir] + 1.j*array_in[iz+Nz, ir]
 
-        
+
 @cuda.jit
 def cuda_copy_2d_to_1d( array_2d, array_1d ) :
     """

--- a/fbpic/fields/spectral_transform/numba_methods.py
+++ b/fbpic/fields/spectral_transform/numba_methods.py
@@ -11,17 +11,17 @@ from fbpic.threading_utils import prange, njit_parallel
 @njit_parallel
 def numba_copy_2dC_to_2dR( array_in, array_out ) :
     """
-    Copy array_in to array_out, on the CPU
-
-    This is typically done in cases where one of the two
-    arrays is in C-order and the other one is in Fortran order.
-    This conversion from C order to Fortran order is needed
-    before using cuBlas functions.
+    Store the complex Nz x Nr array `array_in`
+    into the real 2Nz x Nr array `array_out`,
+    by storing the real part in the first Nz elements of `array_out` along z,
+    and the imaginary part in the next Nz elements.
 
     Parameters :
     ------------
-    array_in, array_out : 2darray of complexs
-        Arrays of shape (Nz, Nr)
+    array_in: 2darray of complexs
+        Array of shape (Nz, Nr)
+    array_out: 2darray of reals
+        Array of shape (2*Nz, Nr)
     """
     Nz, Nr = array_in.shape
 
@@ -34,17 +34,17 @@ def numba_copy_2dC_to_2dR( array_in, array_out ) :
 @njit_parallel
 def numba_copy_2dR_to_2dC( array_in, array_out ) :
     """
-    Copy array_in to array_out, on the CPU
-
-    This is typically done in cases where one of the two
-    arrays is in C-order and the other one is in Fortran order.
-    This conversion from C order to Fortran order is needed
-    before using cuBlas functions.
+    Reconstruct the complex Nz x Nr array `array_out`,
+    from the real 2Nz x Nr array `array_in`,
+    by interpreting the first Nz elements of `array_in` along z as
+    the real part, and the next Nz elements as the imaginary part.
 
     Parameters :
     ------------
-    array_in, array_out : 2darray of complexs
-        Arrays of shape (Nz, Nr)
+    array_in: 2darray of reals
+        Array of shape (2*Nz, Nr)
+    array_out: 2darray of complexs
+        Array of shape (Nz, Nr)
     """
     Nz, Nr = array_out.shape
 

--- a/fbpic/fields/spectral_transform/numba_methods.py
+++ b/fbpic/fields/spectral_transform/numba_methods.py
@@ -8,6 +8,51 @@ fields from interpolation grid to the spectral grid and vice-versa
 """
 from fbpic.threading_utils import prange, njit_parallel
 
+@njit_parallel
+def numba_copy_2dC_to_2dR( array_in, array_out ) :
+    """
+    Copy array_in to array_out, on the CPU
+
+    This is typically done in cases where one of the two
+    arrays is in C-order and the other one is in Fortran order.
+    This conversion from C order to Fortran order is needed
+    before using cuBlas functions.
+
+    Parameters :
+    ------------
+    array_in, array_out : 2darray of complexs
+        Arrays of shape (Nz, Nr)
+    """
+    Nz, Nr = array_in.shape
+
+    # Loop over the 2D grid (parallel in z, if threading is installed)
+    for iz in prange(Nz):
+        for ir in range(Nr):
+            array_out[iz, ir] = array_in[iz, ir].real
+            array_out[iz+Nz, ir] = array_in[iz, ir].imag
+
+@njit_parallel
+def numba_copy_2dR_to_2dC( array_in, array_out ) :
+    """
+    Copy array_in to array_out, on the CPU
+
+    This is typically done in cases where one of the two
+    arrays is in C-order and the other one is in Fortran order.
+    This conversion from C order to Fortran order is needed
+    before using cuBlas functions.
+
+    Parameters :
+    ------------
+    array_in, array_out : 2darray of complexs
+        Arrays of shape (Nz, Nr)
+    """
+    Nz, Nr = array_out.shape
+
+    # Loop over the 2D grid (parallel in z, if threading is installed)
+    for iz in prange(Nz):
+        for ir in range(Nr):
+            array_out[iz, ir] = array_in[iz, ir] + 1.j*array_in[iz+Nz, ir]
+
 # ----------------------------------------------------
 # Functions that combine components in spectral space
 # ----------------------------------------------------


### PR DESCRIPTION
While the fields are represented by complex numbers, the Hankel matrices are real, and therefore we can perform the matrix product on the real part and imaginary part of the fields separately. In pratice, this means that we can do a product of real matrices (`dgemm` kernel) instead of a product of complex matrices (`zgemm` kernel). As shown by the benchmarks below, it turns out that this is significantly faster, both on CPU and GPU. In addition, the conversion/copy from complex to real is negligible or unmodified.

**TODO:**
- [x] Add comments and docstrings

**Benchmarks (with a 2000x400 grid)**

**K80**:

|            	| Kernel name                                                                            	| Total time per iteration (ms) | 
|------------	|----------------------------------------------------------------------------------------	|------------	|
| dev:matrix product	| zgemm_sm35_ldg_nn_32x8x64x8x16                      |         183.6   	| 
| PR:matrix product 	| dgemm_sm_heavy_ldg_nn dgemm_sm35_ldg_nn_128x8x64x16x16 dgemm_sm35_ldg_nn_64x8x128x8x32 	|    123.6        	|
|  dev:copy      | cuda_copy_2d_to_2d           |       19.4     	|
| PR:copy         | cuda_copy_2dC_to_2dR  cuda_copy_2dR_to_2dC | 18.8 |


**GTX 1080 Ti**:

|            	| Kernel name                                                                            	|  Total time per iteration (ms) | 
|------------	|----------------------------------------------------------------------------------------	|------------	|
| dev:matrix product 	| fermiZgemm_v3_kernel                    |         254.1  	| 
| PR:matrix product 	| maxwell_dgemm_128x64_raggedMn_nn 	|    150.6        	|
|  dev:copy      | cuda_copy_2d_to_2d           |       6.7     	|
| PR:copy         | cuda_copy_2dC_to_2dR  cuda_copy_2dR_to_2dC | 6.6 |

**2-core CPU (laptop)**:

|            	| Kernel name                                                                            	|  Total time per iteration (ms) | 
|------------	|----------------------------------------------------------------------------------------	|------------	|
| dev:matrix product 	|  numpy.core.multiarray.dot                 |         1270.5  	| 
| PR:matrix product 	| numpy.core.multiarray.dot            	|    729.3         	|
|  dev:copy      |  None      |      0   	|
| PR:copy         | numba_copy_2dC_to_2dR  numba_copy_2dR_to_2dC | 156.1 |
