### PR TITLE
Fix checkpoints

### DIFF
--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -478,11 +478,6 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
             local_field = getattr( sim.fld.interp[m], field )
             local_field[ i_min_local:i_max_local, : ] += local_array
 
-    # For consistency and diagnostics, redeposit the charge and current
-    # of the full simulation (since the last step erased these quantities)
-    sim.deposit('rho_prev')
-    sim.deposit('J', exchange=True)
-
     print("Done.\n")
 
 

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -359,18 +359,6 @@ class Simulation(object):
                 progress_bar.time( i_step )
                 progress_bar.print_progress()
 
-            # Diagnostics
-            # -----------
-
-            # Run the diagnostics
-            # (E, B, rho, x are defined at time n; J, p at time n-1/2)
-            for diag in self.diags:
-                # Check if the diagnostic should be written at this iteration
-                # and write it, if it is the case.
-                # (If needed: bring rho/J from spectral space, where they
-                # were smoothed/corrected, and copy the data from the GPU.)
-                diag.write( self.iteration )
-
             # Particle exchanges to prepare for this iteration
             # ------------------------------------------------
 
@@ -396,6 +384,23 @@ class Simulation(object):
                 # otherwise rho_prev is obtained from the previous iteration.
                 # Note that the guard cells of rho are never exchanged.)
                 self.deposit('rho_prev', exchange=False)
+
+            # For the field diagnostics of the first step: deposit J
+            # (Note however that this is not the *corrected* current)
+            if i_step == 0:
+                self.deposit('J', exchange=True)
+
+            # Diagnostics
+            # -----------
+
+            # Run the diagnostics
+            # (E, B, rho, x are defined at time n; J, p at time n-1/2)
+            for diag in self.diags:
+                # Check if the diagnostic should be written at this iteration
+                # and write it, if it is the case.
+                # (If needed: bring rho/J from spectral space, where they
+                # were smoothed/corrected, and copy the data from the GPU.)
+                diag.write( self.iteration )
 
             # Main PIC iteration
             # ------------------

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -252,8 +252,7 @@ def load_species( species, name, ts, iteration, comm ):
     species.ux, species.uy, species.uz = ts.get_particle(
         ['ux', 'uy', 'uz' ], iteration=iteration, species=name )
     # Get the weight (multiply it by the charge to conform with FBPIC)
-    w, = ts.get_particle( ['w'], iteration=iteration, species=name )
-    species.w = species.q * w
+    species.w, = ts.get_particle( ['w'], iteration=iteration, species=name )
     # Get the inverse gamma
     species.inv_gamma = 1./np.sqrt(
         1 + species.ux**2 + species.uy**2 + species.uz**2 )


### PR DESCRIPTION
This is a reimplementation of PR #162, decided after off-line discussion with @MKirchen.

From the original PR:

> The checkpoint / restart feature was broken:
> 
> - In load_species the weights were multiplied by the charge q. This should not be done anymore.
> - If a diag_period was at the same time as a checkpoint_period, a wrong diagnostic was written at the first step (i_step == 0) after the restart (wrong charge/currents). With this PR, a check is  performed based on a new attribute (is_restarted) of the Simulation object.

The current PR fixes the second issue by swapping the order of the diagnostics and the particle exchange (particle exchange first, then diagnostics). Since the particle exchange phase is always followed by a deposition of charge (including immediately after a restart, see the remark on `i_step==0`), the charge will now always be available for the diagnostics. In addition, I added a similar line for the currents (only done when `i_step==0`, not for each particle exchange).

As a side-effect, note that this also takes care of the fact that the charge/currents were not deposited on the very first diagnostics (even without restart).