### PR TITLE
Fix checkpoint restart

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -259,6 +259,8 @@ class Simulation(object):
         # Register the time and the iteration
         self.time = 0.
         self.iteration = 0
+        # Register variable that keeps track of restarting
+        self.is_restarted = False
         # Register the filtering flag
         self.filter_currents = filter_currents
 
@@ -337,10 +339,12 @@ class Simulation(object):
             # (E, B, rho, x are defined at time n; J, p at time n-1/2)
             for diag in self.diags:
                 # Check if the diagnostic should be written at this iteration
-                # and write it, if it is the case.
+                # and write it, if it is the case. (If the simulation has
+                # just been restarted, do not write at the first iteration)
                 # (If needed: bring rho/J from spectral space, where they
                 # were smoothed/corrected, and copy the data from the GPU.)
-                diag.write( self.iteration )
+                if not (self.is_restarted and i_step == 0):
+                    diag.write( self.iteration )
 
             # Exchanges to prepare for this iteration
             # ---------------------------------------

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -132,6 +132,12 @@ def restart_from_checkpoint( sim, iteration=None ):
                 load_fields( sim.fld.interp[m], fieldtype,
                              coord, ts, iteration )
 
+    # Register that simulation has been restarted
+    sim.is_restarted = True
+    # Notify the user that the simulation is restarted from checkpoints
+    if comm.rank == 0:
+        print('Restarting simulation at iteration %d.' %sim.iteration)
+
 def check_restart( sim, iteration ):
     """Verify that the restart is valid."""
 
@@ -252,8 +258,7 @@ def load_species( species, name, ts, iteration, comm ):
     species.ux, species.uy, species.uz = ts.get_particle(
         ['ux', 'uy', 'uz' ], iteration=iteration, species=name )
     # Get the weight (multiply it by the charge to conform with FBPIC)
-    w, = ts.get_particle( ['w'], iteration=iteration, species=name )
-    species.w = species.q * w
+    species.w, = ts.get_particle( ['w'], iteration=iteration, species=name )
     # Get the inverse gamma
     species.inv_gamma = 1./np.sqrt(
         1 + species.ux**2 + species.uy**2 + species.uz**2 )


### PR DESCRIPTION
The checkpoint / restart feature was broken:

- In load_species the weights were multiplied by the charge q. This should not be done anymore.
- If a diag_period was at the same time as a checkpoint_period, a wrong diagnostic was written at the first step (i_step == 0) after the restart (wrong charge/currents). With this PR, a check is performed based on a new attribute (is_restarted) of the Simulation object.

Furthermore, the user is informed about the restart and at which iteration the simulation is restarted.