### PR TITLE
Close #166 Error with BoostedParticleDiagnostics when galilean frame is used on GPU

### DIFF
--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -671,15 +671,19 @@ class ParticleCatcher:
             # - Get the prefix sum values that correspond to these indices
             #   (Take into account potential shift due to the moving window)
             z_cell_curr = iz_curr + pref_sum_shift
-            if z_cell_curr > 0:
-                pref_sum_curr = pref_sum.getitem( z_cell_curr*Nr - 1 )
-            else:
+            if z_cell_curr <= 0:
                 pref_sum_curr = 0
-            z_cell_prev = iz_prev + pref_sum_shift
-            if z_cell_prev <= Nz:
-                pref_sum_prev = pref_sum.getitem( z_cell_prev*Nr - 1 )
+            elif z_cell_curr > Nz:
+                pref_sum_curr = species.Ntot
             else:
+                pref_sum_curr = pref_sum.getitem( z_cell_curr*Nr - 1 )
+            z_cell_prev = iz_prev + pref_sum_shift
+            if z_cell_prev <= 0:
+                pref_sum_prev = 0  
+            elif z_cell_prev > Nz:
                 pref_sum_prev = species.Ntot
+            else:
+                pref_sum_prev = pref_sum.getitem( z_cell_prev*Nr - 1 )
             # Calculate number of particles in this area (N_area)
             N_area = pref_sum_prev - pref_sum_curr
             # Check if there are particles to extract


### PR DESCRIPTION
When doing the particle boosted frame diagnostic, the code gets a thin slice of particles on GPU, which is then brought on CPU for further selection.

The bounds check when getting this slice was not done carefully enough, and were resulting in an out-of-bounds. This happened specifically with Galilean frame because `pref_sum_shift` (which measures the shift between the position of the current grid and of the grid at the time of the last sort) can take larger values in this case (typically pref_sum_shift=2 in this case).