### PR TITLE
Refactored printing of simulation setup and the progress bar

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -7,7 +7,7 @@ It defines the structure necessary to implement the boundary exchanges.
 """
 import numpy as np
 from scipy.constants import c
-from fbpic.mpi_utils import comm, MPI, mpi_type_dict, mpi_installed
+from fbpic.mpi_utils import comm, mpi_type_dict, mpi_installed
 from fbpic.fields.fields import InterpolationGrid
 from fbpic.fields.utility_methods import get_stencil_reach
 from fbpic.particles.particles import Particles
@@ -116,14 +116,11 @@ class BoundaryCommunicator(object):
 
         # MPI Setup
         self.use_all_mpi_ranks = use_all_mpi_ranks
-        self.mpi_installed = mpi_installed
-        if self.use_all_mpi_ranks and self.mpi_installed:
-            self.mpi = MPI
+        if self.use_all_mpi_ranks and mpi_installed:
             self.mpi_comm = comm
             self.rank = self.mpi_comm.rank
             self.size = self.mpi_comm.size
         else:
-            self.mpi = MPI
             self.mpi_comm = None
             self.rank = 0
             self.size = 1

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -7,7 +7,7 @@ It defines the structure necessary to implement the boundary exchanges.
 """
 import numpy as np
 from scipy.constants import c
-from fbpic.mpi_utils import comm, mpi_type_dict, mpi_installed
+from fbpic.mpi_utils import comm, MPI, mpi_type_dict, mpi_installed
 from fbpic.fields.fields import InterpolationGrid
 from fbpic.fields.utility_methods import get_stencil_reach
 from fbpic.particles.particles import Particles
@@ -115,11 +115,15 @@ class BoundaryCommunicator(object):
         self.dz = (zmax - zmin)/self.Nz
 
         # MPI Setup
-        if use_all_mpi_ranks and mpi_installed:
+        self.use_all_mpi_ranks = use_all_mpi_ranks
+        self.mpi_installed = mpi_installed
+        if self.use_all_mpi_ranks and self.mpi_installed:
+            self.mpi = MPI
             self.mpi_comm = comm
             self.rank = self.mpi_comm.rank
             self.size = self.mpi_comm.size
         else:
+            self.mpi = MPI
             self.mpi_comm = None
             self.rank = 0
             self.size = 1

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -127,13 +127,14 @@ class BoundaryCommunicator(object):
         self.left_proc = self.rank-1
         self.right_proc = self.rank+1
         # Correct these initial values by taking into account boundaries
-        if boundaries == 'periodic':
+        self.boundaries = boundaries
+        if self.boundaries == 'periodic':
             # Periodic boundary conditions for the domains
             if self.rank == 0:
                 self.left_proc = (self.size-1)
             if self.rank == self.size-1:
                 self.right_proc = 0
-        elif boundaries == 'open':
+        elif self.boundaries == 'open':
             # None means that the boundary is open
             if self.rank == 0:
                 self.left_proc = None

--- a/fbpic/cuda_utils.py
+++ b/fbpic/cuda_utils.py
@@ -109,60 +109,8 @@ def receive_data_from_gpu(simulation):
     simulation.fld.receive_fields_from_gpu()
 
 # -----------------------------------------------------
-# CUDA information
+# CUDA mpi management
 # -----------------------------------------------------
-
-def print_gpu_meminfo(gpu):
-    """
-    Prints memory information about the GPU.
-
-    Parameters :
-    ------------
-    gpu : object
-        A numba cuda gpu context object.
-    """
-    with gpu:
-        meminfo = cuda.current_context().get_memory_info()
-        print("GPU: %s, free: %s Mbytes, total: %s Mbytes \
-              " % (gpu, meminfo[0]*1e-6, meminfo[1]*1e-6))
-
-def print_available_gpus():
-    """
-    Lists all available CUDA GPUs.
-    """
-    cuda.detect()
-
-def print_gpu_meminfo_all():
-    """
-    Prints memory information about all available CUDA GPUs.
-    """
-    gpus = cuda.gpus.lst
-    for gpu in gpus:
-        print_gpu_meminfo(gpu)
-
-def print_current_gpu( mpi ):
-    """
-    Prints information about the currently selected GPU.
-
-    Parameter:
-    ----------
-    mpi: an mpi4py.MPI object
-    """
-    gpu = cuda.gpus.current
-    # Convert bytestring to actual string
-    try:
-        gpu_name = gpu.name.decode()
-    except AttributeError:
-        gpu_name = gpu.name
-    # Print the GPU that is being used
-    if mpi.COMM_WORLD.size > 1:
-        rank = mpi.COMM_WORLD.rank
-        node = mpi.Get_processor_name()
-        message = "MPI rank %d selected a %s GPU with id %s on node %s" %(
-            rank, gpu_name, gpu.id, node)
-    else:
-        message = "FBPIC selected a %s GPU with id %s" %( gpu_name, gpu.id )
-    print(message)
 
 def mpi_select_gpus(mpi):
     """
@@ -178,5 +126,3 @@ def mpi_select_gpus(mpi):
         if rank%n_gpus == i_gpu:
             cuda.select_device(i_gpu)
         mpi.COMM_WORLD.barrier()
-
-    print_current_gpu( mpi )

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -10,7 +10,6 @@ This file steers and controls the simulation.
 # (This needs to be done before the other imports,
 # as it sets the cuda context)
 from fbpic.mpi_utils import MPI
-import numba
 # Check if threading is available
 from .threading_utils import threading_enabled
 # Check if CUDA is available, then import CUDA functions

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -21,13 +21,14 @@ if cuda_installed:
     mpi_select_gpus( MPI )
 
 # Import the rest of the requirements
-import sys, time
+import time
 from scipy.constants import m_e, m_p, e, c
+from .print_utils import print_simulation_setup, \
+            print_runtime_summary, progression_bar
 from .particles import Particles
 from .lpa_utils.boosted_frame import BoostConverter
 from .fields import Fields
 from .boundaries import BoundaryCommunicator, MovingWindow
-from fbpic import __version__
 
 class Simulation(object):
     """
@@ -48,7 +49,8 @@ class Simulation(object):
                  v_comoving=None, use_galilean=True, initialize_ions=False,
                  use_cuda=False, n_guard=None, n_damp=30, exchange_period=None,
                  boundaries='periodic', gamma_boost=None,
-                 use_all_mpi_ranks=True, particle_shape='linear' ):
+                 use_all_mpi_ranks=True, particle_shape='linear',
+                 simulation_info=1 ):
         """
         Initializes a simulation, by creating the following structures:
 
@@ -188,10 +190,17 @@ class Simulation(object):
             Set the particle shape for the charge/current deposition.
             Possible values are 'cubic', 'linear'. ('cubic' corresponds to
             third order shapes and 'linear' to first order shapes).
+
+        simulation_info: int, optional
+            Print information about the simulation setup.
+            0 - Print no information
+            1 (Default) - Print basic information
+            2 - Print detailed information
         """
         # Check whether to use CUDA
         self.use_cuda = use_cuda
         if (use_cuda==True) and (cuda_installed==False):
+            # Print warning if use_cuda = True but CUDA is not available
             print('*** Cuda not available for the simulation.')
             print('*** Performing the simulation on CPU.')
             self.use_cuda = False
@@ -217,7 +226,6 @@ class Simulation(object):
         self.comm = BoundaryCommunicator( Nz, zmin, zmax, Nr, rmax, Nm, dt,
             boundaries, n_order, n_guard, n_damp, exchange_period,
             use_all_mpi_ranks )
-        print_simulation_setup( self.comm, self.use_cuda, self.use_threading )
         # Modify domain region
         zmin, zmax, p_zmin, p_zmax, Nz = \
               self.comm.divide_into_domain(zmin, zmax, p_zmin, p_zmax)
@@ -271,9 +279,12 @@ class Simulation(object):
         # Initialize an empty list of laser antennas
         self.laser_antennas = []
 
+        # Print simulation setup
+        print_simulation_setup( self, level=simulation_info )
+
     def step(self, N=1, correct_currents=True,
-            correct_divE=False, use_true_rho=False,
-            move_positions=True, move_momenta=True, show_progress=True):
+             correct_divE=False, use_true_rho=False,
+             move_positions=True, move_momenta=True, show_progress=True):
         """
         Perform N PIC cycles.
 
@@ -312,13 +323,11 @@ class Simulation(object):
         if self.comm.size > 1 and correct_divE:
             raise ValueError('correct_divE cannot be used in multi-proc mode.')
 
-        # Let the user know that the first step is much longer
-        if show_progress and (self.comm.rank==0):
-            print('Performing %d PIC iterations:' %N )
-            print(' - Just-In-Time compilation (up to one minute) ...')
-
-        # Measure the time taken by the PIC cycle
-        measured_start = time.time()
+        # Initialize variables to measure the time taken by the simulation
+        if show_progress and self.comm.rank==0:
+            start_time = time.time()
+            prev_time = start_time
+            avg_time_per_step = 0.
 
         # Send simulation data to GPU (if CUDA is used)
         if self.use_cuda:
@@ -329,6 +338,11 @@ class Simulation(object):
 
         # Loop over timesteps
         for i_step in range(N):
+
+            # Show a progression bar and calculate ETA
+            if show_progress and self.comm.rank==0:
+                avg_time_per_step, prev_time = progression_bar(
+                    i_step, N, avg_time_per_step, prev_time )
 
             # Diagnostics
             # -----------
@@ -453,9 +467,6 @@ class Simulation(object):
             # Increment the global time and iteration
             self.time += self.dt
             self.iteration += 1
-            # Show a progression bar
-            if show_progress and self.comm.rank==0:
-                progression_bar( i_step, N, measured_start )
 
             # Write the checkpoints if needed
             for checkpoint in self.checkpoints:
@@ -479,10 +490,7 @@ class Simulation(object):
 
         # Print the measured time taken by the PIC cycle
         if show_progress and (self.comm.rank==0):
-            measured_duration = time.time() - measured_start
-            m, s = divmod(measured_duration, 60)
-            h, m = divmod(m, 60)
-            print('\nTime taken (with compilation): %d:%02d:%02d\n' %(h, m, s))
+            print_runtime_summary(N, time.time() - start_time)
 
     def deposit( self, fieldtype, exchange=False ):
         """
@@ -602,56 +610,6 @@ class Simulation(object):
         self.comm.moving_win = MovingWindow( self.fld.interp, self.comm,
             self.dt, self.ptcl, v, self.p_nz, self.time,
             ux_m, uy_m, uz_m, ux_th, uy_th, uz_th, gamma_boost )
-
-def progression_bar( i, Ntot, measured_start, Nbars=50, char='-'):
-    """
-    Shows a progression bar with Nbars and the remaining
-    simulation time.
-    """
-    # First step completed: Show that the PIC loop runs
-    # (This comes after the message on Just-In-Time compilation)
-    if i==0:
-        print(' - Running the PIC loop')
-    # Print the progression bar
-    nbars = int( (i+1)*1./Ntot*Nbars )
-    sys.stdout.write('\r[' + nbars*char )
-    sys.stdout.write((Nbars-nbars)*' ' + ']')
-    sys.stdout.write(' %d/%d' %(i,Ntot))
-    # Estimated time in seconds until it will finish (linear interpolation)
-    eta = (((float(Ntot)/(i+1.))-1.)*(time.time()-measured_start))
-    # Conversion to H:M:S
-    m, s = divmod(eta, 60)
-    h, m = divmod(m, 60)
-    sys.stdout.write(', %d:%02d:%02d left' % (h, m, s))
-    sys.stdout.flush()
-
-def print_simulation_setup( comm, use_cuda, use_threading ):
-    """
-    Print message about the number of proc and
-    whether it is using GPU or CPU.
-
-    Parameters
-    ----------
-    comm: an fbpic BoundaryCommunicator object
-        Contains the information on the MPI decomposition
-
-    use_cuda: bool
-        Whether the simulation is set up to use CUDA
-
-    use_threading: bool
-        Whether the simulation is set up to use threads on CPU
-    """
-    if comm.rank == 0:
-        if use_cuda:
-            message = "\nRunning fbpic-%s on GPU " %__version__
-        else:
-            message = "\nRunning fbpic-%s on CPU " %__version__
-        message += "with %d proc" %comm.size
-        if use_threading and not use_cuda:
-            message += " (%d threads per proc)" %numba.config.NUMBA_NUM_THREADS
-        message += ".\n"
-
-        print( message )
 
 def adapt_to_grid( x, p_xmin, p_xmax, p_nx, ncells_empty=0 ):
     """

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -213,9 +213,10 @@ class Simulation(object):
             self.use_galilean = False
 
         # When running the simulation in a boosted frame, convert the arguments
+        self.gamma_boost = gamma_boost
         uz_m = 0.   # Mean normalized momentum of the particles
-        if gamma_boost is not None:
-            boost = BoostConverter( gamma_boost )
+        if self.gamma_boost is not None:
+            boost = BoostConverter( self.gamma_boost )
             zmin, zmax, dt = boost.copropag_length([ zmin, zmax, dt ])
             p_zmin, p_zmax = boost.static_length([ p_zmin, p_zmax ])
             n_e, = boost.static_density([ n_e ])
@@ -244,19 +245,22 @@ class Simulation(object):
                                 p_rmin, p_rmax, p_nr )
 
         # Initialize the electrons and the ions
-        grid_shape = self.fld.interp[0].Ez.shape
+        self.grid_shape = self.fld.interp[0].Ez.shape
+        self.particle_shape = particle_shape
         self.ptcl = [
             Particles(q=-e, m=m_e, n=n_e, Npz=Npz, zmin=p_zmin,
                       zmax=p_zmax, Npr=Npr, rmin=p_rmin, rmax=p_rmax,
                       Nptheta=p_nt, dt=dt, dens_func=dens_func, uz_m=uz_m,
-                      grid_shape=grid_shape, particle_shape=particle_shape,
+                      grid_shape=self.grid_shape,
+                      particle_shape=self.particle_shape,
                       use_cuda=self.use_cuda ) ]
         if initialize_ions :
             self.ptcl.append(
                 Particles(q=e, m=m_p, n=n_e, Npz=Npz, zmin=p_zmin,
                           zmax=p_zmax, Npr=Npr, rmin=p_rmin, rmax=p_rmax,
                           Nptheta=p_nt, dt=dt, dens_func=dens_func, uz_m=uz_m,
-                          grid_shape=grid_shape, particle_shape=particle_shape,
+                          grid_shape=self.grid_shape,
+                          particle_shape=self.particle_shape,
                           use_cuda=self.use_cuda ) )
 
         # Register the number of particles per cell along z, and dt

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -135,10 +135,10 @@ def progression_bar( i, Ntot, avg_time_per_step, prev_time,
         sys.stdout.write('\r' + nbars*char )
         sys.stdout.write((Nbars-nbars)*' ')
         sys.stdout.write(' %d/%d' %(i+1, Ntot))
-        sys.stdout.write(', %d ms/step' %(time_per_step*1.e3))
+        sys.stdout.write(', %4d ms/step' %(time_per_step*1.e3))
         if i < n_avg:
             # Time estimation is only printed after n_avg timesteps
-            sys.stdout.write(', calculating ETA...')
+            sys.stdout.write(', calc. ETA...')
             sys.stdout.flush()
         else:
             # Estimated time in seconds until it will finish

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -101,14 +101,16 @@ def print_simulation_setup( sim, level=1 ):
                         message += '\nGalilean frame: No'
                 else:
                     message += '\nBoosted frame: False'
-                message += '\n'
+        message += '\n'    
         print( message )
     if level == 2:
         # Sync MPI processes before MPI GPU selection
         sim.comm.mpi_comm.barrier()
+        time.sleep(0.1)
         if sim.use_cuda:
             print_current_gpu( MPI )
-            print('')
+            if sim.comm.rank == 0:
+                print('')
 
 def progression_bar( i, Ntot, avg_time_per_step, prev_time,
                      n_avg=20, Nbars=35, char=u'\u007C'):

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -101,7 +101,7 @@ def print_simulation_setup( sim, level=1 ):
                         message += '\nGalilean frame: No'
                 else:
                     message += '\nBoosted frame: False'
-        message += '\n'    
+        message += '\n'
         print( message )
     if level == 2:
         # Sync MPI processes before MPI GPU selection
@@ -109,6 +109,8 @@ def print_simulation_setup( sim, level=1 ):
         time.sleep(0.1)
         if sim.use_cuda:
             print_current_gpu( MPI )
+            sim.comm.mpi_comm.barrier()
+            time.sleep(0.1)
             if sim.comm.rank == 0:
                 print('')
 

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -37,7 +37,7 @@ def print_simulation_setup( sim, level=1 ):
     if level > 0:
         if sim.comm.rank == 0:
         # Print version of FBPIC
-            message = '\nFBPIC (fbpic-%s)\n'%__version__
+            message += '\nFBPIC (fbpic-%s)\n'%__version__
             # Basic information
             if level == 1:
                 # Print information about computational setup
@@ -74,6 +74,8 @@ def print_simulation_setup( sim, level=1 ):
             # Sync MPI processes before printing
             sim.comm.mpi_comm.barrier()
             if sim.use_cuda:
+                if not sim.comm.rank == 0:
+                    message = ''
                 message += print_current_gpu( sim.comm.mpi_comm )
             sim.comm.mpi_comm.barrier()
             if sim.comm.rank == 0:

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -178,7 +178,6 @@ def print_simulation_setup( sim, verbose_level=1 ):
                 message += '\nMPI available: No'
             if sim.cuda_installed:
                 message += '\nCUDA available: Yes'
-                message += '\nAvailable GPUs: \n%s' %cuda.detect()
             else:
                 message += '\nCUDA available: No'
             if sim.use_cuda:
@@ -197,9 +196,9 @@ def print_simulation_setup( sim, verbose_level=1 ):
 
             message += '\n'
             if sim.fld.n_order == -1:
-                message += '\nPSAOTD stencil order: infinite'
+                message += '\nPSATD stencil order: infinite'
             else:
-                message += '\nPSAOTD stencil order: %d' %sim.fld.n_order
+                message += '\nPSATD stencil order: %d' %sim.fld.n_order
             message += '\nParticle shape: %s' %sim.particle_shape
             message += '\nLongitudinal boundaries: %s' %sim.comm.boundaries
             message += '\nTransverse boundaries: reflective'

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -6,21 +6,134 @@ Fourier-Bessel Particle-In-Cell (FB-PIC) main file
 It defines a set of generic functions for printing simulation information.
 """
 import sys, time
-import numba
 from numba import cuda
 from fbpic import __version__
-# Check availability of various computational setups
-from fbpic.fields.spectral_transform.fourier import mkl_installed
-from fbpic.cuda_utils import cuda_installed
-from fbpic.mpi_utils import MPI, mpi_installed
-from fbpic.threading_utils import threading_enabled
 # Check if terminal is correctly set to UTF-8 and set progress character
 if sys.stdout.encoding == 'UTF-8':
     progress_char = u'\u2588'
 else:
     progress_char = '-'
 
-def print_simulation_setup( sim, level=1 ):
+class ProgressBar(object):
+    """
+    ProgressBar class that keeps track of the time spent by the algorithm.
+    It handles the calculation and printing of the progress bar and a
+    summary of the total runtime.
+    """
+
+    def __init__(self, N, n_avg=20, Nbars=35, char=progress_char):
+        """
+        Initializes a timer / progression bar.
+        Timing is done with respect to the absolute time at initialization.
+
+        Parameters
+        ----------
+        N: int
+            The total number of iterations performed by the step loop
+
+        n_avg: int, optional
+            The amount of recent timesteps used to calculate the average
+            time taken by a step
+
+        Nbar: int, optional
+            The number of bars printed for the progression bar
+
+        char: str, optional
+            The character used to show the progression.
+        """
+        self.N = N
+        self.n_avg = n_avg
+        self.Nbars = Nbars
+        self.bar_char = char
+
+        # Initialize variables to measure the time taken by the simulation
+        self.i_step = 0
+        self.start_time = time.time()
+        self.prev_time = self.start_time
+        self.total_duration = 0.
+        self.time_per_step = 0.
+        self.avg_time_per_step = 0.
+        self.eta = None
+
+    def time( self, i_step ):
+        """
+        Calculates the time taken by the last iterations, the average time
+        taken by the most recent iterations and the estimated remaining
+        simulation time.
+
+        Parameters
+        ----------
+        i_step : int
+            The current iteration of the loop
+        """
+        # Register current step
+        self.i_step = i_step
+        # Calculate time taken by last step
+        curr_time = time.time()
+        self.total_duration = curr_time - self.start_time
+        self.time_per_step = curr_time - self.prev_time
+        # Estimate average time per step
+        self.avg_time_per_step += \
+            (self.time_per_step - self.avg_time_per_step)/self.n_avg
+        if self.i_step <= 2:
+            # Ignores first step in time estimation (compilation time)
+            self.avg_time_per_step = self.time_per_step
+        # Estimated time in seconds until it will finish
+        if self.i_step < self.n_avg:
+            self.eta = None
+        else:
+            self.eta = self.avg_time_per_step*(self.N-self.i_step)
+        # Advance the previous time to the current time
+        self.prev_time = curr_time
+
+    def print_progress( self ):
+        """
+        Prints a progression bar with the estimated
+        remaining simulation time and the time taken by the last step.
+        """
+        i = self.i_step
+        # Print progress bar
+        if i == 0:
+            # Let the user know that the first step is much longer
+            sys.stdout.write('\r' + \
+                'Just-In-Time compilation (up to one minute) ...')
+            sys.stdout.flush()
+        else:
+            # Print the progression bar
+            nbars = int( (i+1)*1./self.N*self.Nbars )
+            sys.stdout.write('\r' + nbars*self.bar_char )
+            sys.stdout.write((self.Nbars-nbars)*' ')
+            sys.stdout.write(' %d/%d' %(i+1,self.N))
+            if self.eta is None:
+                # Time estimation is only printed after n_avg timesteps
+                sys.stdout.write(', calc. ETA...')
+            else:
+                # Conversion to H:M:S
+                m, s = divmod(self.eta, 60)
+                h, m = divmod(m, 60)
+                sys.stdout.write(', %d:%02d:%02d left' % (h, m, s))
+            # Time taken by the last step
+            sys.stdout.write(', %d ms/step' %(self.time_per_step*1.e3))
+            sys.stdout.flush()
+        # Clear line
+        sys.stdout.write('\033[K')
+
+    def print_summary( self ):
+        """
+        Print a summary about the total runtime of the simulation.
+        """
+        avg_tps = (self.total_duration / self.N)*1.e3
+        m, s = divmod(self.total_duration, 60)
+        h, m = divmod(m, 60)
+        print('\nTotal time taken (with compilation): %d:%02d:%02d' %(h, m, s))
+        print('Average time per iteration ' \
+              '(with compilation): %d ms\n' %(avg_tps))
+
+# -----------------------------------------------------
+# Print utilities
+# -----------------------------------------------------
+
+def print_simulation_setup( sim, verbose_level=1 ):
     """
     Print information about the simulation.
     - Version of FBPIC
@@ -34,17 +147,17 @@ def print_simulation_setup( sim, level=1 ):
     sim: an fbpic Simulation object
         Contains all the information of the simulation setup
 
-    level: int, optional
+    verbose_level: int, optional
         Level of detail of the simulation information
         0 - Print no information
         1 (Default) - Print basic information
         2 - Print detailed information
     """
-    if level > 0 and sim.comm.rank == 0:
+    if verbose_level > 0 and sim.comm.rank == 0:
         # Print version of FBPIC
-        message = '\nFBPIC (fbpic-%s)\n'%__version__
+        message = '\nFBPIC (%s)\n'%__version__
         # Basic information
-        if level == 1:
+        if verbose_level == 1:
             # Print information about computational setup
             if sim.use_cuda:
                 message += "\nRunning on GPU "
@@ -53,30 +166,31 @@ def print_simulation_setup( sim, level=1 ):
             if sim.comm.size > 1:
                 message += "with %d MPI processes " %sim.comm.size
             if sim.use_threading and not sim.use_cuda:
-                message += "(%d threads per process) " \
-                    %numba.config.NUMBA_NUM_THREADS
+                message += "(%d threads per process) " %sim.cpu_threads
         # Detailed information
-        if level == 2:
-            if mpi_installed:
+        if verbose_level == 2:
+            if sim.comm.mpi_installed:
                 message += '\nMPI available: Yes'
+                message += '\nMPI Library Information: \n%s' \
+                    %sim.comm.mpi.Get_library_version()
                 message += '\nMPI processes: %d' %sim.comm.size
             else:
                 message += '\nMPI available: No'
-            if cuda_installed:
+            if sim.cuda_installed:
                 message += '\nCUDA available: Yes'
+                message += '\nAvailable GPUs: \n%s' %cuda.detect()
             else:
                 message += '\nCUDA available: No'
             if sim.use_cuda:
                 message += '\nCompute architecture: GPU (CUDA)'
             else:
                 message += '\nCompute architecture: CPU'
-                if threading_enabled:
+                if sim.use_threading:
                     message += '\nCPU multi-threading enabled: Yes'
-                    message += '\nThreads: %s' \
-                        %numba.config.NUMBA_NUM_THREADS
+                    message += '\nThreads: %s' %sim.cpu_threads
                 else:
                     message += '\nCPU multi-threading enabled: No'
-                if mkl_installed:
+                if sim.fld.trans[0].fft.use_mkl:
                     message += '\nFFT library: MKL'
                 else:
                     message += '\nFFT library: pyFFTW'
@@ -85,21 +199,17 @@ def print_simulation_setup( sim, level=1 ):
             if sim.fld.n_order == -1:
                 message += '\nPSAOTD stencil order: infinite'
             else:
-                message += '\nPSAOTD stencil order: %d' \
-                    %sim.fld.n_order
+                message += '\nPSAOTD stencil order: %d' %sim.fld.n_order
             message += '\nParticle shape: %s' %sim.particle_shape
             message += '\nLongitudinal boundaries: %s' %sim.comm.boundaries
             message += '\nTransverse boundaries: reflective'
-            message += '\nGuard region size: %d ' \
-                %sim.comm.n_guard + 'cells'
-            message += '\nDamping region size: %d ' \
-                %sim.comm.n_damp + 'cells'
+            message += '\nGuard region size: %d ' %sim.comm.n_guard + 'cells'
+            message += '\nDamping region size: %d ' %sim.comm.n_damp + 'cells'
             message += '\nParticle exchange period: every %d ' \
                 %sim.comm.exchange_period + 'step'
-            if sim.gamma_boost is not None:
+            if sim.boost is not None:
                 message += '\nBoosted frame: Yes'
-                message += '\nBoosted frame gamma: %d' \
-                    %sim.comm.gamma_boost
+                message += '\nBoosted frame gamma: %d' %sim.boost.gamma0
                 if sim.use_galilean:
                     message += '\nGalilean frame: Yes'
                 else:
@@ -108,106 +218,23 @@ def print_simulation_setup( sim, level=1 ):
                 message += '\nBoosted frame: False'
         message += '\n'
         print( message )
-    if level == 2:
-        # Sync MPI processes before printing MPI GPU selection
+    # GPU selection by MPI processes
+    if verbose_level == 2:
+        # Sync MPI processes before printing
         sim.comm.mpi_comm.barrier()
         time.sleep(0.1)
         if sim.use_cuda:
-            print_current_gpu( MPI )
+            print_current_gpu( sim.comm.mpi )
             sim.comm.mpi_comm.barrier()
             time.sleep(0.1)
             if sim.comm.rank == 0:
                 print('')
-
-def progression_bar( i, Ntot, avg_time_per_step, prev_time,
-                     n_avg=20, Nbars=35, char=progress_char):
-    """
-    Shows a progression bar with Nbars and the estimated
-    remaining simulation time.
-    """
-    # Estimate average time per step
-    curr_time = time.time()
-    time_per_step = curr_time - prev_time
-    avg_time_per_step += (time_per_step - avg_time_per_step)/n_avg
-    if i <= 2:
-        # Ignores first step in time estimation (compilation time)
-        avg_time_per_step = time_per_step
-    # Print progress bar
-    if i == 0:
-        # Let the user know that the first step is much longer
-        sys.stdout.write('\r' + \
-            'Just-In-Time compilation (up to one minute) ...')
-        sys.stdout.flush()
-    else:
-        # Print the progression bar
-        nbars = int( (i+1)*1./Ntot*Nbars )
-        sys.stdout.write('\r' + nbars*char )
-        sys.stdout.write((Nbars-nbars)*' ')
-        sys.stdout.write(' %d/%d' %(i+1, Ntot))
-        if i < n_avg:
-            # Time estimation is only printed after n_avg timesteps
-            sys.stdout.write(', calc. ETA...')
-        else:
-            # Estimated time in seconds until it will finish
-            eta = avg_time_per_step*(Ntot-i)
-            # Conversion to H:M:S
-            m, s = divmod(eta, 60)
-            h, m = divmod(m, 60)
-            sys.stdout.write(', %d:%02d:%02d left' % (h, m, s))
-        # Time taken by the last step
-        sys.stdout.write(', %d ms/step' %(time_per_step*1.e3))
-        sys.stdout.flush()
-    # Clear line
-    sys.stdout.write('\033[K')
-
-    return avg_time_per_step, curr_time
-
-def print_runtime_summary( N, duration ):
-    """
-    Print a summary about the total runtime of the simulation.
-
-    Parameters
-    ----------
-    N: int
-        The total number of iterations performed by the step loop
-
-    duration: float, seconds
-        The total time taken by the step loop
-    """
-    avg_tps = (duration / N)*1.e3
-    m, s = divmod(duration, 60)
-    h, m = divmod(m, 60)
-    print('\nTime taken (with compilation): %d:%02d:%02d' %(h, m, s))
-    print('Average time per iteration ' \
-          '(with compilation): %d ms\n' %(avg_tps))
-
-def print_gpu_meminfo(gpu):
-    """
-    Prints memory information about the GPU.
-
-    Parameters :
-    ------------
-    gpu : object
-        A numba cuda gpu context object.
-    """
-    with gpu:
-        meminfo = cuda.current_context().get_memory_info()
-        print("GPU: %s, free: %s Mbytes, total: %s Mbytes \
-              " % (gpu, meminfo[0]*1e-6, meminfo[1]*1e-6))
 
 def print_available_gpus():
     """
     Lists all available CUDA GPUs.
     """
     cuda.detect()
-
-def print_gpu_meminfo_all():
-    """
-    Prints memory information about all available CUDA GPUs.
-    """
-    gpus = cuda.gpus.lst
-    for gpu in gpus:
-        print_gpu_meminfo(gpu)
 
 def print_current_gpu( mpi ):
     """
@@ -232,3 +259,25 @@ def print_current_gpu( mpi ):
     else:
         message = "FBPIC selected a %s GPU with id %s" %( gpu_name, gpu.id )
     print(message)
+
+def print_gpu_meminfo_all():
+    """
+    Prints memory information about all available CUDA GPUs.
+    """
+    gpus = cuda.gpus.lst
+    for gpu in gpus:
+        print_gpu_meminfo(gpu)
+
+def print_gpu_meminfo(gpu):
+    """
+    Prints memory information about the GPU.
+
+    Parameters :
+    ------------
+    gpu : object
+        A numba cuda gpu context object.
+    """
+    with gpu:
+        meminfo = cuda.current_context().get_memory_info()
+        print("GPU: %s, free: %s Mbytes, total: %s Mbytes \
+              " % (gpu, meminfo[0]*1e-6, meminfo[1]*1e-6))

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -108,7 +108,7 @@ def print_simulation_setup( sim, level=1 ):
         # Sync MPI processes before MPI GPU selection
         sim.comm.mpi_comm.barrier()
         if sim.use_cuda:
-            print_current_gpu( sim.comm.mpi_comm )
+            print_current_gpu( MPI )
 
 def progression_bar( i, Ntot, avg_time_per_step, prev_time,
                      n_avg=20, Nbars=35, char=u'\u007C'):

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -37,9 +37,7 @@ def print_simulation_setup( sim, level=1 ):
     if level > 0:
         if sim.comm.rank == 0:
         # Print version of FBPIC
-            message = '\n' + u'\u007C' + u'\u007C' + u'\u007C'
-            message += '  FBPIC (fbpic-%s)  '%__version__
-            message += u'\u007C' + u'\u007C' + u'\u007C' + '\n'
+            message += '\nFBPIC (fbpic-%s)\n'%__version__
             # Basic information
             if level == 1:
                 # Print information about computational setup

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -12,7 +12,7 @@ from fbpic import __version__
 # Check availability of various computational setups
 from fbpic.fields.spectral_transform.fourier import mkl_installed
 from fbpic.cuda_utils import cuda_installed
-from fbpic.mpi_utils import mpi_installed
+from fbpic.mpi_utils import MPI, mpi_installed
 from fbpic.threading_utils import threading_enabled
 
 def print_simulation_setup( sim, level=1 ):
@@ -63,7 +63,6 @@ def print_simulation_setup( sim, level=1 ):
                     message += '\nCUDA available: No'
                 if sim.use_cuda:
                     message += '\nCompute architecture: GPU (CUDA)'
-                    message += '\nSelected GPUs:\n'
                 else:
                     message += '\nCompute architecture: CPU'
                     if mkl_installed:

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -65,18 +65,17 @@ def print_simulation_setup( sim, level=1 ):
                     message += '\nCompute architecture: GPU (CUDA)'
                 else:
                     message += '\nCompute architecture: CPU'
+                    if threading_enabled:
+                        message += '\nCPU multi-threading enabled: Yes'
+                        message += '\nThreads: %s' \
+                            %numba.config.NUMBA_NUM_THREADS
+                    else:
+                        message += '\nCPU multi-threading enabled: No'
                     if mkl_installed:
                         message += '\nFFT library: MKL'
                     else:
                         message += '\nFFT library: pyFFTW'
 
-
-                if threading_enabled:
-                    message += '\nCPU multi-threading enabled: Yes'
-                    message += '\nThreads: %s' \
-                        %numba.config.NUMBA_NUM_THREADS
-                else:
-                    message += '\nCPU multi-threading enabled: No'
                 message += '\n'
                 if sim.fld.n_order == -1:
                     message += '\nPSAOTD stencil order (accuracy): infinite'
@@ -109,6 +108,7 @@ def print_simulation_setup( sim, level=1 ):
         sim.comm.mpi_comm.barrier()
         if sim.use_cuda:
             print_current_gpu( MPI )
+            print('')
 
 def progression_bar( i, Ntot, avg_time_per_step, prev_time,
                      n_avg=20, Nbars=35, char=u'\u007C'):

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -37,9 +37,9 @@ def print_simulation_setup( sim, level=1 ):
     if level > 0:
         if sim.comm.rank == 0:
         # Print version of FBPIC
-            message = '\n' + u'\u2630' + u'\u2630' + u'\u2630'
+            message = '\n' + u'\u007C' + u'\u007C' + u'\u007C'
             message += '  FBPIC (fbpic-%s)  '%__version__
-            message += u'\u2630' + u'\u2630' + u'\u2630' + '\n'
+            message += u'\u007C' + u'\u007C' + u'\u007C' + '\n'
             # Basic information
             if level == 1:
                 # Print information about computational setup
@@ -115,7 +115,7 @@ def print_simulation_setup( sim, level=1 ):
         print( message )
 
 def progression_bar( i, Ntot, avg_time_per_step, prev_time,
-                     n_avg=20, Nbars=35, char=u'\u2588'):
+                     n_avg=20, Nbars=35, char=u'\u007C'):
     """
     Shows a progression bar with Nbars and the estimated
     remaining simulation time.

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -37,7 +37,7 @@ def print_simulation_setup( sim, level=1 ):
     if level > 0:
         if sim.comm.rank == 0:
         # Print version of FBPIC
-            message += '\nFBPIC (fbpic-%s)\n'%__version__
+            message = '\nFBPIC (fbpic-%s)\n'%__version__
             # Basic information
             if level == 1:
                 # Print information about computational setup

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -53,7 +53,7 @@ def print_simulation_setup( sim, level=1 ):
         print( message )
 
 def progression_bar( i, Ntot, avg_time_per_step, prev_time,
-                     n_avg=20, Nbars=50, char=u'\u2588'):
+                     n_avg=20, Nbars=35, char=u'\u2588'):
     """
     Shows a progression bar with Nbars and the estimated
     remaining simulation time.
@@ -80,7 +80,7 @@ def progression_bar( i, Ntot, avg_time_per_step, prev_time,
         sys.stdout.write(', %d ms/step' %(time_per_step*1.e3))
         if i < n_avg:
             # Time estimation is only printed after n_avg timesteps
-            sys.stdout.write(', estimating time left...')
+            sys.stdout.write(', calculating ETA...')
             sys.stdout.flush()
         else:
             # Estimated time in seconds until it will finish

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -6,8 +6,9 @@ Fourier-Bessel Particle-In-Cell (FB-PIC) main file
 It defines a set of generic functions for printing simulation information.
 """
 import sys, time
-from numba import cuda
 from fbpic import __version__
+from fbpic.cuda_utils import cuda, cuda_installed
+from fbpic.mpi_utils import MPI, mpi_installed
 # Check if terminal is correctly set to UTF-8 and set progress character
 if sys.stdout.encoding == 'UTF-8':
     progress_char = u'\u2588'
@@ -101,9 +102,9 @@ class ProgressBar(object):
         else:
             # Print the progression bar
             nbars = int( (i+1)*1./self.N*self.Nbars )
-            sys.stdout.write('\r' + nbars*self.bar_char )
+            sys.stdout.write('\r|' + nbars*self.bar_char )
             sys.stdout.write((self.Nbars-nbars)*' ')
-            sys.stdout.write(' %d/%d' %(i+1,self.N))
+            sys.stdout.write('| %d/%d' %(i+1,self.N))
             if self.eta is None:
                 # Time estimation is only printed after n_avg timesteps
                 sys.stdout.write(', calc. ETA...')
@@ -169,14 +170,14 @@ def print_simulation_setup( sim, verbose_level=1 ):
                 message += "(%d threads per process) " %sim.cpu_threads
         # Detailed information
         if verbose_level == 2:
-            if sim.comm.mpi_installed:
+            if mpi_installed:
                 message += '\nMPI available: Yes'
                 message += '\nMPI Library Information: \n%s' \
                     %sim.comm.mpi.Get_library_version()
                 message += '\nMPI processes: %d' %sim.comm.size
             else:
                 message += '\nMPI available: No'
-            if sim.cuda_installed:
+            if cuda_installed:
                 message += '\nCUDA available: Yes'
             else:
                 message += '\nCUDA available: No'
@@ -223,7 +224,7 @@ def print_simulation_setup( sim, verbose_level=1 ):
         sim.comm.mpi_comm.barrier()
         time.sleep(0.1)
         if sim.use_cuda:
-            print_current_gpu( sim.comm.mpi )
+            print_current_gpu( MPI )
             sim.comm.mpi_comm.barrier()
             time.sleep(0.1)
             if sim.comm.rank == 0:

--- a/fbpic/print_utils.py
+++ b/fbpic/print_utils.py
@@ -1,0 +1,115 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters, Soeren Jalas
+# License: 3-Clause-BSD-LBNL
+"""
+Fourier-Bessel Particle-In-Cell (FB-PIC) main file
+It defines a set of generic functions for printing simulation information.
+"""
+import sys, time
+import numba
+from fbpic import __version__
+
+def print_simulation_setup( sim, level=1 ):
+    """
+    Print information about the simulation.
+    - Version of FBPIC
+    - CPU or GPU computation
+    - Number of parallel MPI domains
+    - Number of threads in case of CPU multi-threading
+    - (Additional detailed information)
+
+    Parameters
+    ----------
+    sim: an fbpic Simulation object
+        Contains all the information of the simulation setup
+
+    level: int, optional
+        Level of detail of the simulation information
+        0 - Print no information
+        1 (Default) - Print basic information
+        2 - Print detailed information
+    """
+    if sim.comm.rank == 0 and level > 0:
+        # Print version of FBPIC
+        message = '\n' + u'\u2630' + u'\u2630' + u'\u2630'
+        message += '  FBPIC (fbpic-%s)  '%__version__
+        message += u'\u2630' + u'\u2630' + u'\u2630' + '\n'
+        # Basic information
+        if level == 1:
+            # Print information about computational setup
+            if sim.use_cuda:
+                message += "\nRunning on GPU "
+            else:
+                message += "\nRunning on CPU "
+            if sim.comm.size > 1:
+                message += "with %d MPI processes " %sim.comm.size
+            if sim.use_threading and not sim.use_cuda:
+                message += "(%d threads per process) " \
+                    %numba.config.NUMBA_NUM_THREADS
+        # Detailed information
+        if level == 2:
+            print('TBD...')
+
+        print( message )
+
+def progression_bar( i, Ntot, avg_time_per_step, prev_time,
+                     n_avg=20, Nbars=50, char=u'\u2588'):
+    """
+    Shows a progression bar with Nbars and the estimated
+    remaining simulation time.
+    """
+    # Estimate average time per step
+    curr_time = time.time()
+    time_per_step = curr_time - prev_time
+    avg_time_per_step += (time_per_step - avg_time_per_step)/n_avg
+    if i <= 2:
+        # Ignores first step in time estimation (compilation time)
+        avg_time_per_step = time_per_step
+    # Print progress bar
+    if i == 0:
+        # Let the user know that the first step is much longer
+        sys.stdout.write('\r' + '1st iteration & ' + \
+            'Just-In-Time compilation (up to one minute) ...')
+        sys.stdout.flush()
+    else:
+        # Print the progression bar
+        nbars = int( (i+1)*1./Ntot*Nbars )
+        sys.stdout.write('\r' + nbars*char )
+        sys.stdout.write((Nbars-nbars)*' ')
+        sys.stdout.write(' %d/%d' %(i+1, Ntot))
+        sys.stdout.write(', %d ms/step' %(time_per_step*1.e3))
+        if i < n_avg:
+            # Time estimation is only printed after n_avg timesteps
+            sys.stdout.write(', estimating time left...')
+            sys.stdout.flush()
+        else:
+            # Estimated time in seconds until it will finish
+            eta = avg_time_per_step*(Ntot-i)
+            # Conversion to H:M:S
+            m, s = divmod(eta, 60)
+            h, m = divmod(m, 60)
+            sys.stdout.write(', %d:%02d:%02d left' % (h, m, s))
+            sys.stdout.flush()
+    # Clear line
+    sys.stdout.write('\033[K')
+
+    return avg_time_per_step, curr_time
+
+def print_runtime_summary( N, duration ):
+    """
+    Print a summary about the total runtime of the simulation.
+
+    Parameters
+    ----------
+    N: int
+        The total number of iterations performed by the step loop
+
+    duration: float, seconds
+        The total time taken by the step loop
+    """
+    avg_tps = (duration / N)*1.e3
+    m, s = divmod(duration, 60)
+    h, m = divmod(m, 60)
+    print('\nTime taken (with compilation): %d:%02d:%02d' %(h, m, s))
+    print('Average time per iteration ' \
+          '(with compilation): %d ms\n' %(avg_tps))


### PR DESCRIPTION
General changes:
- The printing functions of main.py have been moved to a new file print_utils.py (makes main.py a little bit cleaner)

Enhancements in the printing at the beginning of the simulation:
- The simulation object takes a new argument "simulation_info" that specifies the level of detail for printing simulation information (0 = no information, 1 = basic information (default), 2 = detailed information, such as n_order/n_guard/exchange_period...)
- Prints version of FBPIC after the initialization of the simulation object
- Slight refactoring of the info about the computing architecture used: CPU / GPU / MPI / threads per process

Changes to the progress bar:
- During the first iteration a warning about the JIT compilation overhead is shown instead of the progress bar
- The first iteration is not considered by the calculation of the estimated time anymore
- A moving window-like calculation is used to get the average time per step (no averaging over all steps anymore) - the progress bar does not show an ETA until all steps of the window size are done
- The time taken by the last step is printed (This is useful to estimate current performance)
- Slightly new default style
- The summary of the total runtime at the end of the step function has been moved to a separate function in print_utils.py

Closes #156 
Closes #66 
Closes #94 