### PR TITLE
Close #139 Simplify/optimize the code for current deposition on GPU

### DIFF
--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -229,15 +229,15 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     # Find the z index of the first cell for which particles are kept
     iz_min = max( n_guard + fld.prefix_sum_shift, 0 )
     # Find the z index of the first cell for which particles are removed again
-    iz_max = min( Nz - n_guard + fld.prefix_sum_shift, Nz )
+    iz_max = min( Nz - n_guard + fld.prefix_sum_shift + 1, Nz )
     # Find the corresponding indices in the particle array
     # Reminder: prefix_sum[i] is the cumulative sum of the number of particles
     # in cells 0 to i (where cell i is included)
-    if iz_min*Nr - 1 >= 0:
-        i_min = prefix_sum.getitem( iz_min*Nr - 1 )
+    if iz_min*(Nr+1) - 1 >= 0:
+        i_min = prefix_sum.getitem( iz_min*(Nr+1) - 1 )
     else:
         i_min = 0
-    i_max = prefix_sum.getitem( iz_max*Nr - 1 )
+    i_max = prefix_sum.getitem( iz_max*(Nr+1) - 1 )
     # Because of the way in which the prefix_sum is calculated, if the
     # cell that was requested for i_max is beyond the last non-empty cell,
     # i_max will be zero, but should in fact be species.Ntot

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -667,6 +667,7 @@ class ParticleCatcher:
             Nz, Nr = species.grid_shape
             # Calculate cell area to get particles from
             # - Get z indices of the slices in which to get the particles
+            # (mirrors the index calculation in `get_cell_idx_per_particle`)
             iz_curr = math.ceil((current_z_boost-zmin-0.5*dz)/dz)
             iz_prev = math.ceil((previous_z_boost-zmin-0.5*dz + dt*c)/dz) + 1
             # - Get the prefix sum values that correspond to these indices

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -676,14 +676,14 @@ class ParticleCatcher:
             elif z_cell_curr > Nz:
                 pref_sum_curr = species.Ntot
             else:
-                pref_sum_curr = pref_sum.getitem( z_cell_curr*Nr - 1 )
+                pref_sum_curr = pref_sum.getitem( z_cell_curr*(Nr+1) - 1 )
             z_cell_prev = iz_prev + pref_sum_shift
             if z_cell_prev <= 0:
-                pref_sum_prev = 0  
+                pref_sum_prev = 0
             elif z_cell_prev > Nz:
                 pref_sum_prev = species.Ntot
             else:
-                pref_sum_prev = pref_sum.getitem( z_cell_prev*Nr - 1 )
+                pref_sum_prev = pref_sum.getitem( z_cell_prev*(Nr+1) - 1 )
             # Calculate number of particles in this area (N_area)
             N_area = pref_sum_prev - pref_sum_curr
             # Check if there are particles to extract

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -11,6 +11,7 @@ Major features:
   not to write to disk at every timestep
 """
 import os
+import math
 import numpy as np
 from scipy.constants import c, e
 from .particle_diag import ParticleDiagnostic
@@ -666,8 +667,8 @@ class ParticleCatcher:
             Nz, Nr = species.grid_shape
             # Calculate cell area to get particles from
             # - Get z indices of the slices in which to get the particles
-            iz_curr = int((current_z_boost - zmin - 0.5*dz)/dz)
-            iz_prev = int((previous_z_boost - zmin - 0.5*dz + dt*c)/dz) + 1
+            iz_curr = math.ceil((current_z_boost-zmin-0.5*dz)/dz)
+            iz_prev = math.ceil((previous_z_boost-zmin-0.5*dz + dt*c)/dz) + 1
             # - Get the prefix sum values that correspond to these indices
             #   (Take into account potential shift due to the moving window)
             z_cell_curr = iz_curr + pref_sum_shift

--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -129,8 +129,8 @@ def deposit_rho_gpu_linear(x, y, z, w, q,
     i = cuda.grid(1)
     # Deposit the field per cell in parallel (for threads < number of cells)
     if i < prefix_sum.shape[0]:
-        # Calculate the upper cell index in 2D where the particle
-        # deposits charge, from the 1D threadIdx
+        # Retrieve index of upper grid point (in z and r) from prefix-sum index
+        # (See calculation of prefix-sum index in `get_cell_idx_per_particle`)
         iz_upper = int( i / (Nr+1) )
         ir_upper = int( i - iz_upper * (Nr+1) )
         # Calculate the inclusive offset for the current cell
@@ -304,8 +304,8 @@ def deposit_J_gpu_linear(x, y, z, w, q,
     i = cuda.grid(1)
     # Deposit the field per cell in parallel (for threads < number of cells)
     if i < prefix_sum.shape[0]:
-        # Calculate the upper cell index in 2D where the particle
-        # deposits charge, from the 1D threadIdx
+        # Retrieve index of upper grid point (in z and r) from prefix-sum index
+        # (See calculation of prefix-sum index in `get_cell_idx_per_particle`)
         iz_upper = int( i / (Nr+1) )
         ir_upper = int( i - iz_upper * (Nr+1) )
         # Calculate the inclusive offset for the current cell
@@ -548,8 +548,8 @@ def deposit_rho_gpu_cubic(x, y, z, w, q,
     i = cuda.grid(1)
     # Deposit the field per cell in parallel (for threads < number of cells)
     if i < prefix_sum.shape[0]:
-        # Calculate the upper cell index in 2D where the particle
-        # deposits charge, from the 1D threadIdx
+        # Retrieve index of upper grid point (in z and r) from prefix-sum index
+        # (See calculation of prefix-sum index in `get_cell_idx_per_particle`)
         iz_upper = int( i / (Nr+1) )
         ir_upper = int( i - iz_upper * (Nr+1) )
         # Calculate the inclusive offset for the current cell
@@ -834,7 +834,8 @@ def deposit_J_gpu_cubic(x, y, z, w, q,
     i = cuda.grid(1)
     # Deposit the field per cell in parallel (for threads < number of cells)
     if i < prefix_sum.shape[0]:
-        # Calculate the cell index in 2D from the 1D threadIdx
+        # Retrieve index of upper grid point (in z and r) from prefix-sum index
+        # (See calculation of prefix-sum index in `get_cell_idx_per_particle`)
         iz_upper = int( i / (Nr+1) )
         ir_upper = int( i - iz_upper * (Nr+1) )
         # Calculate the inclusive offset for the current cell

--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -129,10 +129,10 @@ def deposit_rho_gpu_linear(x, y, z, w, q,
     i = cuda.grid(1)
     # Deposit the field per cell in parallel (for threads < number of cells)
     if i < prefix_sum.shape[0]:
-        # Calculate the lowest cell index in 2D where the particle
+        # Calculate the upper cell index in 2D where the particle
         # deposits charge, from the 1D threadIdx
-        iz_lowest = int( i / (Nr+1) )
-        ir_lowest = int( i - iz_lowest * (Nr+1) ) - 1
+        iz_upper = int( i / (Nr+1) )
+        ir_upper = int( i - iz_upper * (Nr+1) )
         # Calculate the inclusive offset for the current cell
         # It represents the number of particles contained in all other cells
         # with an index smaller than i + the total number of particles in the
@@ -205,13 +205,13 @@ def deposit_rho_gpu_linear(x, y, z, w, q,
             R_m1_11 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 1) * R_m1_scal
 
         # Calculate longitudinal indices at which to add charge
-        iz0 = iz_lowest
-        iz1 = iz_lowest + 1
-        if iz1 > Nz-1:
-            iz1 -= Nz
+        iz0 = iz_upper - 1
+        iz1 = iz_upper
+        if iz0 < 0:
+            iz0 += Nz
         # Calculate radial indices at which to add charge
-        ir0 = ir_lowest
-        ir1 = min( ir_lowest + 1, Nr-1 )
+        ir0 = ir_upper - 1
+        ir1 = min( ir_upper, Nr-1 )
         if ir0 < 0:
             # Deposition below the axis: fold index into physical region
             ir0 = -(1 + ir0)
@@ -304,10 +304,10 @@ def deposit_J_gpu_linear(x, y, z, w, q,
     i = cuda.grid(1)
     # Deposit the field per cell in parallel (for threads < number of cells)
     if i < prefix_sum.shape[0]:
-        # Calculate the lowest cell index in 2D where the particle
+        # Calculate the upper cell index in 2D where the particle
         # deposits charge, from the 1D threadIdx
-        iz_lowest = int( i / (Nr+1) )
-        ir_lowest = int( i - iz_lowest * (Nr+1) ) - 1
+        iz_upper = int( i / (Nr+1) )
+        ir_upper = int( i - iz_upper * (Nr+1) )
         # Calculate the inclusive offset for the current cell
         # It represents the number of particles contained in all other cells
         # with an index smaller than i + the total number of particles in the
@@ -433,13 +433,13 @@ def deposit_J_gpu_linear(x, y, z, w, q,
             J_z_m1_11 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 1) * J_z_m1_scal
 
         # Calculate longitudinal indices at which to add charge
-        iz0 = iz_lowest
-        iz1 = iz_lowest + 1
-        if iz1 > Nz-1:
-            iz1 -= Nz
+        iz0 = iz_upper - 1
+        iz1 = iz_upper
+        if iz0 < 0:
+            iz0 += Nz
         # Calculate radial indices at which to add charge
-        ir0 = ir_lowest
-        ir1 = min( ir_lowest + 1, Nr-1 )
+        ir0 = ir_upper - 1
+        ir1 = min( ir_upper, Nr-1 )
         if ir0 < 0:
             # Deposition below the axis: fold index into physical region
             ir0 = -(1 + ir0)
@@ -548,10 +548,10 @@ def deposit_rho_gpu_cubic(x, y, z, w, q,
     i = cuda.grid(1)
     # Deposit the field per cell in parallel (for threads < number of cells)
     if i < prefix_sum.shape[0]:
-        # Calculate the lowest cell index in 2D where the particle
+        # Calculate the upper cell index in 2D where the particle
         # deposits charge, from the 1D threadIdx
-        iz_lowest = int( i / (Nr+1) ) - 1
-        ir_lowest = int( i - (iz_lowest+1) * (Nr+1) ) - 2
+        iz_upper = int( i / (Nr+1) )
+        ir_upper = int( i - iz_upper * (Nr+1) )
         # Calculate the inclusive offset for the current cell
         # It represents the number of particles contained in all other cells
         # with an index smaller than i + the total number of particles in the
@@ -690,21 +690,21 @@ def deposit_rho_gpu_cubic(x, y, z, w, q,
             R_m1_33 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 3)*R_m1_scal
 
         # Calculate longitudinal indices at which to add charge
-        iz0 = iz_lowest
-        iz1 = iz_lowest + 1
-        iz2 = iz_lowest + 2
-        iz3 = iz_lowest + 3
+        iz0 = iz_upper - 2
+        iz1 = iz_upper - 1
+        iz2 = iz_upper
+        iz3 = iz_upper + 1
         if iz0 < 0:
             iz0 += Nz
-        if iz2 > Nz-1:
-            iz2 -= Nz
+        if iz1 < 0:
+            iz1 += Nz
         if iz3 > Nz-1:
             iz3 -= Nz
         # Calculate radial indices at which to add charge
-        ir0 = ir_lowest
-        ir1 = min( ir_lowest + 1, Nr-1 )
-        ir2 = min( ir_lowest + 2, Nr-1 )
-        ir3 = min( ir_lowest + 3, Nr-1 )
+        ir0 = ir_upper - 2
+        ir1 = min( ir_upper - 1, Nr-1 )
+        ir2 = min( ir_upper    , Nr-1 )
+        ir3 = min( ir_upper + 1, Nr-1 )
         if ir0 < 0:
             # Deposition below the axis: fold index into physical region
             ir0 = -(1 + ir0)
@@ -835,8 +835,8 @@ def deposit_J_gpu_cubic(x, y, z, w, q,
     # Deposit the field per cell in parallel (for threads < number of cells)
     if i < prefix_sum.shape[0]:
         # Calculate the cell index in 2D from the 1D threadIdx
-        iz_lowest = int( i / (Nr+1) ) - 1
-        ir_lowest = int( i - (iz_lowest+1) * (Nr+1) ) - 2
+        iz_upper = int( i / (Nr+1) )
+        ir_upper = int( i - iz_upper * (Nr+1) )
         # Calculate the inclusive offset for the current cell
         # It represents the number of particles contained in all other cells
         # with an index smaller than i + the total number of particles in the
@@ -1126,21 +1126,21 @@ def deposit_J_gpu_cubic(x, y, z, w, q,
             J_z_m1_33 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 3)*J_z_m1_scal
 
         # Calculate longitudinal indices at which to add charge
-        iz0 = iz_lowest
-        iz1 = iz_lowest + 1
-        iz2 = iz_lowest + 2
-        iz3 = iz_lowest + 3
+        iz0 = iz_upper - 2
+        iz1 = iz_upper - 1
+        iz2 = iz_upper
+        iz3 = iz_upper + 1
         if iz0 < 0:
             iz0 += Nz
-        if iz2 > Nz-1:
-            iz2 -= Nz
+        if iz1 < 0:
+            iz1 += Nz
         if iz3 > Nz-1:
             iz3 -= Nz
         # Calculate radial indices at which to add charge
-        ir0 = ir_lowest
-        ir1 = min( ir_lowest + 1, Nr-1 )
-        ir2 = min( ir_lowest + 2, Nr-1 )
-        ir3 = min( ir_lowest + 3, Nr-1 )
+        ir0 = ir_upper - 2
+        ir1 = min( ir_upper - 1, Nr-1 )
+        ir2 = min( ir_upper    , Nr-1 )
+        ir3 = min( ir_upper + 1, Nr-1 )
         if ir0 < 0:
             # Deposition below the axis: fold index into physical region
             ir0 = -(1 + ir0)

--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -60,20 +60,20 @@ def get_cell_idx_per_particle(cell_idx, sorted_idx,
             r_cell =  invdr*(rj - rmin) - 0.5
             z_cell =  invdz*(zj - zmin) - 0.5
 
-            # Original index of the uppper and lower cell
-            ir_upper = int(math.floor( r_cell )) + 1
-            iz_lower = int(math.floor( z_cell ))
+            # Original index of the uppper and upper cell
+            ir_upper = int(math.ceil( r_cell ))
+            iz_upper = int(math.ceil( z_cell ))
 
             # Treat the boundary conditions
             # absorbing in upper r
             if ir_upper > Nr:
                 ir_upper = Nr
             # periodic boundaries in z
-            if iz_lower < 0:
-                iz_lower += Nz
-            elif iz_lower > Nz-1:
-                iz_lower -= Nz
-            # iz_lower has values between 0 and Nz-1.
+            if iz_upper < 0:
+                iz_upper += Nz
+            elif iz_upper > Nz-1:
+                iz_upper -= Nz
+            # iz_upper has values between 0 and Nz-1.
             # ir_upper has values between 0 and Nr (included).
             # This corresponds to the Nz*(Nr+1) different inter-gridpoint
             # areas in a box that is periodic in z but aperiodic in r.
@@ -81,7 +81,7 @@ def get_cell_idx_per_particle(cell_idx, sorted_idx,
             # Reset sorted_idx array
             sorted_idx[i] = i
             # Calculate the 1D cell_idx
-            cell_idx[i] = ir_upper + iz_lower * (Nr+1)
+            cell_idx[i] = ir_upper + iz_upper * (Nr+1)
 
 def sort_particles_per_cell(cell_idx, sorted_idx):
     """

--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -60,7 +60,7 @@ def get_cell_idx_per_particle(cell_idx, sorted_idx,
             r_cell =  invdr*(rj - rmin) - 0.5
             z_cell =  invdz*(zj - zmin) - 0.5
 
-            # Original index of the uppper and upper cell
+            # Original index of the uppper grid point in z and r
             ir_upper = int(math.ceil( r_cell ))
             iz_upper = int(math.ceil( z_cell ))
 

--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -61,26 +61,27 @@ def get_cell_idx_per_particle(cell_idx, sorted_idx,
             z_cell =  invdz*(zj - zmin) - 0.5
 
             # Original index of the uppper and lower cell
-            ir_lower = int(math.floor( r_cell ))
+            ir_upper = int(math.floor( r_cell )) + 1
             iz_lower = int(math.floor( z_cell ))
 
             # Treat the boundary conditions
-            # guard cells in lower r
-            if ir_lower < 0:
-                ir_lower = 0
             # absorbing in upper r
-            if ir_lower > Nr-1:
-                ir_lower = Nr-1
+            if ir_upper > Nr:
+                ir_upper = Nr
             # periodic boundaries in z
             if iz_lower < 0:
                 iz_lower += Nz
-            if iz_lower > Nz-1:
+            elif iz_lower > Nz-1:
                 iz_lower -= Nz
+            # iz_lower has values between 0 and Nz-1.
+            # ir_upper has values between 0 and Nr (included).
+            # This corresponds to the Nz*(Nr+1) different inter-gridpoint
+            # areas in a box that is periodic in z but aperiodic in r.
 
             # Reset sorted_idx array
             sorted_idx[i] = i
-            # Calculate the 1D cell_idx by cell_idx_ir + cell_idx_iz * Nr
-            cell_idx[i] = ir_lower + iz_lower * Nr
+            # Calculate the 1D cell_idx
+            cell_idx[i] = ir_upper + iz_lower * (Nr+1)
 
 def sort_particles_per_cell(cell_idx, sorted_idx):
     """


### PR DESCRIPTION
This pull request is a proposition to slightly change the way in which we sort the particles on the GPU, in order to simplify the deposition kernels.

More precisely, in the current `dev` branch, the particles are sorted according to the index of their lower grid point in z and r as shown here with tuples of `(iz_lower, ir_lower)`. (In the code, these tuples are actually translated into a single index `ir_lower + Nr*iz_lower`, but this is a detail.)
<img width="400" alt="screen shot 2018-01-09 at 10 27 35 pm" src="https://user-images.githubusercontent.com/6685781/34758635-628d8952-f58c-11e7-8e0a-fd1a4bcad683.png">
Notice that the particles that are below the first radial grid cell do not have a lower grid point in r, and so, **currently**, they are put in the same "bag" as the particles that are inbetween the first radial grid point and second radial grid point. (The same problem does not occur in `z` because of the periodicity in z.)

Then, the deposition kernel on GPU go through the particles in each colored area and deposits charge/current to the surrounding grid points. However, because the particles below and above the first radial grid cell do not deposit charge to the same grid points and in the same way, the deposition kernel need a lot of if conditions to treat this special case.

Instead, I suggest that we slightly change the index according to which the particles are sorted and use, instead, the upper index:
<img width="375" alt="screen shot 2018-01-09 at 10 37 03 pm" src="https://user-images.githubusercontent.com/6685781/34758869-b1af326e-f58d-11e7-8fee-0991739232df.png">
The particles that are above the last grid point do not have an upper grid point, but in that case we can simply use `ir_upper = Nr`. Thus the index `ir_upper` can have values between `0` and `Nr` (included) and so the linearized index should be calculated according to `ir_upper + (Nr+1)*iz_upper`. (The same could have been done with `ir_lower` having values between `-1` and `Nr-1` but is less intuitive because of potentially negative values.)

In this case, the deposition kernels can be significantly simplified because we now know, from the sorting index (a.k.a prefix sum index) to which cells the macroparticles will deposit, without ambiguity. This is what this pull request does.

The automated tests pass on GPU.

The changes show essentially no speed-up (see table below), but allow, on the whole, to remove ~400 lines of code. In addition, I think the kernels are also conceptually slightly easier to understand.

|     | Cubic J  | Cubic rho | Linear J | Linear rho |
|-----|----------|-----------|----------|------------|
| dev | 89.438ms | 22.496ms  | 16.943ms | 5.7967ms   |
| PR  | 89.117ms | 22.413ms  | 16.832ms | 5.7674ms   |

This PR has a lot of changes in the file `cuda_methods.py`. I suggest looking at the kernel for linear deposition of rho to get the idea of the PR (since it is the simplest kernel and the other kernels are just repetitions of the same idea.)
  