### PR TITLE
Close #176 MKL FFT errors on Windows

### DIFF
--- a/fbpic/fields/spectral_transform/mkl_fft.py
+++ b/fbpic/fields/spectral_transform/mkl_fft.py
@@ -26,7 +26,7 @@ if sys.platform in ['linux', 'linux2']:
 elif sys.platform == 'darwin':
     mkl = ctypes.CDLL('libmkl_rt.dylib')
 elif sys.platform == 'win32':
-    mkl = ctypes.CDLL('libmkl_rt.dll')
+    mkl = ctypes.CDLL('mkl_rt.dll')
 else:
     raise ValueError('Unrecognized plateform: %s' %sys.platform)
 

--- a/fbpic/threading_utils.py
+++ b/fbpic/threading_utils.py
@@ -5,12 +5,14 @@
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines a set of generic functions for multithreaded CPU execution.
 """
-import os
+import os, sys
 import numpy as np
 from numba import njit
 
-# By default threading is enabled
+# By default threading is enabled, except on Windows (not supported by Numba)
 threading_enabled = True
+if sys.platform == 'win32':
+    threading_enabled = False
 
 # Check if the environment variable FBPIC_DISABLE_THREADING is set to 1
 # and in that case, disable threading

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     maintainer='Remi Lehe',
     maintainer_email='remi.lehe@normalesup.org',
     license='BSD-3-Clause-LBNL',
-    packages=find_packages('./'),
+    packages=find_packages('.'),
     tests_require=['pytest', 'matplotlib', 'openpmd_viewer'],
     cmdclass={'test': PyTest},
     install_requires=install_requires,


### PR DESCRIPTION
Although Windows is not the priority for fbpic, it might be good to have the code work there too, if it requires not too much effort. 

With the few changes of this PR, I was able to run the standard LWFA example. Note that I had to disable threading (I was getting an exception from Numba during JIT compilation, saying that Windows is not supported yet).