### PR TITLE
[WIP] Overload the + operator for laser profiles

### DIFF
--- a/fbpic/lpa_utils/laser/__init__.py
+++ b/fbpic/lpa_utils/laser/__init__.py
@@ -3,6 +3,7 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It imports functions which are useful when initializing a laser pulse
 """
 from .laser import add_laser, add_laser_pulse
-from .laser_profiles import GaussianLaser
+from .laser_profiles import GaussianLaser, LaguerreGaussLaser
 
-__all__ = ['add_laser', 'add_laser_pulse', 'GaussianLaser']
+__all__ = ['add_laser', 'add_laser_pulse',
+            'GaussianLaser', 'LaguerreGaussLaser']

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -137,7 +137,7 @@ class LaguerreGaussLaser( object ):
         .. math::
             I(r, \theta, z) \propto \left( \frac{2r^2}{w(z)}^2 \right)^m
             L^m_p\left( \frac{2r^2}{w(z)}^2 \right)
-            \exp\left( -\frac{2r^2}{w(z)}^2 \right) \cos(m(\theta-\theta_0))
+            \exp\left( -\frac{2r^2}{w(z)}^2 \right) \cos^2[m(\theta-\theta_0)]
         where :math:`L^m_p` is a Laguerre polynomial, and where `w(z)` is
         the waist and has the same expression as for a Gaussian laser pulse.
         (See Siegman, Lasers (1986) Chapter 16: Wave optics and Gaussian beams)
@@ -149,8 +149,8 @@ class LaguerreGaussLaser( object ):
             number of "rings" in the radial intensity profile of the laser.)
 
         m: int
-            The azimuthal order of the pulse. (In the transverse plane,
-            the intensity of the pulse varies as cos(m*(theta-theta0)).)
+            The azimuthal order of the pulse. (In the transverse plane, the
+            intensity of the pulse varies as :math:`cos^2[m(\theta-\theta0)]`.)
 
             .. note::
                 In order to be properly resolved by the simulation,
@@ -188,7 +188,8 @@ class LaguerreGaussLaser( object ):
 
         theta0: float (rad)
             The azimuthal position of (one of) the maxima of intensity, in the
-            transverse plane. (The intensity varies as `cos(m*(theta-theta0))`)
+            transverse plane.
+            (The intensity varies as :math:`cos^2[m(\theta-\theta0)]`)
         """
         # Set a number of parameters for the laser
         k0 = 2*np.pi/lambda0

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -7,6 +7,7 @@ It defines a set of common laser profiles.
 """
 import numpy as np
 from scipy.constants import c, m_e, e
+from scipy.special import factorial, genlaguerre
 
 class GaussianLaser( object ):
     """Class that calculates a Gaussian laser pulse."""
@@ -116,6 +117,140 @@ class GaussianLaser( object ):
             - 1./stretch_factor * self.inv_ctau2 * ( c*t  + self.z0 - z )**2
         # Get the transverse profile
         profile = np.exp(exp_argument) / ( diffract_factor * stretch_factor**0.5 )
+
+        # Get the projection along x and y, with the correct polarization
+        Ex = self.E0x * profile
+        Ey = self.E0y * profile
+
+        return( Ex.real, Ey.real )
+
+
+class LaguerreGaussLaser( object ):
+    """Class that calculates a Laguerre-Gauss pulse."""
+
+    def __init__( self, p, m, a0, waist, tau, z0, zf=None, theta_pol=0.,
+                    lambda0=0.8e-6, cep_phase=0., theta0=0. ):
+        """
+        Define a linearly-polarized Laguerre-Gauss laser profile.
+
+        The intensity profile of the pulse is given by
+        .. math::
+            I(r, \theta, z) \propto \left( \frac{2r^2}{w(z)}^2 \right)^m
+            L^m_p\left( \frac{2r^2}{w(z)}^2 \right)
+            \exp\left( -\frac{2r^2}{w(z)}^2 \right) \cos(m(\theta-\theta_0))
+        where :math:`L^m_p` is a Laguerre polynomial, and where `w(z)` is
+        the waist and has the same expression as for a Gaussian laser pulse.
+        (See Siegman, Lasers (1986) Chapter 16: Wave optics and Gaussian beams)
+
+        Parameters:
+        -----------
+        p: int
+            The order of the Laguerre polynomial. (Increasing p increases the
+            number of "rings" in the radial intensity profile of the laser.)
+
+        m: int
+            The azimuthal order of the pulse. (In the transverse plane,
+            the intensity of the pulse varies as cos(m*(theta-theta0)).)
+
+            .. note::
+                In order to be properly resolved by the simulation,
+                this laser profile requires the azimuthal modes up to ``m+1``.
+                (i.e. the number of required azimuthal modes is ``Nm=m+2``)
+
+        a0: float (dimensionless)
+            The amplitude of the pulse, defined so that the total
+            energy of the pulse is the same as that of a Gaussian pulse
+            with the same a0, waist and tau. (i.e. The energy of the pulse
+            is independent of p and m, here.)
+
+        waist: float (in meters)
+            Laser waist in the focal plane
+
+        tau: float (in meters^-1)
+            The duration of the laser (in the lab frame)
+
+        z0: float (m)
+            The initial position of the centroid of the laser (in the lab frame)
+
+        zf: float (m), optional
+            The position of the focal plane (in the lab frame)
+
+        theta_pol: float (in radians), optional
+           The angle of polarization with respect to the x axis.
+           Default: 0 rad.
+
+        lambda0: float (m)
+            The wavelength of the laser (in the lab frame)
+
+        cep_phase: float (rad)
+            The Carrier Enveloppe Phase (CEP), i.e. the phase of the laser
+            oscillation, at the position where the laser enveloppe is maximum.
+
+        theta0: float (rad)
+            The azimuthal position of (one of) the maxima of intensity, in the
+            transverse plane. (The intensity varies as `cos(m*(theta-theta0))`)
+        """
+        # Set a number of parameters for the laser
+        k0 = 2*np.pi/lambda0
+        zr = 0.5*k0*waist**2
+        # Scaling factor, so that the pulse energy is independent of p and m.
+        scaled_amplitude = np.sqrt( factorial(p)/factorial(m+p) )
+        if m != 0:
+            scaled_amplitude *= 2**.5
+        E0 = scaled_amplitude * a0 * m_e*c**2 * k0/e
+
+        # If no focal plane position is given, use z0
+        if zf is None:
+            zf = z0
+
+        # Store the parameters
+        self.p = p
+        self.m = m
+        self.laguerre_pm = genlaguerre(self.p, self.m) # Laguerre polynomial
+        self.k0 = k0
+        self.inv_zr = 1./zr
+        self.zf = zf
+        self.z0 = z0
+        self.E0x = E0 * np.cos(theta_pol)
+        self.E0y = E0 * np.sin(theta_pol)
+        self.w0 = waist
+        self.cep_phase = cep_phase
+        self.inv_ctau2 = 1./(c*tau)**2
+
+    def E_field( self, x, y, z, t ):
+        """
+        Return the electric field of the laser
+
+        Parameters:
+        -----------
+        x, y, z: ndarrays (meters)
+            The positions at which to calculate the profile (in the lab frame)
+
+        t: ndarray or float (seconds)
+            The time at which to calculate the profile (in the lab frame)
+
+        Returns:
+        --------
+        Ex, Ey: ndarrays of the same shape as x, y, z
+        """
+        # Diffraction factor, waist and Gouy phase
+        diffract_factor = 1. - 1j * ( z - self.zf ) * self.inv_zr
+        w = self.w0 * abs( diffract_factor )
+        psi = - np.angle( diffract_factor )
+        # Calculate the scaled radius and azimuthal angle
+        scaled_radius_squared = 2*( x**2 + y**2 ) / w**2
+        scaled_radius = np.sqrt( scaled_radius_squared )
+        theta = np.angle( x + 1.j*y )
+        # Calculate the argument of the complex exponential
+        exp_argument = 1j*self.cep_phase + 1j*self.k0*( c*t + self.z0 - z ) \
+            - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
+            - self.inv_ctau2 * ( c*t  + self.z0 - z )**2 \
+            # Additional Gouy phase and azimuthal phase for Laguerre-Gauss pulse
+            + 1.j*(2*self.p + self.m)*psi
+        # Get the transverse profile
+        profile = np.exp(exp_argument) / diffract_factor \
+                * scaled_radius**m * self.laguerre_pm(scaled_radius_squared) \
+                * np.cos( self.m*(theta-self.theta0) )
 
         # Get the projection along x and y, with the correct polarization
         Ex = self.E0x * profile

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -207,6 +207,7 @@ class LaguerreGaussLaser( object ):
         self.p = p
         self.m = m
         self.laguerre_pm = genlaguerre(self.p, self.m) # Laguerre polynomial
+        self.theta0 = theta0
         self.k0 = k0
         self.inv_zr = 1./zr
         self.zf = zf
@@ -245,12 +246,11 @@ class LaguerreGaussLaser( object ):
         exp_argument = 1j*self.cep_phase + 1j*self.k0*( c*t + self.z0 - z ) \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
             - self.inv_ctau2 * ( c*t  + self.z0 - z )**2 \
-            # Additional Gouy phase and azimuthal phase for Laguerre-Gauss pulse
-            + 1.j*(2*self.p + self.m)*psi
+            + 1.j*(2*self.p + self.m)*psi # *Additional* Gouy phase
         # Get the transverse profile
         profile = np.exp(exp_argument) / diffract_factor \
-                * scaled_radius**m * self.laguerre_pm(scaled_radius_squared) \
-                * np.cos( self.m*(theta-self.theta0) )
+            * scaled_radius**self.m * self.laguerre_pm(scaled_radius_squared) \
+            * np.cos( self.m*(theta-self.theta0) )
 
         # Get the projection along x and y, with the correct polarization
         Ex = self.E0x * profile

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -258,12 +258,8 @@ def propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
     # Get the analytical solution
     z_prop = c*dt*N_step*np.arange(N_diag)
     ZR = 0.5*k0*w0**2
-    if m in [1, 2]:
-        w_analytic = w0*np.sqrt( 1 + (z_prop-zf)**2/ZR**2 )
-        E_analytic = E0/( 1 + (z_prop-zf)**2/ZR**2 )**(1./2)
-    else : # zf is not implemented for the other modes
-        w_analytic = w0*np.sqrt( 1 + z_prop**2/ZR**2 )
-        E_analytic = E0/( 1 + z_prop**2/ZR**2 )**(1./2)
+    w_analytic = w0*np.sqrt( 1 + (z_prop-zf)**2/ZR**2 )
+    E_analytic = E0/( 1 + (z_prop-zf)**2/ZR**2 )**(1./2)
 
     # Either plot the results and check them manually
     if show is True:
@@ -331,9 +327,9 @@ def init_fields( sim, w, ctau, k0, z0, zf, E0, m=1 ) :
     # Create the relevant laser profile
     if m == 0:
         # Build a radially-polarized pulse from 2 Laguerre-Gauss profiles
-        profile = LaguerreGaussLaser( 0, 1, a0, w, tau, z0, zf=zf,
+        profile = LaguerreGaussLaser( 0, 1, 0.5*a0, w, tau, z0, zf=zf,
                     lambda0=lambda0, theta_pol=0., theta0=0. ) \
-                + LaguerreGaussLaser( 0, 1, a0, w, tau, z0, zf=zf,
+                + LaguerreGaussLaser( 0, 1, 0.5*a0, w, tau, z0, zf=zf,
                     lambda0=lambda0, theta_pol=np.pi/2, theta0=np.pi/2 )
     elif m == 1:
         profile = GaussianLaser( a0=a0, waist=w, tau=tau,

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -258,7 +258,7 @@ def propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
     # Get the analytical solution
     z_prop = c*dt*N_step*np.arange(N_diag)
     ZR = 0.5*k0*w0**2
-    if m == 1:
+    if m in [1, 2]:
         w_analytic = w0*np.sqrt( 1 + (z_prop-zf)**2/ZR**2 )
         E_analytic = E0/( 1 + (z_prop-zf)**2/ZR**2 )**(1./2)
     else : # zf is not implemented for the other modes
@@ -450,12 +450,13 @@ def fit_fields( fld, m ) :
     if m==1 :  # Gaussian profile
         fit_result = curve_fit(gaussian_transverse_profile, r,
                             laser_profile, p0=np.array([w0,E0]) )
+    else: # Annular profile, or Laguerre-Gaussian profile
+        fit_result = curve_fit(annular_transverse_profile, r,
+                            laser_profile, p0=np.array([w0,E0]) )
+    if m > 0:
         # Factor 2 on the amplitude, related to the factor 2
         # in the particle gather for the modes m > 0
         fit_result[0][1] = 2*fit_result[0][1]
-    elif m in [0,2]: # Annular profile, or Laguerre-Gaussian profile
-        fit_result = curve_fit(annular_transverse_profile, r,
-                            laser_profile, p0=np.array([w0,E0]) )
 
     return( fit_result[0] )
 

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -283,6 +283,7 @@ def propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
     # of w and E are close
     else:
         assert np.allclose( w, w_analytic, rtol=rtol )
+        assert np.allclose( E, E_analytic, rtol=5.e-3 )
         print('The simulation results agree with the theory to %e.' %rtol)
 
     # Return a dictionary of the results


### PR DESCRIPTION
**Please merge #172 first**

This pull request introduces the overloaded + operator for laser profiles. This is done by:
- Having a base class, which defines the `__add__` method, and from which all laser classes should inherit.
- Defining a new type of profile (`SummedProfile`) which is returned by the `__add__`method, and simply calls each of the profiles of the sum, and then adds the resulting fields.

The automated tests have been updated to take this profile into account.