### PR TITLE
Allow CPU multi-threading with numba 0.36

### DIFF
--- a/fbpic/threading_utils.py
+++ b/fbpic/threading_utils.py
@@ -23,13 +23,15 @@ if threading_enabled:
     try:
         # Try to import the threading function prange
         from numba import prange as numba_prange
-        # (Temporarily) check that numba is version 0.34 (other versions fail)
-        import numba; assert numba.__version__.startswith('0.34')
+        # Check that numba is version 0.34 or 0.36 (other versions fail)
+        import numba
+        assert ( numba.__version__.startswith('0.34') or \
+            numba.__version__.startswith('0.36') )
     except (ImportError, AssertionError):
         threading_enabled = False
         print('*** Threading not available for the simulation.')
-        print('*** (Please make sure that numba 0.34 is installed,')
-        print('***  e.g. by typing `conda install numba=0.34` in a terminal)')
+        print('*** (Please make sure that numba 0.34 or 0.36 is installed,')
+        print('***  e.g. by typing `conda install numba=0.36` in a terminal)')
 
 # Set the function njit_parallel and prange to the correct object
 if not threading_enabled:

--- a/fbpic/threading_utils.py
+++ b/fbpic/threading_utils.py
@@ -31,7 +31,7 @@ if threading_enabled:
         threading_enabled = False
         print('*** Threading not available for the simulation.')
         print('*** (Please make sure that numba 0.34 or 0.36 is installed,')
-        print('***  e.g. by typing `conda install numba=0.36` in a terminal)')
+        print('***  e.g. by typing `conda install numba=0.34` in a terminal)')
 
 # Set the function njit_parallel and prange to the correct object
 if not threading_enabled:


### PR DESCRIPTION
The newest version of numba (0.36) works fine with FBPIC multi-threading.
The restriction in threading_utils.py has been modified such that numba 0.34 and 0.36 can be used together with multi-threading. 
When numba 0.34 or 0.36 are not installed, the user is recommended to install numba 0.34 (as 0.36 is not yet included in the official anaconda channel)

Note: We should remove this restriction completely in the future and just require a minimum numba version.
