### PR TITLE
Write GPU kernels on a per-mode basis

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -725,13 +725,11 @@ class BoundaryCommunicator(object):
                     # Damp the fields on the GPU
                     dim_grid, dim_block = cuda_tpb_bpg_2d(
                         self.n_guard+self.n_damp, interp[0].Nr )
-
-                    cuda_damp_EB_left[dim_grid, dim_block](
-                        interp[0].Er, interp[0].Et, interp[0].Ez,
-                        interp[0].Br, interp[0].Bt, interp[0].Bz,
-                        interp[1].Er, interp[1].Et, interp[1].Ez,
-                        interp[1].Br, interp[1].Bt, interp[1].Bz,
-                        self.d_left_damp, self.n_guard, self.n_damp)
+                    for m in range(len(interp)):
+                        cuda_damp_EB_left[dim_grid, dim_block](
+                            interp[m].Er, interp[m].Et, interp[m].Ez,
+                            interp[m].Br, interp[m].Bt, interp[m].Bz,
+                            self.d_left_damp, self.n_guard, self.n_damp)
                 else:
                     # Damp the fields on the CPU
                     nd = self.n_guard + self.n_damp
@@ -750,13 +748,11 @@ class BoundaryCommunicator(object):
                     # Damp the fields on the GPU
                     dim_grid, dim_block = cuda_tpb_bpg_2d(
                         self.n_guard+self.n_damp, interp[0].Nr )
-
-                    cuda_damp_EB_right[dim_grid, dim_block](
-                        interp[0].Er, interp[0].Et, interp[0].Ez,
-                        interp[0].Br, interp[0].Bt, interp[0].Bz,
-                        interp[1].Er, interp[1].Et, interp[1].Ez,
-                        interp[1].Br, interp[1].Bt, interp[1].Bz,
-                        self.d_right_damp, self.n_guard, self.n_damp)
+                    for m in range(len(interp)):
+                        cuda_damp_EB_right[dim_grid, dim_block](
+                            interp[m].Er, interp[m].Et, interp[m].Ez,
+                            interp[m].Br, interp[m].Bt, interp[m].Bz,
+                            self.d_right_damp, self.n_guard, self.n_damp)
                 else:
                     # Damp the fields on the CPU
                     nd = self.n_guard + self.n_damp

--- a/fbpic/boundaries/cuda_methods.py
+++ b/fbpic/boundaries/cuda_methods.py
@@ -366,17 +366,14 @@ def add_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r,
 # CUDA damping kernels:
 # --------------------
 @cuda.jit
-def cuda_damp_EB_left( Er0, Et0, Ez0, Br0, Bt0, Bz0,
-                  Er1, Et1, Ez1, Br1, Bt1, Bz1,
-                  damp_array, n_guard, n_damp ) :
+def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, n_guard, n_damp ):
     """
     Multiply the E and B fields in the left guard cells
     by damp_array.
 
     Parameters :
     ------------
-    Er0, Et0, Ez0, Br0, Bt0, Bz0,
-    Er1, Et1, Ez1, Br1, Bt1, Bz1 : 2darrays of complexs
+    Er, Et, Ez, Br, Bt, Bz: 2darrays of complexs
         Contain the fields to be damped
         The first axis corresponds to z and the second to r
 
@@ -394,7 +391,7 @@ def cuda_damp_EB_left( Er0, Et0, Ez0, Br0, Bt0, Bz0,
     iz, ir = cuda.grid(2)
 
     # Obtain the size of the array along z and r
-    Nz, Nr = Er0.shape
+    Nz, Nr = Er.shape
 
     # Modify the fields
     if ir < Nr :
@@ -403,31 +400,22 @@ def cuda_damp_EB_left( Er0, Et0, Ez0, Br0, Bt0, Bz0,
             damp_factor_left = damp_array[iz]
 
             # At the left end
-            Er0[iz, ir] *= damp_factor_left
-            Et0[iz, ir] *= damp_factor_left
-            Ez0[iz, ir] *= damp_factor_left
-            Br0[iz, ir] *= damp_factor_left
-            Bt0[iz, ir] *= damp_factor_left
-            Bz0[iz, ir] *= damp_factor_left
-            Er1[iz, ir] *= damp_factor_left
-            Et1[iz, ir] *= damp_factor_left
-            Ez1[iz, ir] *= damp_factor_left
-            Br1[iz, ir] *= damp_factor_left
-            Bt1[iz, ir] *= damp_factor_left
-            Bz1[iz, ir] *= damp_factor_left
+            Er[iz, ir] *= damp_factor_left
+            Et[iz, ir] *= damp_factor_left
+            Ez[iz, ir] *= damp_factor_left
+            Br[iz, ir] *= damp_factor_left
+            Bt[iz, ir] *= damp_factor_left
+            Bz[iz, ir] *= damp_factor_left
 
 @cuda.jit
-def cuda_damp_EB_right( Er0, Et0, Ez0, Br0, Bt0, Bz0,
-                  Er1, Et1, Ez1, Br1, Bt1, Bz1,
-                  damp_array, n_guard, n_damp ) :
+def cuda_damp_EB_right( Er, Et, Ez, Br, Bt, Bz, damp_array, n_guard, n_damp ):
     """
     Multiply the E and B fields in the right guard cells
     by damp_array.
 
     Parameters :
     ------------
-    Er0, Et0, Ez0, Br0, Bt0, Bz0,
-    Er1, Et1, Ez1, Br1, Bt1, Bz1 : 2darrays of complexs
+    Er, Et, Ez, Br, Bt, Bz : 2darrays of complexs
         Contain the fields to be damped
         The first axis corresponds to z and the second to r
 
@@ -445,7 +433,7 @@ def cuda_damp_EB_right( Er0, Et0, Ez0, Br0, Bt0, Bz0,
     iz, ir = cuda.grid(2)
 
     # Obtain the size of the array along z and r
-    Nz, Nr = Er0.shape
+    Nz, Nr = Er.shape
 
     # Modify the fields
     if ir < Nr :
@@ -455,15 +443,9 @@ def cuda_damp_EB_right( Er0, Et0, Ez0, Br0, Bt0, Bz0,
 
             # At the right end
             iz_right = Nz - iz - 1
-            Er0[iz_right, ir] *= damp_factor_right
-            Et0[iz_right, ir] *= damp_factor_right
-            Ez0[iz_right, ir] *= damp_factor_right
-            Br0[iz_right, ir] *= damp_factor_right
-            Bt0[iz_right, ir] *= damp_factor_right
-            Bz0[iz_right, ir] *= damp_factor_right
-            Er1[iz_right, ir] *= damp_factor_right
-            Et1[iz_right, ir] *= damp_factor_right
-            Ez1[iz_right, ir] *= damp_factor_right
-            Br1[iz_right, ir] *= damp_factor_right
-            Bt1[iz_right, ir] *= damp_factor_right
-            Bz1[iz_right, ir] *= damp_factor_right
+            Er[iz_right, ir] *= damp_factor_right
+            Et[iz_right, ir] *= damp_factor_right
+            Ez[iz_right, ir] *= damp_factor_right
+            Br[iz_right, ir] *= damp_factor_right
+            Bt[iz_right, ir] *= damp_factor_right
+            Bz[iz_right, ir] *= damp_factor_right

--- a/fbpic/fields/cuda_methods.py
+++ b/fbpic/fields/cuda_methods.py
@@ -14,17 +14,17 @@ c2 = c**2
 # ------------------
 
 @cuda.jit
-def cuda_erase_scalar( mode0, mode1 ) :
+def cuda_erase_scalar( array ):
     """
-    Set the two input arrays to 0
+    Set input array to 0
 
-    These arrays are typically interpolation grid arrays, and they
-    are set to zero before depositing the currents
+    The array is typically an interpolation grid array, and it
+    is set to zero before depositing the currents
 
-    Parameters :
+    Parameters:
     ------------
-    mode0, mode1 : 2darrays of complexs
-       Arrays that represent the fields on the grid
+    array: 2darrays of complexs
+       Array that represent the fields on the grid
        (The first axis corresponds to z and the second axis to r) d
     """
 
@@ -32,21 +32,20 @@ def cuda_erase_scalar( mode0, mode1 ) :
     iz, ir = cuda.grid(2)
 
     # Set the elements of the array to 0
-    if (iz < mode0.shape[0]) and (ir < mode0.shape[1]) :
-        mode0[iz, ir] = 0
-        mode1[iz, ir] = 0
+    if (iz < array.shape[0]) and (ir < array.shape[1]):
+        array[iz, ir] = 0
 
 @cuda.jit
-def cuda_erase_vector(mode0r, mode1r, mode0t, mode1t, mode0z, mode1z) :
+def cuda_erase_vector( array_r, array_t, array_z ):
     """
-    Set the two input arrays to 0
+    Set the input arrays to 0
 
     These arrays are typically interpolation grid arrays, and they
     are set to zero before depositing the currents
 
-    Parameters :
+    Parameters:
     ------------
-    mode0r, mode1r, mode0t, mode1t, mode0z, mode1z : 2darrays of complexs
+    array_r, array_t, array_z: 2darrays of complexs
        Arrays that represent the fields on the grid
        (The first axis corresponds to z and the second axis to r)
     """
@@ -55,77 +54,63 @@ def cuda_erase_vector(mode0r, mode1r, mode0t, mode1t, mode0z, mode1z) :
     iz, ir = cuda.grid(2)
 
     # Set the elements of the array to 0
-    if (iz < mode0r.shape[0]) and (ir < mode0r.shape[1]) :
-        mode0r[iz, ir] = 0
-        mode0t[iz, ir] = 0
-        mode0z[iz, ir] = 0
-        mode1r[iz, ir] = 0
-        mode1t[iz, ir] = 0
-        mode1z[iz, ir] = 0
+    if (iz < array_r.shape[0]) and (ir < array_r.shape[1]):
+        array_r[iz, ir] = 0
+        array_t[iz, ir] = 0
+        array_z[iz, ir] = 0
 
 # ---------------------------
 # Divide by volume functions
 # ---------------------------
 
 @cuda.jit
-def cuda_divide_scalar_by_volume( mode0, mode1, invvol0, invvol1 ) :
+def cuda_divide_scalar_by_volume( array, invvol ):
     """
-    Multiply the input arrays by the corresponding invvol
+    Multiply the input array by the corresponding invvol
 
-    Parameters :
+    Parameters:
     ------------
-    mode0, mode1 : 2darrays of complexs
-       Arrays that represent the fields on the grid
+    array: 2darray of complexs
+       Array that represent the fields on the grid
        (The first axis corresponds to z and the second axis to r)
 
-    invvol0, invvol1 : 1darrays of floats
-       Arrays that contain the inverse of the volume of the cell
+    invvol: 1darray of floats
+       Array that contain the inverse of the volume of the cell
        The axis corresponds to r
-
-    Nz, Nr : ints
-       The dimensions of the arrays
     """
 
     # Cuda 2D grid
     iz, ir = cuda.grid(2)
 
     # Multiply by inverse volume
-    if (iz < mode0.shape[0]) and (ir < mode0.shape[1]) :
-        mode0[iz, ir] = mode0[iz, ir] * invvol0[ir]
-        mode1[iz, ir] = mode1[iz, ir] * invvol1[ir]
+    if (iz < array.shape[0]) and (ir < array.shape[1]):
+        array[iz, ir] = array[iz, ir] * invvol[ir]
 
 
 @cuda.jit
-def cuda_divide_vector_by_volume( mode0r, mode1r, mode0t, mode1t,
-                    mode0z, mode1z, invvol0, invvol1 ) :
+def cuda_divide_vector_by_volume( array_r, array_t, array_z, invvol ):
     """
     Multiply the input arrays by the corresponding invvol
 
-    Parameters :
+    Parameters:
     ------------
-    mode0r, mode1r, mode0t, mode1t, mode0z, mode1z : 2darrays of complexs
+    array_r, array_t, array_z: 2darrays of complexs
        Arrays that represent the fields on the grid
        (The first axis corresponds to z and the second axis to r)
 
-    invvol0, invvol1 : 1darrays of floats
+    invvol: 1darray of floats
        Arrays that contain the inverse of the volume of the cell
        The axis corresponds to r
-
-    Nz, Nr : ints
-       The dimensions of the arrays
     """
 
     # Cuda 2D grid
     iz, ir = cuda.grid(2)
 
     # Multiply by inverse volume
-    if (iz < mode0r.shape[0]) and (ir < mode0r.shape[1]) :
-        mode0r[iz, ir] = mode0r[iz, ir] * invvol0[ir]
-        mode0t[iz, ir] = mode0t[iz, ir] * invvol0[ir]
-        mode0z[iz, ir] = mode0z[iz, ir] * invvol0[ir]
-        mode1r[iz, ir] = mode1r[iz, ir] * invvol1[ir]
-        mode1t[iz, ir] = mode1t[iz, ir] * invvol1[ir]
-        mode1z[iz, ir] = mode1z[iz, ir] * invvol1[ir]
+    if (iz < array_r.shape[0]) and (ir < array_r.shape[1]):
+        array_r[iz, ir] = array_r[iz, ir] * invvol[ir]
+        array_t[iz, ir] = array_t[iz, ir] * invvol[ir]
+        array_z[iz, ir] = array_z[iz, ir] * invvol[ir]
 
 # -----------------------------------
 # Methods of the SpectralGrid object

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -356,24 +356,21 @@ class Fields(object) :
             dim_grid, dim_block = cuda_tpb_bpg_2d( self.Nz, self.Nr )
 
             # Erase the arrays on the GPU
-            if fieldtype == 'rho' :
-                cuda_erase_scalar[dim_grid, dim_block](
-                    self.interp[0].rho, self.interp[1].rho )
-            elif fieldtype == 'J' :
-                cuda_erase_vector[dim_grid, dim_block](
-                    self.interp[0].Jr, self.interp[1].Jr,
-                    self.interp[0].Jt, self.interp[1].Jt,
-                    self.interp[0].Jz, self.interp[1].Jz )
-            elif fieldtype == 'E' :
-                cuda_erase_vector[dim_grid, dim_block](
-                    self.interp[0].Er, self.interp[1].Er,
-                    self.interp[0].Et, self.interp[1].Et,
-                    self.interp[0].Ez, self.interp[1].Ez )
-            elif fieldtype == 'B' :
-                cuda_erase_vector[dim_grid, dim_block](
-                    self.interp[0].Br, self.interp[1].Br,
-                    self.interp[0].Bt, self.interp[1].Bt,
-                    self.interp[0].Bz, self.interp[1].Bz )
+            if fieldtype == 'rho':
+                for m in range(self.Nm):
+                    cuda_erase_scalar[dim_grid, dim_block](self.interp[m].rho)
+            elif fieldtype == 'J':
+                for m in range(self.Nm):
+                    cuda_erase_vector[dim_grid, dim_block](
+                      self.interp[m].Jr, self.interp[m].Jt, self.interp[m].Jz)
+            elif fieldtype == 'E':
+                for m in range(self.Nm):
+                    cuda_erase_vector[dim_grid, dim_block](
+                      self.interp[m].Er, self.interp[m].Et, self.interp[m].Ez)
+            elif fieldtype == 'B':
+                for m in range(self.Nm):
+                    cuda_erase_vector[dim_grid, dim_block](
+                      self.interp[m].Br, self.interp[m].Bt, self.interp[m].Bz)
             else :
                 raise ValueError('Invalid string for fieldtype: %s'%fieldtype)
         else :
@@ -430,16 +427,15 @@ class Fields(object) :
             # Perform division on the GPU
             dim_grid, dim_block = cuda_tpb_bpg_2d( self.Nz, self.Nr )
 
-            if fieldtype == 'rho' :
-                cuda_divide_scalar_by_volume[dim_grid, dim_block](
-                    self.interp[0].rho, self.interp[1].rho,
-                    self.interp[0].d_invvol, self.interp[1].d_invvol )
-            elif fieldtype == 'J' :
-                cuda_divide_vector_by_volume[dim_grid, dim_block](
-                    self.interp[0].Jr, self.interp[1].Jr,
-                    self.interp[0].Jt, self.interp[1].Jt,
-                    self.interp[0].Jz, self.interp[1].Jz,
-                    self.interp[0].d_invvol, self.interp[1].d_invvol )
+            if fieldtype == 'rho':
+                for m in range(self.Nm):
+                    cuda_divide_scalar_by_volume[dim_grid, dim_block](
+                        self.interp[m].rho, self.interp[m].d_invvol )
+            elif fieldtype == 'J':
+                for m in range(self.Nm):
+                    cuda_divide_vector_by_volume[dim_grid, dim_block](
+                        self.interp[m].Jr, self.interp[m].Jt,
+                        self.interp[m].Jz, self.interp[m].d_invvol )
             else :
                 raise ValueError('Invalid string for fieldtype: %s'%fieldtype)
         else :

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -420,8 +420,8 @@ class Fields(object) :
         Parameter
         ---------
         fieldtype :
-            A string which represents the kind of field to be erased
-            (either 'rho' or 'J')
+            A string which represents the kind of field to be divided by
+            the volume (either 'rho' or 'J')
         """
         if self.use_cuda :
             # Perform division on the GPU

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -592,14 +592,12 @@ class SliceHandler:
             dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( Nr )
 
             # Extract the slices
-            slice_array = extract_slice_cuda[ dim_grid_1d, dim_block_1d ](
-                Nr, iz, Sz, slice_array,
-                interp[0].Er, interp[0].Et, interp[0].Ez,
-                interp[0].Br, interp[0].Bt, interp[0].Bz,
-                interp[0].Jr, interp[0].Jt, interp[0].Jz, interp[0].rho,
-                interp[1].Er, interp[1].Et, interp[1].Ez,
-                interp[1].Br, interp[1].Bt, interp[1].Bz,
-                interp[1].Jr, interp[1].Jt, interp[1].Jz, interp[1].rho )
+            for m in range(fld.Nm):
+                extract_slice_cuda[ dim_grid_1d, dim_block_1d ](
+                    Nr, iz, Sz, slice_array,
+                    interp[m].Er, interp[m].Et, interp[m].Ez,
+                    interp[m].Br, interp[m].Bt, interp[m].Bz,
+                    interp[m].Jr, interp[m].Jt, interp[m].Jz, interp[m].rho, m)
 
     def extract_slice_cpu( self, fld, iz, Sz, slice_array ):
         """
@@ -660,7 +658,7 @@ class SliceHandler:
         output_array[0,:] = getattr(fld.interp[0], quantity)[iz_slice,:].real
         # Get the higher modes
         # There is a factor 2 here so as to comply with the convention in
-        # Lifschitz et al., which is also the convention adopted in Warp Circ
+        # Lifschitz et al., which is also the convention adopted in FBPIC
         for m in range(1,fld.Nm):
             higher_mode_slice = 2*getattr(fld.interp[m], quantity)[iz_slice,:]
             output_array[2*m-1, :] = higher_mode_slice.real
@@ -722,8 +720,7 @@ if cuda_installed:
 
     @cuda.jit
     def extract_slice_cuda( Nr, iz, Sz, slice_arr,
-        Er0, Et0, Ez0, Br0, Bt0, Bz0, Jr0, Jt0, Jz0, rho0,
-        Er1, Et1, Ez1, Br1, Bt1, Bz1, Jr1, Jt1, Jz1, rho1 ):
+        Er, Et, Ez, Br, Bt, Bz, Jr, Jt, Jz, rho, m ):
         """
         Extract a slice of the fields at iz and iz+1, and interpolated
         between those two points using Sz and (1-Sz)
@@ -742,60 +739,56 @@ if cuda_installed:
         slice_arr: cuda.device_array
             Array of floats of shape (10, 2*Nm-1, Nr)
 
-        Er0, Et0, etc...: cuda.device_array
-            Array of complexs of shape (Nz, Nr)
+        Er, Et, etc...: cuda.device_array
+            Array of complexs of shape (Nz, Nr), for the azimuthal mode m
+
+        m: int
+            Index of the azimuthal mode involved
         """
         # One thread per radial position
         ir = cuda.grid(1)
         # Intermediate variables
         izp = iz+1
-        Szp = 1 - Sz
+        Szp = 1. - Sz
 
         if ir < Nr:
             # Interpolate the field in the longitudinal direction
             # and store it into pre-packed arrays
 
-            # Mode 0
-            slice_arr[0,0,ir] = Sz*Er0[iz,ir].real + Szp*Er0[izp,ir].real
-            slice_arr[1,0,ir] = Sz*Et0[iz,ir].real + Szp*Et0[izp,ir].real
-            slice_arr[2,0,ir] = Sz*Ez0[iz,ir].real + Szp*Ez0[izp,ir].real
-            slice_arr[3,0,ir] = Sz*Br0[iz,ir].real + Szp*Br0[izp,ir].real
-            slice_arr[4,0,ir] = Sz*Bt0[iz,ir].real + Szp*Bt0[izp,ir].real
-            slice_arr[5,0,ir] = Sz*Bz0[iz,ir].real + Szp*Bz0[izp,ir].real
-            slice_arr[6,0,ir] = Sz*Jr0[iz,ir].real + Szp*Jr0[izp,ir].real
-            slice_arr[7,0,ir] = Sz*Jt0[iz,ir].real + Szp*Jt0[izp,ir].real
-            slice_arr[8,0,ir] = Sz*Jz0[iz,ir].real + Szp*Jz0[izp,ir].real
-            slice_arr[9,0,ir] = Sz*rho0[iz,ir].real + \
-                                    Szp*rho0[izp,ir].real
-            # Get the higher modes
+            # For the higher modes:
             # There is a factor 2 here so as to comply with the convention in
-            # Lifschitz et al., which is also the convention of Warp
-            # For better performance, this factor is included in the shape
-            # factors ('t' stands for 'twice' below)
-            tSz = 2*Sz
-            tSzp = 2*Szp
+            # Lifschitz et al., which is also the convention of FBPIC
+            # For performance, this is included in the shape factor.
+            if m > 0:
+                Sz = 2*Sz
+                Szp = 2*Szp
+                # Index at which the mode should be added
+                # in the array `slice_arr`
+                im = 2*m-1
+            else:
+                im = 0
 
-            # Mode 1 (real part)
-            slice_arr[0,1,ir] = tSz*Er1[iz,ir].real + tSzp*Er1[izp,ir].real
-            slice_arr[1,1,ir] = tSz*Et1[iz,ir].real + tSzp*Et1[izp,ir].real
-            slice_arr[2,1,ir] = tSz*Ez1[iz,ir].real + tSzp*Ez1[izp,ir].real
-            slice_arr[3,1,ir] = tSz*Br1[iz,ir].real + tSzp*Br1[izp,ir].real
-            slice_arr[4,1,ir] = tSz*Bt1[iz,ir].real + tSzp*Bt1[izp,ir].real
-            slice_arr[5,1,ir] = tSz*Bz1[iz,ir].real + tSzp*Bz1[izp,ir].real
-            slice_arr[6,1,ir] = tSz*Jr1[iz,ir].real + tSzp*Jr1[izp,ir].real
-            slice_arr[7,1,ir] = tSz*Jt1[iz,ir].real + tSzp*Jt1[izp,ir].real
-            slice_arr[8,1,ir] = tSz*Jz1[iz,ir].real + tSzp*Jz1[izp,ir].real
-            slice_arr[9,1,ir] = tSz*rho1[iz,ir].real + \
-                                    tSzp*rho1[izp,ir].real
-            # Mode 1 (imaginary part)
-            slice_arr[0,2,ir] = tSz*Er1[iz,ir].imag + tSzp*Er1[izp,ir].imag
-            slice_arr[1,2,ir] = tSz*Et1[iz,ir].imag + tSzp*Et1[izp,ir].imag
-            slice_arr[2,2,ir] = tSz*Ez1[iz,ir].imag + tSzp*Ez1[izp,ir].imag
-            slice_arr[3,2,ir] = tSz*Br1[iz,ir].imag + tSzp*Br1[izp,ir].imag
-            slice_arr[4,2,ir] = tSz*Bt1[iz,ir].imag + tSzp*Bt1[izp,ir].imag
-            slice_arr[5,2,ir] = tSz*Bz1[iz,ir].imag + tSzp*Bz1[izp,ir].imag
-            slice_arr[6,2,ir] = tSz*Jr1[iz,ir].imag + tSzp*Jr1[izp,ir].imag
-            slice_arr[7,2,ir] = tSz*Jt1[iz,ir].imag + tSzp*Jt1[izp,ir].imag
-            slice_arr[8,2,ir] = tSz*Jz1[iz,ir].imag + tSzp*Jz1[izp,ir].imag
-            slice_arr[9,2,ir] = tSz*rho1[iz,ir].imag + \
-                                    tSzp*rho1[izp,ir].imag
+            # Real part
+            slice_arr[0,im,ir] = Sz*Er[iz,ir].real + Szp*Er[izp,ir].real
+            slice_arr[1,im,ir] = Sz*Et[iz,ir].real + Szp*Et[izp,ir].real
+            slice_arr[2,im,ir] = Sz*Ez[iz,ir].real + Szp*Ez[izp,ir].real
+            slice_arr[3,im,ir] = Sz*Br[iz,ir].real + Szp*Br[izp,ir].real
+            slice_arr[4,im,ir] = Sz*Bt[iz,ir].real + Szp*Bt[izp,ir].real
+            slice_arr[5,im,ir] = Sz*Bz[iz,ir].real + Szp*Bz[izp,ir].real
+            slice_arr[6,im,ir] = Sz*Jr[iz,ir].real + Szp*Jr[izp,ir].real
+            slice_arr[7,im,ir] = Sz*Jt[iz,ir].real + Szp*Jt[izp,ir].real
+            slice_arr[8,im,ir] = Sz*Jz[iz,ir].real + Szp*Jz[izp,ir].real
+            slice_arr[9,im,ir] = Sz*rho[iz,ir].real + Szp*rho[izp,ir].real
+
+            if m > 0:
+                # Imaginary part
+                slice_arr[0,im+1,ir] = Sz*Er[iz,ir].imag + Szp*Er[izp,ir].imag
+                slice_arr[1,im+1,ir] = Sz*Et[iz,ir].imag + Szp*Et[izp,ir].imag
+                slice_arr[2,im+1,ir] = Sz*Ez[iz,ir].imag + Szp*Ez[izp,ir].imag
+                slice_arr[3,im+1,ir] = Sz*Br[iz,ir].imag + Szp*Br[izp,ir].imag
+                slice_arr[4,im+1,ir] = Sz*Bt[iz,ir].imag + Szp*Bt[izp,ir].imag
+                slice_arr[5,im+1,ir] = Sz*Bz[iz,ir].imag + Szp*Bz[izp,ir].imag
+                slice_arr[6,im+1,ir] = Sz*Jr[iz,ir].imag + Szp*Jr[izp,ir].imag
+                slice_arr[7,im+1,ir] = Sz*Jt[iz,ir].imag + Szp*Jt[izp,ir].imag
+                slice_arr[8,im+1,ir] = Sz*Jz[iz,ir].imag + Szp*Jz[izp,ir].imag
+                slice_arr[9,im+1,ir] = Sz*rho[iz,ir].imag + Szp*rho[izp,ir].imag

--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -136,7 +136,7 @@ Nz = 200         # Number of gridpoints along z
 zmax = 40.e-6    # Length of the box along z (meters)
 Nr = 64          # Number of gridpoints along r
 rmax = 20.e-6    # Length of the box along r (meters)
-Nm = 3           # Number of modes used
+Nm = 2           # Number of modes used
 n_order = 16     # Order of the finite stencil
 # The simulation timestep
 dt = zmax/Nz/c   # Timestep (seconds)


### PR DESCRIPTION
Many of the GPU kernels were hard-coded for exactly 2 azimuthal modes. 

This pull request generalizes them for an arbitrary number of modes.

This PR passes the automated tests on GPU. I also benchmarked the code on the standard 2000x400 grid, and did not see any difference in performance compared to the current `dev` branch.