### PR TITLE
Reduce duplication in gathering kernels by using more elementary functions

### DIFF
--- a/fbpic/particles/gathering/cuda_methods.py
+++ b/fbpic/particles/gathering/cuda_methods.py
@@ -9,9 +9,12 @@ on the GPU using CUDA.
 from numba import cuda, float64, int64
 import math
 # Import inline functions
-from .inline_functions import add_linear_gather_for_mode
+from .inline_functions import \
+    add_linear_gather_for_mode, add_cubic_gather_for_mode
 # Compile the inline functions for GPU
 add_linear_gather_for_mode = cuda.jit( add_linear_gather_for_mode,
+                                        device=True, inline=True )
+add_cubic_gather_for_mode = cuda.jit( add_cubic_gather_for_mode,
                                         device=True, inline=True )
 
 # -----------------------
@@ -167,7 +170,7 @@ def gather_field_gpu_linear(x, y, z,
         Ez[i] = Fz
 
         # B-Field
-        # ----------------------------
+        # -------
         # Clear the placeholders for the
         # gathered field for each coordinate
         Fr = 0.
@@ -313,131 +316,39 @@ def gather_field_gpu_cubic(x, y, z,
                 ir[index_r] = Nr - 1
 
         # E-Field
-        # ----------------------------
-        # Define the initial placeholders for the
-        # gathered field for each coordinate
+        # -------
         Fr = 0.
         Ft = 0.
         Fz = 0.
-
-        # Mode 0
-        # ----------------------------
-        # Create temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-        # Add the fields for mode 0
-        for index_r in range(4):
-            for index_z in range(4):
-                Fr_m += Sz[index_z]*Sr[index_r]*Er_m0[iz[index_z], ir[index_r]]
-                Ft_m += Sz[index_z]*Sr[index_r]*Et_m0[iz[index_z], ir[index_r]]
-                if Sz[index_z]*Sr[index_r] < 0:
-                    Fz_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                        Ez_m0[iz[index_z], ir[index_r]]
-                else:
-                    Fz_m += Sz[index_z]*Sr[index_r]* \
-                        Ez_m0[iz[index_z], ir[index_r]]
-
-        Fr += (Fr_m*exptheta_m0).real
-        Ft += (Ft_m*exptheta_m0).real
-        Fz += (Fz_m*exptheta_m0).real
-
-        # Mode 1
-        # ----------------------------
-        # Clear the temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-        # Add the fields for mode 1
-        for index_r in range(4):
-            for index_z in range(4):
-                if Sz[index_z]*Sr[index_r] < 0:
-                    Fr_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                                Er_m1[iz[index_z], ir[index_r]]
-                    Ft_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                                Et_m1[iz[index_z], ir[index_r]]
-                else:
-                    Fr_m += Sz[index_z]*Sr[index_r]* \
-                                Er_m1[iz[index_z], ir[index_r]]
-                    Ft_m += Sz[index_z]*Sr[index_r]* \
-                                Et_m1[iz[index_z], ir[index_r]]
-                Fz_m += Sz[index_z]*Sr[index_r]*Ez_m1[iz[index_z], ir[index_r]]
-
-        # Add the fields from the mode 1
-        Fr += 2*(Fr_m*exptheta_m1).real
-        Ft += 2*(Ft_m*exptheta_m1).real
-        Fz += 2*(Fz_m*exptheta_m1).real
-
+        # Add contribution from mode 0
+        Fr, Ft, Fz = add_cubic_gather_for_mode( 0,
+            Fr, Ft, Fz, exptheta_m0, Er_m0, Et_m0, Ez_m0,
+            ir, iz, Sr, Sz )
+        # Add contribution from mode 1
+        Fr, Ft, Fz = add_cubic_gather_for_mode( 1,
+            Fr, Ft, Fz, exptheta_m1, Er_m1, Et_m1, Ez_m1,
+            ir, iz, Sr, Sz )
         # Convert to Cartesian coordinates
         # and write to particle field arrays
-        Ex[i] = (cos*Fr - sin*Ft)
-        Ey[i] = (sin*Fr + cos*Ft)
+        Ex[i] = cos*Fr - sin*Ft
+        Ey[i] = sin*Fr + cos*Ft
         Ez[i] = Fz
 
         # B-Field
-        # ----------------------------
+        # -------
         # Clear the placeholders for the
         # gathered field for each coordinate
         Fr = 0.
         Ft = 0.
         Fz = 0.
-
-        # Mode 0
-        # ----------------------------
-        # Create temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-        # Add the fields for mode 0
-        for index_r in range(4):
-            for index_z in range(4):
-                Fr_m += Sz[index_z]*Sr[index_r]* \
-                    Br_m0[iz[index_z], ir[index_r]]
-                Ft_m += Sz[index_z]*Sr[index_r]* \
-                    Bt_m0[iz[index_z], ir[index_r]]
-                if Sz[index_z]*Sr[index_r] < 0:
-                    Fz_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                        Bz_m0[iz[index_z], ir[index_r]]
-                else:
-                    Fz_m += Sz[index_z]*Sr[index_r]* \
-                        Bz_m0[iz[index_z], ir[index_r]]
-
-        # Add the fields from the mode 0
-        Fr += (Fr_m*exptheta_m0).real
-        Ft += (Ft_m*exptheta_m0).real
-        Fz += (Fz_m*exptheta_m0).real
-
-        # Mode 1
-        # ----------------------------
-        # Clear the temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-
-        # Add the fields for mode 1
-        for index_r in range(4):
-            for index_z in range(4):
-                if Sz[index_z]*Sr[index_r] < 0:
-                    Fr_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                        Br_m1[iz[index_z], ir[index_r]]
-                    Ft_m += (-1.)*Sz[index_z]*Sr[index_r]* \
-                        Bt_m1[iz[index_z], ir[index_r]]
-                else:
-                    Fr_m += Sz[index_z]*Sr[index_r]* \
-                        Br_m1[iz[index_z], ir[index_r]]
-                    Ft_m += Sz[index_z]*Sr[index_r]* \
-                        Bt_m1[iz[index_z], ir[index_r]]
-                Fz_m += Sz[index_z]*Sr[index_r]*Bz_m1[iz[index_z], ir[index_r]]
-
-        # Add the fields from the mode 1
-        Fr += 2*(Fr_m*exptheta_m1).real
-        Ft += 2*(Ft_m*exptheta_m1).real
-        Fz += 2*(Fz_m*exptheta_m1).real
-
+        # Add contribution from mode 0
+        Fr, Ft, Fz =  add_cubic_gather_for_mode( 0,
+            Fr, Ft, Fz, exptheta_m0, Br_m0, Bt_m0, Bz_m0,
+            ir, iz, Sr, Sz )
+        # Add contribution from mode 1
+        Fr, Ft, Fz =  add_cubic_gather_for_mode( 1,
+            Fr, Ft, Fz, exptheta_m1, Br_m1, Bt_m1, Bz_m1,
+            ir, iz, Sr, Sz )
         # Convert to Cartesian coordinates
         # and write to particle field arrays
         Bx[i] = cos*Fr - sin*Ft

--- a/fbpic/particles/gathering/cuda_methods.py
+++ b/fbpic/particles/gathering/cuda_methods.py
@@ -283,24 +283,28 @@ def gather_field_gpu_cubic(x, y, z,
         # Calculate the shape factors
         ir = cuda.local.array((4,), dtype=int64)
         Sr = cuda.local.array((4,), dtype=float64)
-        ir[0] = int64(math.floor(r_cell)) - 1
+        ir_lowest = int64(math.floor(r_cell)) - 1
+        ir[0] = ir_lowest
         ir[1] = ir[0] + 1
         ir[2] = ir[1] + 1
         ir[3] = ir[2] + 1
-        Sr[0] = -1./6. * ((r_cell-ir[0])-2)**3
-        Sr[1] = 1./6. * (3*((r_cell-ir[1])**3)-6*((r_cell-ir[1])**2)+4)
-        Sr[2] = 1./6. * (3*((ir[2]-r_cell)**3)-6*((ir[2]-r_cell)**2)+4)
-        Sr[3] = -1./6. * ((ir[3]-r_cell)-2)**3
+        r_local = r_cell-ir_lowest
+        Sr[0] = -1./6. * (r_local-2.)**3
+        Sr[1] = 1./6. * (3.*(r_local-1.)**3 - 6.*(r_local-1.)**2 + 4.)
+        Sr[2] = 1./6. * (3.*(2.-r_local)**3 - 6.*(2.-r_local)**2 + 4.)
+        Sr[3] = -1./6. * (1.-r_local)**3
         iz = cuda.local.array((4,), dtype=int64)
         Sz = cuda.local.array((4,), dtype=float64)
-        iz[0] = int64(math.floor(z_cell)) - 1
+        iz_lowest = int64(math.floor(z_cell)) - 1
+        iz[0] = iz_lowest
         iz[1] = iz[0] + 1
         iz[2] = iz[1] + 1
         iz[3] = iz[2] + 1
-        Sz[0] = -1./6. * ((z_cell-iz[0])-2)**3
-        Sz[1] = 1./6. * (3*((z_cell-iz[1])**3)-6*((z_cell-iz[1])**2)+4)
-        Sz[2] = 1./6. * (3*((iz[2]-z_cell)**3)-6*((iz[2]-z_cell)**2)+4)
-        Sz[3] = -1./6. * ((iz[3]-z_cell)-2)**3
+        z_local = z_cell-iz_lowest
+        Sz[0] = -1./6. * (z_local-2.)**3
+        Sz[1] = 1./6. * (3.*(z_local-1.)**3 - 6.*(z_local-1.)**2 + 4.)
+        Sz[2] = 1./6. * (3.*(2.-z_local)**3 - 6.*(2.-z_local)**2 + 4.)
+        Sz[3] = -1./6. * (1.-z_local)**3
         # Lower and upper periodic boundary for z
         for index_z in range(4):
             if iz[index_z] < 0:

--- a/fbpic/particles/gathering/cuda_methods.py
+++ b/fbpic/particles/gathering/cuda_methods.py
@@ -3,11 +3,16 @@
 # License: 3-Clause-BSD-LBNL
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
-It defines the field gathering methods linear and cubic order shapes 
+It defines the field gathering methods linear and cubic order shapes
 on the GPU using CUDA.
 """
 from numba import cuda, float64, int64
 import math
+# Import inline functions
+from .inline_functions import add_linear_gather_for_mode
+# Compile the inline functions for GPU
+add_linear_gather_for_mode = cuda.jit( add_linear_gather_for_mode,
+                                        device=True, inline=True )
 
 # -----------------------
 # Field gathering linear
@@ -132,7 +137,7 @@ def gather_field_gpu_linear(x, y, z,
         if iz_upper > Nz-1:
             iz_upper -= Nz
 
-        #Precalculate Shapes
+        # Precalculate Shapes
         S_ll = Sz_lower*Sr_lower
         S_lu = Sz_lower*Sr_upper
         S_ul = Sz_upper*Sr_lower
@@ -141,91 +146,20 @@ def gather_field_gpu_linear(x, y, z,
         S_ug = Sz_upper*Sr_guard
 
         # E-Field
-        # ----------------------------
-        # Define the initial placeholders for the
-        # gathered field for each coordinate
+        # -------
         Fr = 0.
         Ft = 0.
         Fz = 0.
-
-        # Mode 0
-        # ----------------------------
-        # Create temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-        # Add the fields for mode 0
-        # Lower cell in z, Lower cell in r
-        Fr_m += S_ll * Er_m0[ iz_lower, ir_lower ]
-        Ft_m += S_ll * Et_m0[ iz_lower, ir_lower ]
-        Fz_m += S_ll * Ez_m0[ iz_lower, ir_lower ]
-        # Lower cell in z, Upper cell in r
-        Fr_m += S_lu * Er_m0[ iz_lower, ir_upper ]
-        Ft_m += S_lu * Et_m0[ iz_lower, ir_upper ]
-        Fz_m += S_lu * Ez_m0[ iz_lower, ir_upper ]
-        # Upper cell in z, Lower cell in r
-        Fr_m += S_ul * Er_m0[ iz_upper, ir_lower ]
-        Ft_m += S_ul * Et_m0[ iz_upper, ir_lower ]
-        Fz_m += S_ul * Ez_m0[ iz_upper, ir_lower ]
-        # Upper cell in z, Upper cell in r
-        Fr_m += S_uu * Er_m0[ iz_upper, ir_upper ]
-        Ft_m += S_uu * Et_m0[ iz_upper, ir_upper ]
-        Fz_m += S_uu * Ez_m0[ iz_upper, ir_upper ]
-        # Add the fields from the guard cells
-        if ir_lower == ir_upper == 0:
-            # Lower cell in z
-            Fr_m += -1. * S_lg * Er_m0[ iz_lower, 0]
-            Ft_m += -1. * S_lg * Et_m0[ iz_lower, 0]
-            Fz_m +=  1. * S_lg * Ez_m0[ iz_lower, 0]
-            # Upper cell in z
-            Fr_m += -1. * S_ug * Er_m0[ iz_upper, 0]
-            Ft_m += -1. * S_ug * Et_m0[ iz_upper, 0]
-            Fz_m +=  1. * S_ug * Ez_m0[ iz_upper, 0]
-        # Add the fields from the mode 0
-        Fr += (Fr_m*exptheta_m0).real
-        Ft += (Ft_m*exptheta_m0).real
-        Fz += (Fz_m*exptheta_m0).real
-
-        # Mode 1
-        # ----------------------------
-        # Clear the temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-        # Add the fields for mode 1
-        # Lower cell in z, Lower cell in r
-        Fr_m += S_ll * Er_m1[ iz_lower, ir_lower ]
-        Ft_m += S_ll * Et_m1[ iz_lower, ir_lower ]
-        Fz_m += S_ll * Ez_m1[ iz_lower, ir_lower ]
-        # Lower cell in z, Upper cell in r
-        Fr_m += S_lu * Er_m1[ iz_lower, ir_upper ]
-        Ft_m += S_lu * Et_m1[ iz_lower, ir_upper ]
-        Fz_m += S_lu * Ez_m1[ iz_lower, ir_upper ]
-        # Upper cell in z, Lower cell in r
-        Fr_m += S_ul * Er_m1[ iz_upper, ir_lower ]
-        Ft_m += S_ul * Et_m1[ iz_upper, ir_lower ]
-        Fz_m += S_ul * Ez_m1[ iz_upper, ir_lower ]
-        # Upper cell in z, Upper cell in r
-        Fr_m += S_uu * Er_m1[ iz_upper, ir_upper ]
-        Ft_m += S_uu * Et_m1[ iz_upper, ir_upper ]
-        Fz_m += S_uu * Ez_m1[ iz_upper, ir_upper ]
-        # Add the fields from the guard cells
-        if ir_lower == ir_upper == 0:
-            # Lower cell in z
-            Fr_m +=  1. * S_lg * Er_m1[ iz_lower, 0]
-            Ft_m +=  1. * S_lg * Et_m1[ iz_lower, 0]
-            Fz_m += -1. * S_lg * Ez_m1[ iz_lower, 0]
-            # Upper cell in z
-            Fr_m +=  1. * S_ug * Er_m1[ iz_upper, 0]
-            Ft_m +=  1. * S_ug * Et_m1[ iz_upper, 0]
-            Fz_m += -1. * S_ug * Ez_m1[ iz_upper, 0]
-        # Add the fields from the mode 1
-        Fr += 2*(Fr_m*exptheta_m1).real
-        Ft += 2*(Ft_m*exptheta_m1).real
-        Fz += 2*(Fz_m*exptheta_m1).real
-
+        # Add contribution from mode 0
+        Fr, Ft, Fz = add_linear_gather_for_mode( 0,
+            Fr, Ft, Fz, exptheta_m0, Er_m0, Et_m0, Ez_m0,
+            iz_lower, iz_upper, ir_lower, ir_upper,
+            S_ll, S_lu, S_lg, S_ul, S_uu, S_ug )
+        # Add contribution from mode 1
+        Fr, Ft, Fz = add_linear_gather_for_mode( 1,
+            Fr, Ft, Fz, exptheta_m1, Er_m1, Et_m1, Ez_m1,
+            iz_lower, iz_upper, ir_lower, ir_upper,
+            S_ll, S_lu, S_lg, S_ul, S_uu, S_ug )
         # Convert to Cartesian coordinates
         # and write to particle field arrays
         Ex[i] = cos*Fr - sin*Ft
@@ -239,86 +173,16 @@ def gather_field_gpu_linear(x, y, z,
         Fr = 0.
         Ft = 0.
         Fz = 0.
-
-        # Mode 0
-        # ----------------------------
-        # Create temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-        # Add the fields for mode 0
-        # Lower cell in z, Lower cell in r
-        Fr_m += S_ll * Br_m0[ iz_lower, ir_lower ]
-        Ft_m += S_ll * Bt_m0[ iz_lower, ir_lower ]
-        Fz_m += S_ll * Bz_m0[ iz_lower, ir_lower ]
-        # Lower cell in z, Upper cell in r
-        Fr_m += S_lu * Br_m0[ iz_lower, ir_upper ]
-        Ft_m += S_lu * Bt_m0[ iz_lower, ir_upper ]
-        Fz_m += S_lu * Bz_m0[ iz_lower, ir_upper ]
-        # Upper cell in z, Lower cell in r
-        Fr_m += S_ul * Br_m0[ iz_upper, ir_lower ]
-        Ft_m += S_ul * Bt_m0[ iz_upper, ir_lower ]
-        Fz_m += S_ul * Bz_m0[ iz_upper, ir_lower ]
-        # Upper cell in z, Upper cell in r
-        Fr_m += S_uu * Br_m0[ iz_upper, ir_upper ]
-        Ft_m += S_uu * Bt_m0[ iz_upper, ir_upper ]
-        Fz_m += S_uu * Bz_m0[ iz_upper, ir_upper ]
-        # Add the fields from the guard cells
-        if ir_lower == ir_upper == 0:
-            # Lower cell in z
-            Fr_m += -1. * S_lg * Br_m0[ iz_lower, 0]
-            Ft_m += -1. * S_lg * Bt_m0[ iz_lower, 0]
-            Fz_m +=  1. * S_lg * Bz_m0[ iz_lower, 0]
-            # Upper cell in z
-            Fr_m += -1. * S_ug * Br_m0[ iz_upper, 0]
-            Ft_m += -1. * S_ug * Bt_m0[ iz_upper, 0]
-            Fz_m +=  1. * S_ug * Bz_m0[ iz_upper, 0]
-        # Add the fields from the mode 0
-        Fr += (Fr_m*exptheta_m0).real
-        Ft += (Ft_m*exptheta_m0).real
-        Fz += (Fz_m*exptheta_m0).real
-
-        # Mode 1
-        # ----------------------------
-        # Clear the temporary variables
-        # for the "per mode" gathering
-        Fr_m = 0.j
-        Ft_m = 0.j
-        Fz_m = 0.j
-        # Add the fields for mode 1
-        # Lower cell in z, Lower cell in r
-        Fr_m += S_ll * Br_m1[ iz_lower, ir_lower ]
-        Ft_m += S_ll * Bt_m1[ iz_lower, ir_lower ]
-        Fz_m += S_ll * Bz_m1[ iz_lower, ir_lower ]
-        # Lower cell in z, Upper cell in r
-        Fr_m += S_lu * Br_m1[ iz_lower, ir_upper ]
-        Ft_m += S_lu * Bt_m1[ iz_lower, ir_upper ]
-        Fz_m += S_lu * Bz_m1[ iz_lower, ir_upper ]
-        # Upper cell in z, Lower cell in r
-        Fr_m += S_ul * Br_m1[ iz_upper, ir_lower ]
-        Ft_m += S_ul * Bt_m1[ iz_upper, ir_lower ]
-        Fz_m += S_ul * Bz_m1[ iz_upper, ir_lower ]
-        # Upper cell in z, Upper cell in r
-        Fr_m += S_uu * Br_m1[ iz_upper, ir_upper ]
-        Ft_m += S_uu * Bt_m1[ iz_upper, ir_upper ]
-        Fz_m += S_uu * Bz_m1[ iz_upper, ir_upper ]
-
-        # Add the fields from the guard cells
-        if ir_lower == ir_upper == 0:
-            # Lower cell in z
-            Fr_m +=  1. * S_lg * Br_m1[ iz_lower, 0]
-            Ft_m +=  1. * S_lg * Bt_m1[ iz_lower, 0]
-            Fz_m += -1. * S_lg * Bz_m1[ iz_lower, 0]
-            # Upper cell in z
-            Fr_m +=  1. * S_ug * Br_m1[ iz_upper, 0]
-            Ft_m +=  1. * S_ug * Bt_m1[ iz_upper, 0]
-            Fz_m += -1. * S_ug * Bz_m1[ iz_upper, 0]
-        # Add the fields from the mode 1
-        Fr += 2*(Fr_m*exptheta_m1).real
-        Ft += 2*(Ft_m*exptheta_m1).real
-        Fz += 2*(Fz_m*exptheta_m1).real
-
+        # Add contribution from mode 0
+        Fr, Ft, Fz = add_linear_gather_for_mode( 0,
+            Fr, Ft, Fz, exptheta_m0, Br_m0, Bt_m0, Bz_m0,
+            iz_lower, iz_upper, ir_lower, ir_upper,
+            S_ll, S_lu, S_lg, S_ul, S_uu, S_ug )
+        # Add contribution from mode 1
+        Fr, Ft, Fz = add_linear_gather_for_mode( 1,
+            Fr, Ft, Fz, exptheta_m1, Br_m1, Bt_m1, Bz_m1,
+            iz_lower, iz_upper, ir_lower, ir_upper,
+            S_ll, S_lu, S_lg, S_ul, S_uu, S_ug )
         # Convert to Cartesian coordinates
         # and write to particle field arrays
         Bx[i] = cos*Fr - sin*Ft

--- a/fbpic/particles/gathering/inline_functions.py
+++ b/fbpic/particles/gathering/inline_functions.py
@@ -11,7 +11,39 @@ def add_linear_gather_for_mode( m,
     iz_lower, iz_upper, ir_lower, ir_upper,
     S_ll, S_lu, S_lg, S_ul, S_uu, S_ug ):
     """
-    # TODO
+    Add the contribution of the gathered field from azimuthal mode `m` to the
+    fields felt by one macroparticle (`Fr`, `Ft`, `Fz`), using linear weights.
+
+    Parameters:
+    -----------
+    m: int
+        The index of the azimuthal mode that is added.
+
+    Fr, Ft, Fz: floats
+        The fields felt by one macroparticle, which represent either E or B
+        (before the contribution of mode `m` has been added)
+
+    exptheta_m: complex
+        The complex azimuthal factor $e^{-i m \theta}$ where $\theta$ is
+        the azimuthal position of the macroparticle considered.
+
+    Fr_grid, Ft_grid, Fz_grid: 2darrays of complexs
+        The fields on the interpolation grid for mode `m`
+
+    iz_lower, iz_upper, ir_lower, ir_upper: ints
+        Lower and upper index in z and r from which the macroparticle
+        considered should gather the fields (in the arrays F*_grid)
+
+    S_ll, S_lu, S_lg, S_ul, S_uu, S_ug: floats
+        The weights with which the fields are gathered, for the macroparticle
+        considered. `S_lg` and `S_ug` are used for fields gathered from below
+        the axis.
+
+    Returns:
+    --------
+    Fr, Ft, Fz: floats
+        The fields felt by one macroparticle, which represent either E or B
+        (after the contribution of mode `m` has been added)
     """
     # Create temporary variables
     # for the "per mode" gathering
@@ -62,7 +94,38 @@ def add_cubic_gather_for_mode( m,
     Fr, Ft, Fz, exptheta_m, Fr_grid, Ft_grid, Fz_grid,
     ir, iz, Sr, Sz ):
     """
-    # TODO
+    Add the contribution of the gathered field from azimuthal mode `m` to the
+    fields felt by one macroparticle (`Fr`, `Ft`, `Fz`), using cubic weights.
+
+    Parameters:
+    -----------
+    m: int
+        The index of the azimuthal mode that is added.
+
+    Fr, Ft, Fz: floats
+        The fields felt by one macroparticle, which represent either E or B
+        (before the contribution of mode `m` has been added)
+
+    exptheta_m: complex
+        The complex azimuthal factor $e^{-i m \theta}$ where $\theta$ is
+        the azimuthal position of the macroparticle considered.
+
+    Fr_grid, Ft_grid, Fz_grid: 2darrays of complexs
+        The fields on the interpolation grid for mode `m`
+
+    ir, iz: 1darrays containing 4 ints
+        The indices in r and z from which the macroparticle
+        considered should gather the fields (in the arrays F*_grid)
+
+    Sr, Sz: 1darrays containing 4 floats
+        The weights in r and z with which the macroparticle
+        considered should gather the fields (in the arrays F*_grid)
+
+    Returns:
+    --------
+    Fr, Ft, Fz: floats
+        The fields felt by one macroparticle, which represent either E or B
+        (after the contribution of mode `m` has been added)
     """
     # Create temporary variables
     # for the "per mode" gathering

--- a/fbpic/particles/gathering/inline_functions.py
+++ b/fbpic/particles/gathering/inline_functions.py
@@ -1,0 +1,58 @@
+# Copyright 2017, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines inline functions that are compiled for both GPU and CPU, and
+used in the gathering kernels.
+"""
+def add_linear_gather_for_mode( m,
+    Fr, Ft, Fz, exptheta_m, Fr_grid, Ft_grid, Fz_grid,
+    iz_lower, iz_upper, ir_lower, ir_upper,
+    S_ll, S_lu, S_lg, S_ul, S_uu, S_ug ):
+    """
+    # TODO
+    """
+    # Create temporary variables
+    # for the "per mode" gathering
+    Fr_m = 0.j
+    Ft_m = 0.j
+    Fz_m = 0.j
+    # Lower cell in z, Lower cell in r
+    Fr_m += S_ll * Fr_grid[ iz_lower, ir_lower ]
+    Ft_m += S_ll * Ft_grid[ iz_lower, ir_lower ]
+    Fz_m += S_ll * Fz_grid[ iz_lower, ir_lower ]
+    # Lower cell in z, Upper cell in r
+    Fr_m += S_lu * Fr_grid[ iz_lower, ir_upper ]
+    Ft_m += S_lu * Ft_grid[ iz_lower, ir_upper ]
+    Fz_m += S_lu * Fz_grid[ iz_lower, ir_upper ]
+    # Upper cell in z, Lower cell in r
+    Fr_m += S_ul * Fr_grid[ iz_upper, ir_lower ]
+    Ft_m += S_ul * Ft_grid[ iz_upper, ir_lower ]
+    Fz_m += S_ul * Fz_grid[ iz_upper, ir_lower ]
+    # Upper cell in z, Upper cell in r
+    Fr_m += S_uu * Fr_grid[ iz_upper, ir_upper ]
+    Ft_m += S_uu * Ft_grid[ iz_upper, ir_upper ]
+    Fz_m += S_uu * Fz_grid[ iz_upper, ir_upper ]
+    # Add the fields from the guard cells
+    if ir_lower == ir_upper == 0:
+        flip_factor = (-1.)**m
+        # Lower cell in z
+        Fr_m += -flip_factor * S_lg * Fr_grid[ iz_lower, 0]
+        Ft_m += -flip_factor * S_lg * Ft_grid[ iz_lower, 0]
+        Fz_m +=  flip_factor * S_lg * Fz_grid[ iz_lower, 0]
+        # Upper cell in z
+        Fr_m += -flip_factor * S_ug * Fr_grid[ iz_upper, 0]
+        Ft_m += -flip_factor * S_ug * Ft_grid[ iz_upper, 0]
+        Fz_m +=  flip_factor * S_ug * Fz_grid[ iz_upper, 0]
+    # Add the contribution from mode m to Fr, Ft, Fz
+    # (Take into account factor 2 in the definition of azimuthal modes)
+    if m == 0:
+        factor = 1.
+    else:
+        factor = 2.
+    Fr += factor*(Fr_m*exptheta_m).real
+    Ft += factor*(Ft_m*exptheta_m).real
+    Fz += factor*(Fz_m*exptheta_m).real
+
+    return(Fr, Ft, Fz)

--- a/fbpic/particles/gathering/inline_functions.py
+++ b/fbpic/particles/gathering/inline_functions.py
@@ -56,3 +56,40 @@ def add_linear_gather_for_mode( m,
     Fz += factor*(Fz_m*exptheta_m).real
 
     return(Fr, Ft, Fz)
+
+
+def add_cubic_gather_for_mode( m,
+    Fr, Ft, Fz, exptheta_m, Fr_grid, Ft_grid, Fz_grid,
+    ir, iz, Sr, Sz ):
+    """
+    # TODO
+    """
+    # Create temporary variables
+    # for the "per mode" gathering
+    Fr_m = 0.j
+    Ft_m = 0.j
+    Fz_m = 0.j
+    # Add the fields for mode 0
+    for index_r in range(4):
+        for index_z in range(4):
+            weight = Sz[index_z]*Sr[index_r]
+            if weight < 0:
+                flip_factor = (-1)**m
+                Fr_m +=  flip_factor*weight*Fr_grid[iz[index_z], ir[index_r]]
+                Ft_m +=  flip_factor*weight*Ft_grid[iz[index_z], ir[index_r]]
+                Fz_m += -flip_factor*weight*Fz_grid[iz[index_z], ir[index_r]]
+            else:
+                Fr_m += weight*Fr_grid[iz[index_z], ir[index_r]]
+                Ft_m += weight*Ft_grid[iz[index_z], ir[index_r]]
+                Fz_m += weight*Fz_grid[iz[index_z], ir[index_r]]
+    # Add the contribution from mode m to Fr, Ft, Fz
+    # (Take into account factor 2 in the definition of azimuthal modes)
+    if m == 0:
+        factor = 1.
+    else:
+        factor = 2.
+    Fr += factor*(Fr_m*exptheta_m).real
+    Ft += factor*(Ft_m*exptheta_m).real
+    Fz += factor*(Fz_m*exptheta_m).real
+
+    return(Fr, Ft, Fz)

--- a/fbpic/particles/gathering/inline_functions.py
+++ b/fbpic/particles/gathering/inline_functions.py
@@ -113,13 +113,19 @@ def add_cubic_gather_for_mode( m,
     Fr_grid, Ft_grid, Fz_grid: 2darrays of complexs
         The fields on the interpolation grid for mode `m`
 
-    ir_lowest, iz_lowest: 1darrays containing 4 ints
-        The indices in r and z from which the macroparticle
+    ir_lowest, iz_lowest: ints
+        The lowest indices in r and z from which the macroparticle
         considered should gather the fields (in the arrays F*_grid)
+        These indices can in fact be negative and out-of-bound
+        (e.g. for particles close to the axis) but get corrected within
+        this function.
 
     Sr_arr, Sz_arr: 1darrays containing 4 floats
         The weights in r and z with which the macroparticle
         considered should gather the fields (in the arrays F*_grid)
+
+    Nr, Nz: ints
+        Dimensions of the field arrays.
 
     Returns:
     --------

--- a/fbpic/particles/gathering/threading_methods.py
+++ b/fbpic/particles/gathering/threading_methods.py
@@ -262,9 +262,7 @@ def gather_field_numba_cubic(x, y, z,
 
         # Create private arrays for each thread
         # to store the particle index and shape
-        ir = np.empty( 4, dtype=int64)
         Sr = np.empty( 4 )
-        iz = np.empty( 4, dtype=int64)
         Sz = np.empty( 4 )
 
         # Loop over all particles in thread chunk

--- a/fbpic/particles/gathering/threading_methods.py
+++ b/fbpic/particles/gathering/threading_methods.py
@@ -303,7 +303,6 @@ def gather_field_numba_cubic(x, y, z,
             Sr[1] = 1./6. * (3.*(r_local-1.)**3 - 6.*(r_local-1.)**2 + 4.)
             Sr[2] = 1./6. * (3.*(2.-r_local)**3 - 6.*(2.-r_local)**2 + 4.)
             Sr[3] = -1./6. * (1.-r_local)**3
-            Sz = cuda.local.array((4,), dtype=float64)
             iz_lowest = int64(math.floor(z_cell)) - 1
             z_local = z_cell-iz_lowest
             Sz[0] = -1./6. * (z_local-2.)**3

--- a/fbpic/particles/gathering/threading_methods.py
+++ b/fbpic/particles/gathering/threading_methods.py
@@ -297,39 +297,19 @@ def gather_field_numba_cubic(x, y, z,
             z_cell = invdz*(zj - zmin) - 0.5
 
             # Calculate the shape factors
-            ir[0] = int64(math.floor(r_cell)) - 1
-            ir[1] = ir[0] + 1
-            ir[2] = ir[1] + 1
-            ir[3] = ir[2] + 1
-            Sr[0] = -1./6. * ((r_cell-ir[0])-2)**3
-            Sr[1] = 1./6. * (3*((r_cell-ir[1])**3)-6*((r_cell-ir[1])**2)+4)
-            Sr[2] = 1./6. * (3*((ir[2]-r_cell)**3)-6*((ir[2]-r_cell)**2)+4)
-            Sr[3] = -1./6. * ((ir[3]-r_cell)-2)**3
-            iz[0] = int64(math.floor(z_cell)) - 1
-            iz[1] = iz[0] + 1
-            iz[2] = iz[1] + 1
-            iz[3] = iz[2] + 1
-            Sz[0] = -1./6. * ((z_cell-iz[0])-2)**3
-            Sz[1] = 1./6. * (3*((z_cell-iz[1])**3)-6*((z_cell-iz[1])**2)+4)
-            Sz[2] = 1./6. * (3*((iz[2]-z_cell)**3)-6*((iz[2]-z_cell)**2)+4)
-            Sz[3] = -1./6. * ((iz[3]-z_cell)-2)**3
-            # Lower and upper periodic boundary for z
-            index_z = 0
-            while index_z < 4:
-                if iz[index_z] < 0:
-                    iz[index_z] += Nz
-                if iz[index_z] > Nz - 1:
-                    iz[index_z] -= Nz
-                index_z += 1
-            # Lower and upper boundary for r
-            index_r = 0
-            while index_r < 4:
-                if ir[index_r] < 0:
-                    ir[index_r] = abs(ir[index_r])-1
-                    Sr[index_r] = (-1.)*Sr[index_r]
-                if ir[index_r] > Nr - 1:
-                    ir[index_r] = Nr - 1
-                index_r += 1
+            ir_lowest = int64(math.floor(r_cell)) - 1
+            r_local = r_cell-ir_lowest
+            Sr[0] = -1./6. * (r_local-2.)**3
+            Sr[1] = 1./6. * (3.*(r_local-1.)**3 - 6.*(r_local-1.)**2 + 4.)
+            Sr[2] = 1./6. * (3.*(2.-r_local)**3 - 6.*(2.-r_local)**2 + 4.)
+            Sr[3] = -1./6. * (1.-r_local)**3
+            Sz = cuda.local.array((4,), dtype=float64)
+            iz_lowest = int64(math.floor(z_cell)) - 1
+            z_local = z_cell-iz_lowest
+            Sz[0] = -1./6. * (z_local-2.)**3
+            Sz[1] = 1./6. * (3.*(z_local-1.)**3 - 6.*(z_local-1.)**2 + 4.)
+            Sz[2] = 1./6. * (3.*(2.-z_local)**3 - 6.*(2.-z_local)**2 + 4.)
+            Sz[3] = -1./6. * (1.-z_local)**3
 
             # E-Field
             # -------
@@ -339,11 +319,11 @@ def gather_field_numba_cubic(x, y, z,
             # Add contribution from mode 0
             Fr, Ft, Fz = add_cubic_gather_for_mode( 0,
                 Fr, Ft, Fz, exptheta_m0, Er_m0, Et_m0, Ez_m0,
-                ir, iz, Sr, Sz )
+                ir_lowest, iz_lowest, Sr, Sz, Nr, Nz )
             # Add contribution from mode 1
             Fr, Ft, Fz = add_cubic_gather_for_mode( 1,
                 Fr, Ft, Fz, exptheta_m1, Er_m1, Et_m1, Ez_m1,
-                ir, iz, Sr, Sz )
+                ir_lowest, iz_lowest, Sr, Sz, Nr, Nz )
             # Convert to Cartesian coordinates
             # and write to particle field arrays
             Ex[i] = cos*Fr - sin*Ft
@@ -360,11 +340,11 @@ def gather_field_numba_cubic(x, y, z,
             # Add contribution from mode 0
             Fr, Ft, Fz =  add_cubic_gather_for_mode( 0,
                 Fr, Ft, Fz, exptheta_m0, Br_m0, Bt_m0, Bz_m0,
-                ir, iz, Sr, Sz )
+                ir_lowest, iz_lowest, Sr, Sz, Nr, Nz )
             # Add contribution from mode 1
             Fr, Ft, Fz =  add_cubic_gather_for_mode( 1,
                 Fr, Ft, Fz, exptheta_m1, Br_m1, Bt_m1, Bz_m1,
-                ir, iz, Sr, Sz )
+                ir_lowest, iz_lowest, Sr, Sz, Nr, Nz )
             # Convert to Cartesian coordinates
             # and write to particle field arrays
             Bx[i] = cos*Fr - sin*Ft


### PR DESCRIPTION
In the code for field gathering, there is a lot of code duplication:
- the gathering and weighting of E is very similar to gathering and weighting of B
- the gathering for mode 0 is very similar to the gathering for mode 1
- the code for CPU is very similar to the code for GPU

For this reason, I wrote a single function that does the gathering and weighting for an arbitrary field (E or B), arbitrary mode, and for both CPU and GPU (with one version for linear shape and one version cubic shape). This elementary function is then used in the CPU and GPU kernels (it is compiled either `cuda` or `numba` ; a similar approach was used in the ionization code.)

Also, I got rid of the `iz` and `ir` arrays for cubic deposition (as they are very easy to recalculate on the fly, just before accessing the corresponding fields.)

The tests pass on CPU and GPU. 

Here are the timings on GPU (only for the gathering kernel, time per call, measured on a GTX 1080):

|     | Linear gathering | Cubic gathering | 
|-----|------------------|-----------------|
| dev | 20.920ms         | 120.87ms        |
| PR  | 20.723ms         | ~~77.80ms~~ 79.72ms       |

I am quite surprised by the speed-up in the cubic gathering (~~I did change the cubic code a little to avoid calculating `Sz*Sr` many times (see the variable `weight`)~~). @MKirchen @soerenjalas Would you have time to do some profiling on a K80 or P100?

Here are the timing on a 12-core CPU, as a function of the number of threads (the dashed line corresponds to this PR, the solid line corresponds to the `dev` branch):
<img width="576" alt="screen shot 2018-01-05 at 3 19 46 pm" src="https://user-images.githubusercontent.com/6685781/34632708-e53af402-f22b-11e7-934e-930eb5e37f80.png">

So in summary: 
- For cubic shape, the new code is much faster on GPU, and just lightly slower for CPU.
- For linear shape, the new code has about the same speed on GPU, but is significantly slower on CPU. However, this is mitigated for a large number of threads. Moreover, for linear shape, the gathering is usually not the most costly part of the PIC loop.

For this reason (and for all the simplifications that this PR makes in the code), my opinion would be that this is worth merging. @MKirchen @soerenjalas : Any opinion?
  