### PR TITLE
Use numba 0.36 in automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ python:
 
 before_install:
   # Setup miniconda
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=$HOME/miniconda2/bin:$PATH
+  - export PATH=$HOME/miniconda3/bin:$PATH
   # Create a virtual environment with the right version of python
   - conda create -n testing python=$TRAVIS_PYTHON_VERSION --yes
   - source activate testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: precise
 language: python
 python:
     - "2.7"
-    - "3.5"
+    - "3.6"
 
 before_install:
   # Setup miniconda

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -157,14 +157,14 @@ def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0, sig_gamma,
         Saves the generated beam distribution as an .npz file "string".npz
     """
     # Get Gaussian particle distribution in x,y,z
-    x = np.random.normal(0., sig_r, N)
-    y = np.random.normal(0., sig_r, N)
-    z = np.random.normal(zf, sig_z, N) # with offset in z
+    x = sig_r * np.random.normal(0., 1., N)
+    y = sig_r * np.random.normal(0., 1., N)
+    z = zf + sig_z * np.random.normal(0., 1., N) # with offset in z
     # Define sigma of ux and uy based on normalized emittance
     sig_ur = (n_emit/sig_r)
     # Get Gaussian distribution of transverse normalized momenta ux, uy
-    ux = np.random.normal(0., sig_ur, N)
-    uy = np.random.normal(0., sig_ur, N)
+    ux = sig_ur * np.random.normal(0., 1., N)
+    uy = sig_ur * np.random.normal(0., 1., N)
     # Now we imprint an energy spread on the gammas of each particle
     if sig_gamma > 0.:
         gamma = np.random.normal(gamma0, sig_gamma, N)


### PR DESCRIPTION
After PR #170, I realized that the automated tests were using numba 0.35 instead of numba 0.36. Upon further investigation, it seems that this is because we were using Miniconda 2 (I do not fully understand why numba 0.36 is not automatically installed in this case).

For this reason, I switched to Miniconda 3, and checked that numba 0.36 is indeed used in automated tests. In addition, I also switched the Python3 tests from Python 3.5 to Python 3.6.

An unexpected consequence of Miniconda 3 is that, with Python 2, it installs numpy 1.10 instead of 1.13. This caused some bugs because the `random.normal` (which is used in bunch.py) does not support being passed a standard deviation of 0. Therefore, I also modified `bunch.py` so that it never passes a standard deviation of 0 to `random.normal`.