### PR TITLE
Use the new version of numba (0.36)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes numba==0.34 scipy h5py mkl
+  - conda install --yes numba scipy h5py mkl
   - conda install --yes -c conda-forge mpi4py
   - pip install pyflakes
   - python setup.py install

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ it from [here](https://www.continuum.io/downloads).
 
 - Install the dependencies of FBPIC. This can be done in two lines:
 ```
-conda install numba=0.34 scipy h5py mkl
+conda install numba scipy h5py mkl
 conda install -c conda-forge mpi4py
 ```
 - Download and install FBPIC:

--- a/docs/source/install/install_cori_edison.rst
+++ b/docs/source/install/install_cori_edison.rst
@@ -60,7 +60,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install numba=0.34 scipy h5py mkl
+       conda install numba scipy h5py mkl
        conda install -c conda-forge mpi4py
 
 -  Install ``fbpic``

--- a/docs/source/install/install_jureca.rst
+++ b/docs/source/install/install_jureca.rst
@@ -44,7 +44,7 @@ In order to download and install `Anaconda <https://www.continuum.io/downloads>`
 Then install the dependencies of FBPIC:
 ::
 
-   conda install numba=0.34 mkl
+   conda install numba mkl
    conda install -c numba pyculib
 
 It is important that the following packages are **NOT** installed

--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -56,7 +56,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install numba=0.34 scipy h5py mkl
+       conda install numba scipy h5py mkl
        conda install -c conda-forge mpi4py
        conda install -c numba pyculib
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -14,7 +14,7 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
   ::
 
-     conda install numba=0.34 scipy h5py mkl
+     conda install numba scipy h5py mkl
      conda install -c conda-forge mpi4py
 
 -  Install ``fbpic``

--- a/docs/source/install/install_titan.rst
+++ b/docs/source/install/install_titan.rst
@@ -57,7 +57,7 @@ Installation of FBPIC and its dependencies
 
   ::
 
-    conda install numba=0.34 scipy h5py mkl
+    conda install numba scipy h5py mkl
     conda install -c numba pyculib
 
 -  Clone and install the ``fbpic`` repository using git


### PR DESCRIPTION
Now that numba 0.36 is available on the standard conda channel, we should not recommend numba 0.34 anymore.