### PR TITLE
Better user-support regarding MKL

### DIFF
--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -56,7 +56,8 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install -c conda-forge numba=0.34 scipy h5py mpi4py
+       conda install numba=0.34 scipy h5py mkl
+       conda install -c conda-forge mpi4py
        conda install -c numba pyculib
 
 

--- a/docs/source/install/install_titan.rst
+++ b/docs/source/install/install_titan.rst
@@ -57,8 +57,7 @@ Installation of FBPIC and its dependencies
 
   ::
 
-    conda install numba=0.34
-    conda install -c conda-forge
+    conda install numba=0.34 scipy h5py mkl
     conda install -c numba pyculib
 
 -  Clone and install the ``fbpic`` repository using git

--- a/fbpic/fields/spectral_transform/fourier.py
+++ b/fbpic/fields/spectral_transform/fourier.py
@@ -18,7 +18,7 @@ if cuda_installed:
 try:
     from .mkl_fft import MKLFFT
     mkl_installed = True
-except ImportError:
+except OSError:
     import pyfftw
     mkl_installed = False
 


### PR DESCRIPTION
There are few problems regarding user-support around MKL:
- The documentation does not systematically ask the user to install MKL.
- When MKL is not installed, the code crashes because it tries to catch the wrong exception.

This PR corrects those two issues.