### PR TITLE
Continuous plasma injection: modify the position from which injection starts

### DIFF
--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -119,7 +119,7 @@ class MovingWindow(object):
                     break
             # Default value in the absence of continuously-injected particles
             if self.z_end_plasma is None:
-                self.z_end_plasma = self.z_inject
+                self.z_end_plasma = interp[0].zmax - (ng+nd)*interp[0].dz
             self.nz_inject = 0
             self.p_nz = p_nz
 


### PR DESCRIPTION
When doing continuous injection in FBPIC: 
- If there is some plasma inside the initial physical box, the FBPIC continuous injection starts from the right end of that plasma.
- However, when there is no plasma in the initial box, FBPIC has to pick a z position from which to start the continuous injection. 

In the current version of the code, this initial position was effectively set at a given position inside the guard/damp cells, instead of being set at the limit of the physical box. This can cause slightly incorrect results at the beginning of the simulation, because the plasma started being injected slightly later than it should.

The current pull request fixes this by setting the initial injection position to the right of the physical box.