### PR TITLE
Reduce the number of Hankel transforms per iteration

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -705,10 +705,10 @@ class BoundaryCommunicator(object):
         add_buffers_to_particles( species, float_recv_left, float_recv_right,
                                     uint_recv_left, uint_recv_right )
 
-    def damp_guard_EB( self, interp ):
+    def damp_EB_open_boundary( self, interp ):
         """
-        Apply the damping shape in the right and left guard cells.
-        Damp the fields E and B in the guard cells.
+        Damp the fields E and B in the damp cells, at the right and left
+        of the *global* simulation box.
 
         Parameter:
         -----------
@@ -766,9 +766,6 @@ class BoundaryCommunicator(object):
     def generate_damp_array( self, n_guard, n_damp ):
         """
         Create a 1d damping array of length n_guard.
-
-        The expression of the damping array depends on whether the guard cells
-        correspond to an open boundary or a boundary with another processor.
 
         Parameters
         ----------

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -295,7 +295,7 @@ class Fields(object) :
     def spect2interp(self, fieldtype) :
         """
         Transform the fields `fieldtype` from the spectral grid
-        to the spectral grid
+        to the interpolation grid
 
         Parameter
         ---------
@@ -340,6 +340,114 @@ class Fields(object) :
                     self.spect[m].rho_prev, self.interp[m].rho )
         else :
             raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
+
+    def spect2partial_interp(self, fieldtype) :
+        """
+        Transform the fields `fieldtype` from the spectral grid,
+        by only performing an inverse FFT in z (but no Hankel transform)
+
+        This is typically done before exchanging guard cells in z
+        (a full FFT+Hankel transform is not necessary in this case)
+
+        The result is stored in the interpolation grid (for economy of memory),
+        but one should be aware that these fields are not actually the
+        interpolation fields. These "incorrect" fields would however be
+        overwritten by subsequent calls to `spect2interp` (see `step` function)
+
+        Parameter
+        ---------
+        fieldtype :
+            A string which represents the kind of field to transform
+            (either 'E', 'B', 'J', 'rho_next', 'rho_prev')
+        """
+        # Use the appropriate transformation depending on the fieldtype.
+        if fieldtype == 'E' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].Ez, self.interp[m].Ez )
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].Ep, self.interp[m].Er )
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].Em, self.interp[m].Et )
+        elif fieldtype == 'B' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].Bz, self.interp[m].Bz )
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].Bp, self.interp[m].Br )
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].Bm, self.interp[m].Bt )
+        elif fieldtype == 'J' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].Jz, self.interp[m].Jz )
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].Jp, self.interp[m].Jr )
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].Jm, self.interp[m].Jt )
+        elif fieldtype == 'rho_next' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].rho_next, self.interp[m].rho )
+        elif fieldtype == 'rho_prev' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].rho_prev, self.interp[m].rho )
+        else :
+            raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
+
+
+    def partial_interp2spect(self, fieldtype) :
+        """
+        Transform the fields `fieldtype` from the partial representation
+        in interpolation space (obtained from `spect2partial_interp`)
+        to the spectral grid.
+
+        This is typically done after exchanging guard cells in z
+        (a full FFT+Hankel transform is not necessary in this case)
+
+        Parameter
+        ---------
+        fieldtype :
+            A string which represents the kind of field to transform
+            (either 'E', 'B', 'J', 'rho_next', 'rho_prev')
+        """
+        # Use the appropriate transformation depending on the fieldtype.
+        if fieldtype == 'E' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.transform(
+                    self.interp[m].Ez, self.spect[m].Ez )
+                self.trans[m].fft.transform(
+                    self.interp[m].Er, self.spect[m].Ep )
+                self.trans[m].fft.transform(
+                    self.interp[m].Et, self.spect[m].Em )
+        elif fieldtype == 'B' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.transform(
+                    self.interp[m].Bz, self.spect[m].Bz )
+                self.trans[m].fft.transform(
+                    self.interp[m].Br, self.spect[m].Bp )
+                self.trans[m].fft.transform(
+                    self.interp[m].Bt, self.spect[m].Bm )
+        elif fieldtype == 'J' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.transform(
+                    self.interp[m].Jz, self.spect[m].Jz )
+                self.trans[m].fft.transform(
+                    self.interp[m].Jr, self.spect[m].Jp )
+                self.trans[m].fft.transform(
+                    self.interp[m].Jt, self.spect[m].Jm )
+        elif fieldtype == 'rho_next' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.transform(
+                    self.interp[m].rho, self.spect[m].rho_next )
+        elif fieldtype == 'rho_prev' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.transform(
+                    self.interp[m].rho, self.spect[m].rho_prev )
+        else :
+            raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
+
 
     def erase(self, fieldtype ) :
         """

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -432,9 +432,9 @@ class Simulation(object):
                     # Exchange the guard cells of corrected J between domains
                     # (If correct_currents is False, the exchange of J
                     # is done in the function `deposit`)
-                    fld.spect2interp('J')
+                    fld.spect2partial_interp('J')
                     self.comm.exchange_fields(fld.interp, 'J', 'add')
-                    fld.interp2spect('J')
+                    fld.partial_interp2spect('J')
                     fld.exchanged_source['J'] = True
 
             # Push the fields E and B on the spectral grid to t = (n+1) dt
@@ -447,10 +447,10 @@ class Simulation(object):
                 # the interpolation grids
                 self.comm.move_grids(fld, self.dt, self.time)
 
-            # Get the (MPI-exchanged and damped) E and B field in both
+            # Get the MPI-exchanged and damped E and B field in both
             # spectral space and interpolation space
             # (Since exchange/damp operation is purely along z, spectral fields
-            # are updated by doing an FFT/iFFT instead of a full transform)
+            # are updated by doing an iFFT/FFT instead of a full transform)
             fld.spect2partial_interp('E')
             fld.spect2partial_interp('B')
             self.comm.exchange_fields(fld.interp, 'E', 'replace')

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -324,6 +324,12 @@ class Simulation(object):
         if self.use_cuda:
             send_data_to_gpu(self)
 
+        # Get the E and B fields in spectral space initially
+        # (In the rest of the loop, E and B will only be transformed
+        # from spectal space to real space, but never the other way around)
+        fld.interp2spect('E')
+        fld.interp2spect('B')
+
         # Beginning of the N iterations
         # -----------------------------
 
@@ -342,12 +348,8 @@ class Simulation(object):
                 # were smoothed/corrected, and copy the data from the GPU.)
                 diag.write( self.iteration )
 
-            # Exchanges to prepare for this iteration
-            # ---------------------------------------
-
-            # Exchange the fields (E,B) in the guard cells between MPI domains
-            self.comm.exchange_fields(fld.interp, 'E', 'replace')
-            self.comm.exchange_fields(fld.interp, 'B', 'replace')
+            # Particle exchanges to prepare for this iteration
+            # ------------------------------------------------
 
             # Check whether this iteration involves particle exchange.
             # Note: Particle exchange is imposed at the first iteration
@@ -374,6 +376,21 @@ class Simulation(object):
 
             # Main PIC iteration
             # ------------------
+
+            # Get the (MPI-exchanged and damped) E and B field in both
+            # spectral space and interpolation space
+            # (Since exchange/damp operation is purely along z, spectral fields
+            # are updated by doing an FFT/iFFT instead of a full transform)
+            fld.spect2partial_interp('E')
+            fld.spect2partial_interp('B')
+            self.comm.exchange_fields(fld.interp, 'E', 'replace')
+            self.comm.exchange_fields(fld.interp, 'B', 'replace')
+            self.comm.damp_EB_open_boundary( fld.interp )
+            fld.partial_interp2spect('E')
+            fld.partial_interp2spect('B')
+            # Get the corresponding fields in interpolation space
+            fld.spect2interp('E')
+            fld.spect2interp('B')
 
             # Gather the fields from the grid at t = n dt
             for species in ptcl:
@@ -432,11 +449,6 @@ class Simulation(object):
                     fld.interp2spect('J')
                     fld.exchanged_source['J'] = True
 
-            # Damp the fields in the guard cells
-            self.comm.damp_guard_EB( fld.interp )
-            # Get the damped fields on the spectral grid at t = n dt
-            fld.interp2spect('E')
-            fld.interp2spect('B')
             # Push the fields E and B on the spectral grid to t = (n+1) dt
             fld.push( use_true_rho )
             if correct_divE:
@@ -446,9 +458,6 @@ class Simulation(object):
                 # Shift the fields is spectral space and update positions of
                 # the interpolation grids
                 self.comm.move_grids(fld, self.dt, self.time)
-            # Get the fields E and B on the interpolation grid at t = (n+1) dt
-            fld.spect2interp('E')
-            fld.spect2interp('B')
 
             # Increment the global time and iteration
             self.time += self.dt


### PR DESCRIPTION
In the current dev branch, we perform 16 Hankel transform and 16 Fourier transform per azimuthal mode and per iteration. Within those 16 transforms, 12 transforms are done because we do a `spect2interp` and `interp2spect` of the fields E and B (2 * 2 fields * 3 components).

The reason for performing these back-and-forth transformations is that we have to perform some operations on the fields in spectral space (Maxwell push) and some operations in real space (MPI exchanges and damping of the open boundaries). 

However, because the MPI exchanges and damping of the open boundaries is purely along z, updating the spectral fields can be done only by a succession an inverse and forward Fourier transform (no Hankel transform involved). Then updating the fields in interpolation space requires an additional Hankel + Fourier transform.

This effectively replaces the 16 Hankel and 16 Fourier transforms by 10 Hankel and 22 Fourier transforms (per mode, per iteration). Because the Fourier transforms are almost always much faster than the Hankel transforms, this results in a speedup of the simulation.

*Note: I am definitely not the first to use this trick! @hightower has been using it for a while in his code [chimera](https://github.com/hightower8083/chimera).*