### PR TITLE
Refactor the calculation of domain boundaries

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -939,11 +939,11 @@ class BoundaryCommunicator(object):
             gathered_array = None
 
         # Select the physical region of the local box
-        Nz_local, iz_start_domain = self.get_Nz_and_iz(
+        Nz_local, iz_start_local_domain = self.get_Nz_and_iz(
             local=True, with_damp=False, with_guard=False, rank=self.rank )
-        _, iz_start_array = self.get_Nz_and_iz(
+        _, iz_start_local_array = self.get_Nz_and_iz(
             local=True, with_damp=True, with_guard=True, rank=self.rank )
-        iz_in_array = iz_start_domain - iz_start_array
+        iz_in_array = iz_start_local_domain - iz_start_local_array
         local_array = array[ iz_in_array:iz_in_array+Nz_local, : ]
 
         # Then send the arrays

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -827,7 +827,7 @@ class BoundaryCommunicator(object):
         if self.rank == root:
             Nz_global, iz_start_global = self.get_Nz_and_iz( 
                 local=False, with_guard=False, with_damp=False )
-            zmin_global, zmax_global = self.get_zmin( 
+            zmin_global, zmax_global = self.get_zmin_zmax( 
                 local=False, with_guard=False, with_damp=False )
             # Create new grid array that contains cell positions in z
             z = zmin_global + \

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -825,21 +825,16 @@ class BoundaryCommunicator(object):
         """
         # Calculate global edges of the simulation box on root process
         if self.rank == root:
-            n_remove = self.n_guard
-            if self.left_proc is None:
-                # Add damp cells if root process is rank 0
-                n_remove += self.n_damp
-            # Calculate the global zmin without the guard (and damp) region
-            zmin_global = grid.zmin + self.dz * \
-                    (n_remove - self.rank*self.Nz_domain)
+            Nz_global, iz_start_global = self.get_Nz_and_iz( 
+                local=False, with_guard=False, with_damp=False )
+            zmin_global, zmax_global = self.get_zmin( 
+                local=False, with_guard=False, with_damp=False )
             # Create new grid array that contains cell positions in z
-            Nz_global, iz_start_global = self.get_Nz_and_iz( local=False,
-                                            with_guard=False, with_damp=False )
             z = zmin_global + \
                 self.dz*( 0.5 + iz_start_global + np.arange(Nz_global) )
             # Initialize new InterpolationGrid object that
             # is used to gather the global grid data
-            gathered_grid = InterpolationGrid(z=z, r=grid.r, m=grid.m )
+            gathered_grid = InterpolationGrid(z=z, r=grid.r, m=grid.m)
         else:
             # Other processes do not need to initialize new InterpolationGrid
             gathered_grid = None

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -825,9 +825,9 @@ class BoundaryCommunicator(object):
         """
         # Calculate global edges of the simulation box on root process
         if self.rank == root:
-            Nz_global, iz_start_global = self.get_Nz_and_iz( 
+            Nz_global, iz_start_global = self.get_Nz_and_iz(
                 local=False, with_guard=False, with_damp=False )
-            zmin_global, zmax_global = self.get_zmin_zmax( 
+            zmin_global, zmax_global = self.get_zmin_zmax(
                 local=False, with_guard=False, with_damp=False )
             # Create new grid array that contains cell positions in z
             z = zmin_global + \
@@ -882,9 +882,12 @@ class BoundaryCommunicator(object):
             gathered_array = None
 
         # Select the physical region of the local box
-        Nz_local, iz_start_local = self.get_Nz_and_iz(
+        Nz_local, iz_start_domain = self.get_Nz_and_iz(
             local=True, with_damp=False, with_guard=False, rank=self.rank )
-        local_array = array[ iz_start_local:iz_start_local+Nz_local , : ]
+        _, iz_start_array = self.get_Nz_and_iz(
+            local=True, with_damp=True, with_guard=True, rank=self.rank )
+        iz_in_array = iz_start_domain - iz_start_array
+        local_array = array[ iz_in_array:iz_in_array+Nz_local, : ]
 
         # Then send the arrays
         if self.size > 1:
@@ -922,7 +925,7 @@ class BoundaryCommunicator(object):
         Returns:
         ---------
         local_array: 2darray (local grid array)
-            A local array that contains the local simulation data
+            A local array that contains the data of the local physical domain
         """
         # Create empty array having the shape of the local domain
         Nz_local, iz_start_local = self.get_Nz_and_iz(

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -343,7 +343,8 @@ def add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
         Propagation direction of the beam.
     """
     # Select the particles that are in the local subdomain
-    zmin, zmax = sim.comm.get_zmin_zmax( sim.fld, local=True )
+    zmin, zmax = sim.comm.get_zmin_zmax(
+        local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
     selected = (z >= zmin) & (z < zmax)
     x = x[selected]
     y = y[selected]
@@ -435,7 +436,8 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
     # erase the pre-existing E and B field in sim.fld
     global_Nz, _ = sim.comm.get_Nz_and_iz(
                     local=False, with_guard=False, with_damp=False )
-    global_zmin, global_zmax = sim.comm.get_zmin_zmax(sim.fld, local=False)
+    global_zmin, global_zmax = sim.comm.get_zmin_zmax(
+                    local=False, with_guard=False, with_damp=False )
     global_fld = Fields( global_Nz, global_zmax,
             sim.fld.Nr, sim.fld.rmax, sim.fld.Nm, sim.fld.dt,
             zmin=global_zmin, n_order=sim.fld.n_order, use_cuda=False)

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -477,7 +477,7 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
             local_array = sim.comm.scatter_grid_array( global_array )
             # Add it to the fields of sim.fld
             local_field = getattr( sim.fld.interp[m], field )
-            local_field[ i_min_local:i_max_local, : ] += local_array
+            local_field[ iz_local:iz_local+Nz_local, : ] += local_array
 
     # For consistency and diagnostics, redeposit the charge and current
     # of the full simulation (since the last step erased these quantities)

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -467,11 +467,11 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
     # Communicate the results from proc 0 to the other procs
     # and add it to the interpolation grid of sim.fld.
     # - First find the indices at which the fields should be added
-    Nz_local, iz_local_domain = sim.comm.get_Nz_and_iz(
+    Nz_local, iz_start_local_domain = sim.comm.get_Nz_and_iz(
         local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
-    _, iz_local_array = sim.comm.get_Nz_and_iz(
+    _, iz_start_local_array = sim.comm.get_Nz_and_iz(
         local=True, with_damp=True, with_guard=True, rank=sim.comm.rank )
-    iz_in_array = iz_local_domain - iz_local_array
+    iz_in_array = iz_start_local_domain - iz_start_local_array
     # - Then loop over modes and fields
     for m in range(sim.fld.Nm):
         for field in ['Er', 'Et', 'Ez', 'Br', 'Bt', 'Bz']:

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -433,7 +433,8 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
     # (Space-charge calculation is a global operation)
     # Note: in the single-proc case, this is also useful in order not to
     # erase the pre-existing E and B field in sim.fld
-    global_Nz = sim.comm.Nz
+    global_Nz, _ = sim.comm.get_Nz_and_iz(
+                    local=False, with_guard=False, with_damp=False )
     global_zmin, global_zmax = sim.comm.get_zmin_zmax(sim.fld, local=False)
     global_fld = Fields( global_Nz, global_zmax,
             sim.fld.Nr, sim.fld.rmax, sim.fld.Nm, sim.fld.dt,

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -467,8 +467,11 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
     # Communicate the results from proc 0 to the other procs
     # and add it to the interpolation grid of sim.fld.
     # - First find the indices at which the fields should be added
-    Nz_local, iz_local = sim.comm.get_Nz_and_iz(
+    Nz_local, iz_local_domain = sim.comm.get_Nz_and_iz(
         local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
+    _, iz_local_array = sim.comm.get_Nz_and_iz(
+        local=True, with_damp=True, with_guard=True, rank=sim.comm.rank )
+    iz_in_array = iz_local_domain - iz_local_array
     # - Then loop over modes and fields
     for m in range(sim.fld.Nm):
         for field in ['Er', 'Et', 'Ez', 'Br', 'Bt', 'Bz']:
@@ -477,7 +480,7 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
             local_array = sim.comm.scatter_grid_array( global_array )
             # Add it to the fields of sim.fld
             local_field = getattr( sim.fld.interp[m], field )
-            local_field[ iz_local:iz_local+Nz_local, : ] += local_array
+            local_field[ iz_in_arrayl:iz_in_array+Nz_local, : ] += local_array
 
     # For consistency and diagnostics, redeposit the charge and current
     # of the full simulation (since the last step erased these quantities)

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -467,10 +467,8 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
     # Communicate the results from proc 0 to the other procs
     # and add it to the interpolation grid of sim.fld.
     # - First find the indices at which the fields should be added
-    i_min_local = sim.comm.n_guard
-    if sim.comm.left_proc is None:
-        i_min_local += sim.comm.n_damp
-    i_max_local = i_min_local + sim.comm.Nz_domain
+    Nz_local, iz_local = sim.comm.get_Nz_and_iz(
+        local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
     # - Then loop over modes and fields
     for m in range(sim.fld.Nm):
         for field in ['Er', 'Et', 'Ez', 'Br', 'Bt', 'Bz']:

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -480,7 +480,7 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
             local_array = sim.comm.scatter_grid_array( global_array )
             # Add it to the fields of sim.fld
             local_field = getattr( sim.fld.interp[m], field )
-            local_field[ iz_in_arrayl:iz_in_array+Nz_local, : ] += local_array
+            local_field[ iz_in_array:iz_in_array+Nz_local, : ] += local_array
 
     # For consistency and diagnostics, redeposit the charge and current
     # of the full simulation (since the last step erased these quantities)

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -232,17 +232,8 @@ class LaserAntenna( object ):
         # Check if baseline_z is in the local physical domain
         # (This prevents out-of-bounds errors, and prevents 2 neighboring
         # processors from simultaneously depositing the laser antenna)
-        zmin_local = fld.interp[0].zmin
-        zmax_local = fld.interp[0].zmax
-        # If a communicator is provided, remove the guard cells
-        if comm is not None:
-            dz = fld.interp[0].dz
-            zmin_local += dz*comm.n_guard
-            if comm.left_proc is None:
-                zmin_local += dz*comm.n_damp
-            zmax_local -= dz*comm.n_guard
-            if comm.right_proc is None:
-                zmax_local -= dz*comm.n_damp
+        zmin_local, zmax_local = sim.comm.get_zmin_zmax(
+            local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
         # Interrupt this function if the antenna is not in the local domain
         z_antenna = self.baseline_z[0]
         if (z_antenna < zmin_local) or (z_antenna >= zmax_local):

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -232,8 +232,8 @@ class LaserAntenna( object ):
         # Check if baseline_z is in the local physical domain
         # (This prevents out-of-bounds errors, and prevents 2 neighboring
         # processors from simultaneously depositing the laser antenna)
-        zmin_local, zmax_local = sim.comm.get_zmin_zmax(
-            local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
+        zmin_local, zmax_local = comm.get_zmin_zmax(
+            local=True, with_damp=False, with_guard=False, rank=comm.rank )
         # Interrupt this function if the antenna is not in the local domain
         z_antenna = self.baseline_z[0]
         if (z_antenna < zmin_local) or (z_antenna >= zmax_local):

--- a/fbpic/lpa_utils/laser/direct_injection.py
+++ b/fbpic/lpa_utils/laser/direct_injection.py
@@ -81,11 +81,11 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
     # Communicate the results from proc 0 to the other procs
     # and add it to the interpolation grid of sim.fld.
     # - First find the indices at which the fields should be added
-    Nz_local, iz_local_domain = sim.comm.get_Nz_and_iz(
+    Nz_local, iz_start_local_domain = sim.comm.get_Nz_and_iz(
         local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
-    _, iz_local_array = sim.comm.get_Nz_and_iz(
+    _, iz_start_local_array = sim.comm.get_Nz_and_iz(
         local=True, with_damp=True, with_guard=True, rank=sim.comm.rank )
-    iz_in_array = iz_local_domain - iz_local_array
+    iz_in_array = iz_start_local_domain - iz_start_local_array
     # - Then loop over modes and fields
     for m in range(sim.fld.Nm):
         for field in ['Er', 'Et', 'Ez', 'Br', 'Bt', 'Bz']:

--- a/fbpic/lpa_utils/laser/direct_injection.py
+++ b/fbpic/lpa_utils/laser/direct_injection.py
@@ -81,10 +81,8 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
     # Communicate the results from proc 0 to the other procs
     # and add it to the interpolation grid of sim.fld.
     # - First find the indices at which the fields should be added
-    i_min_local = sim.comm.n_guard
-    if sim.comm.left_proc is None:
-        i_min_local += sim.comm.n_damp
-    i_max_local = i_min_local + sim.comm.Nz_domain
+    Nz_local, iz_local = sim.comm.get_Nz_and_iz(
+        local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
     # - Then loop over modes and fields
     for m in range(sim.fld.Nm):
         for field in ['Er', 'Et', 'Ez', 'Br', 'Bt', 'Bz']:
@@ -93,7 +91,7 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
             local_array = sim.comm.scatter_grid_array( global_array )
             # Add it to the fields of sim.fld
             local_field = getattr( sim.fld.interp[m], field )
-            local_field[ i_min_local:i_max_local, : ] += local_array
+            local_field[ iz_local:iz_local+Nz_local, : ] += local_array
 
     print("Done.\n")
 

--- a/fbpic/lpa_utils/laser/direct_injection.py
+++ b/fbpic/lpa_utils/laser/direct_injection.py
@@ -55,7 +55,8 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
     # (Calculating the self-consistent Ez and B is a global operation)
     global_Nz, _ = sim.comm.get_Nz_and_iz(
                     local=False, with_guard=False, with_damp=False )
-    global_zmin, global_zmax = sim.comm.get_zmin_zmax(sim.fld, local=False)
+    global_zmin, global_zmax = sim.comm.get_zmin_zmax(
+                    local=False, with_guard=False, with_damp=False )
     global_fld = Fields( global_Nz, global_zmax,
             sim.fld.Nr, sim.fld.rmax, sim.fld.Nm, sim.fld.dt,
             zmin=global_zmin, n_order=sim.fld.n_order, use_cuda=False)

--- a/fbpic/lpa_utils/laser/direct_injection.py
+++ b/fbpic/lpa_utils/laser/direct_injection.py
@@ -53,7 +53,8 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
 
     # Create a global field object across all subdomains, and copy the fields
     # (Calculating the self-consistent Ez and B is a global operation)
-    global_Nz = sim.comm.Nz
+    global_Nz, _ = sim.comm.get_Nz_and_iz(
+                    local=False, with_guard=False, with_damp=False )
     global_zmin, global_zmax = sim.comm.get_zmin_zmax(sim.fld, local=False)
     global_fld = Fields( global_Nz, global_zmax,
             sim.fld.Nr, sim.fld.rmax, sim.fld.Nm, sim.fld.dt,

--- a/fbpic/lpa_utils/laser/direct_injection.py
+++ b/fbpic/lpa_utils/laser/direct_injection.py
@@ -81,8 +81,11 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
     # Communicate the results from proc 0 to the other procs
     # and add it to the interpolation grid of sim.fld.
     # - First find the indices at which the fields should be added
-    Nz_local, iz_local = sim.comm.get_Nz_and_iz(
+    Nz_local, iz_local_domain = sim.comm.get_Nz_and_iz(
         local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
+    _, iz_local_array = sim.comm.get_Nz_and_iz(
+        local=True, with_damp=True, with_guard=True, rank=sim.comm.rank )
+    iz_in_array = iz_local_domain - iz_local_array
     # - Then loop over modes and fields
     for m in range(sim.fld.Nm):
         for field in ['Er', 'Et', 'Ez', 'Br', 'Bt', 'Bz']:
@@ -91,7 +94,7 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
             local_array = sim.comm.scatter_grid_array( global_array )
             # Add it to the fields of sim.fld
             local_field = getattr( sim.fld.interp[m], field )
-            local_field[ iz_local:iz_local+Nz_local, : ] += local_array
+            local_field[ iz_in_array:iz_in_array+Nz_local, : ] += local_array
 
     print("Done.\n")
 

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -233,7 +233,7 @@ class Simulation(object):
             use_all_mpi_ranks )
         # Modify domain region
         zmin, zmax, p_zmin, p_zmax, Nz = \
-              self.comm.divide_into_domain(zmin, zmax, p_zmin, p_zmax)
+              self.comm.divide_into_domain( p_zmin, p_zmax )
 
         # Initialize the field structure
         self.fld = Fields( Nz, zmax, Nr, rmax, Nm, dt,
@@ -585,6 +585,8 @@ class Simulation(object):
         """
         # Calculate shift distance over a half timestep
         shift_distance = self.v_comoving * 0.5 * self.dt
+        # Shift the boundaries of the global domain
+        self.comm.shift_global_domain_positions( shift_distance )
         # Shift the boundaries of the grid
         for m in range(self.fld.Nm):
             self.fld.interp[m].zmin += shift_distance

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -151,8 +151,8 @@ class BoostedFieldDiagnostic(FieldDiagnostic):
             zmax_boost = self.fld.interp[0].zmax
         else:
             # If a communicator is provided, remove guard and damp cells
-            zmin_boost, zmax_boost = \
-                self.comm.get_zmin_zmax(self.fld, local=True)
+            zmin_boost, zmax_boost = self.comm.get_zmin_zmax(
+                local=True, with_damp=False, with_guard=False, rank=self.rank )
 
         # Extract the current time in the boosted frame
         time = iteration * self.fld.dt

--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -97,7 +97,8 @@ class FieldDiagnostic(OpenPMDDiagnostic):
             Nz = self.fld.interp[0].Nz
         else:
             zmin, _ = self.comm.get_zmin_zmax( self.fld, local=False )
-            Nz = self.comm.Nz
+            Nz = self.comm.get_Nz_and_iz(
+                    local=False, with_damp=False, with_guard=False )
 
         # Create the file with these attributes
         filename = "data%08d.h5" %iteration

--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -96,8 +96,9 @@ class FieldDiagnostic(OpenPMDDiagnostic):
             zmin = self.fld.interp[0].zmin
             Nz = self.fld.interp[0].Nz
         else:
-            zmin, _ = self.comm.get_zmin_zmax( self.fld, local=False )
-            Nz = self.comm.get_Nz_and_iz(
+            zmin, _ = self.comm.get_zmin_zmax(
+                    local=False, with_damp=False, with_guard=False )
+            Nz, _ = self.comm.get_Nz_and_iz(
                     local=False, with_damp=False, with_guard=False )
 
         # Create the file with these attributes


### PR DESCRIPTION
The code related to the size/boundaries of local and global domains is currently somewhat messy:
- There are many redundant variables stored inside the `BoundaryCommunicator` object (`Nz_domain_procs`, `Nz_domain`, `Nz_enlarged_procs`, `Nz_enlarged`, `Nz`). Also, it is not always clear whether these quantities include guard cells and/or damp cells, and whether they apply to the local or global domain.
- The position of local/global boundaries are recalculated several times in different places of the codes. This is redundant, and also complicates/lengthens parts of the code that are not directly related to domain decomposition.
- The two above remarks make it hard to change the code, if at some point we want to change the domain decomposition (e.g. to have better load-balancing)

Instead, this PR introduces two methods of the `BoundaryCommunicator` (`get_Nz_and_iz`, `get_zmin_zmax` ; see docstrings in the code below for a detailed explanation of what they do) which are used in the rest of the code. In particular, `get_Nz_and_iz` is the **single** place where the domain decomposition is defined, and should be principle be the only thing to change, if we change the distribution of cells between processors.

Also, these two new methods make it very clear whether the damp/guard are included and whether the domain considered is local or global.

Note that I had to add a new internal variable `_zmin_global_domain` in the `BoundaryCommunicator` object (which records the lower edge of the box ; and is, unfortunately, partially redundant with the `zmin` of `InterpolationGrid` ). This variable needs to be updated when the moving window moves, and when using the Galilean frame, which I did.