### PR TITLE
Initialize laser field in the damp cells

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -909,7 +909,7 @@ class BoundaryCommunicator(object):
         # Return the gathered grid
         return(gathered_grid)
 
-    def gather_grid_array(self, array, root=0):
+    def gather_grid_array(self, array, root=0, with_damp=False):
         """
         Gather a grid array on the root process by using the
         mpi4py routine Gatherv, that gathers arbitrary shape arrays
@@ -918,10 +918,13 @@ class BoundaryCommunicator(object):
         Parameter:
         -----------
         array: 2darray (grid array)
-            A grid array of the local domain
+            The local grid of the current MPI rank (with guard and damp cells.)
 
         root: int, optional
             Process that gathers the data
+
+        with_damp: bool, optional
+            Whether to include the damp cells in the gathered array.
 
         Returns:
         ---------
@@ -965,7 +968,7 @@ class BoundaryCommunicator(object):
             return(gathered_array)
 
 
-    def scatter_grid_array(self, array, root = 0):
+    def scatter_grid_array(self, array, root=0, with_damp=False):
         """
         Scatter an array that has the size of the global physical domain
         and is defined on the root process, into local arrays on each processes

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -993,10 +993,11 @@ class BoundaryCommunicator(object):
             A local array that contains the data of domain (without guard
             cells, but with damp cells if `with_damp` is True)
         """
-        # Check that the input array has the right size
+        # Get the global starting index, and the size of `array`
         Nz_global, iz_start_global = self.get_Nz_and_iz(
             local=False, with_damp=with_damp, with_guard=False )
-        assert array.shape[0] == Nz_global
+        if array is not None:
+            assert array.shape[0] == Nz_global
 
         # Create empty array having the shape of the local domain
         Nz_local, iz_start_local = self.get_Nz_and_iz(

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -435,9 +435,9 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
     # Note: in the single-proc case, this is also useful in order not to
     # erase the pre-existing E and B field in sim.fld
     global_Nz, _ = sim.comm.get_Nz_and_iz(
-                    local=False, with_guard=False, with_damp=False )
+                    local=False, with_damp=True, with_guard=False )
     global_zmin, global_zmax = sim.comm.get_zmin_zmax(
-                    local=False, with_guard=False, with_damp=False )
+                    local=False, with_damp=True, with_guard=False )
     global_fld = Fields( global_Nz, global_zmax,
             sim.fld.Nr, sim.fld.rmax, sim.fld.Nm, sim.fld.dt,
             zmin=global_zmin, n_order=sim.fld.n_order, use_cuda=False)
@@ -445,7 +445,8 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
     for m in range(sim.fld.Nm):
         for field in ['Jr', 'Jt', 'Jz', 'rho']:
             local_array = getattr( sim.fld.interp[m], field )
-            gathered_array = sim.comm.gather_grid_array( local_array )
+            gathered_array = sim.comm.gather_grid_array(
+                                            local_array, with_damp=True )
             setattr( global_fld.interp[m], field, gathered_array )
 
     # Calculate the space-charge fields on the global grid
@@ -468,7 +469,7 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
     # and add it to the interpolation grid of sim.fld.
     # - First find the indices at which the fields should be added
     Nz_local, iz_start_local_domain = sim.comm.get_Nz_and_iz(
-        local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
+        local=True, with_damp=True, with_guard=False, rank=sim.comm.rank )
     _, iz_start_local_array = sim.comm.get_Nz_and_iz(
         local=True, with_damp=True, with_guard=True, rank=sim.comm.rank )
     iz_in_array = iz_start_local_domain - iz_start_local_array
@@ -477,7 +478,8 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
         for field in ['Er', 'Et', 'Ez', 'Br', 'Bt', 'Bz']:
             # Get the local result from proc 0
             global_array = getattr( global_fld.interp[m], field )
-            local_array = sim.comm.scatter_grid_array( global_array )
+            local_array = sim.comm.scatter_grid_array(
+                                    global_array, with_damp=True )
             # Add it to the fields of sim.fld
             local_field = getattr( sim.fld.interp[m], field )
             local_field[ iz_in_array:iz_in_array+Nz_local, : ] += local_array


### PR DESCRIPTION
PR #150 introduced a more general and self-consistent way of initializing the laser, but it also stopped initializing the fields in the damp cells. (With PR #150, the field in the damp cells is zero, whereas it was not the case before.)

However, initializing the fields to 0 in the damp cells creates a sharp discontinuity between the last physical cell and the first damp cell. This discontinuity may produce low-amplitude spurious fields, when evolved with the Maxwell solver. For this reason, the current PR modifies the initialization of the laser so that the damp cells are initialized as well. As can be seen below, this removes the low-amplitude spurious field. (Note that the colorscale is strongly saturated for the laser pulse itself, so as to show the low-amplitude spurious field.)

![image2 001](https://user-images.githubusercontent.com/6685781/34470743-217cf1e6-eeed-11e7-8142-14d24bbfcf0d.png)


In practice, the changes of this PR essentially consist in modifying the function `gather_grid` and `scatter_grid` so that they can optionally include the damp cells, and then using this option when initializing the laser fields (and space-charge fields). These changes are made easier by the refactoring of PR #179.



 