### PR TITLE
Implement gathering for arbitrary number of modes, on CPU and GPU

### DIFF
--- a/fbpic/particles/gathering/cuda_methods_one_mode.py
+++ b/fbpic/particles/gathering/cuda_methods_one_mode.py
@@ -20,7 +20,13 @@ add_cubic_gather_for_mode = cuda.jit( add_cubic_gather_for_mode,
 @cuda.jit
 def erase_eb_cuda( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
     """
-    #TODO
+    Reset the arrays of fields (i.e. set them to 0)
+
+    Parameters
+    ----------
+    Ex, Ey, Ez, Bx, By, Bz: 1d arrays of floats
+        (One element per macroparticle)
+        Represents the fields on the macroparticles
     """
     i = cuda.grid(1)
     if i < Ntot:

--- a/fbpic/particles/gathering/threading_methods_one_mode.py
+++ b/fbpic/particles/gathering/threading_methods_one_mode.py
@@ -1,0 +1,333 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines the field gathering methods linear and cubic order shapes
+on the CPU with threading, for one azimuthal mode at a time
+"""
+import numba
+from numba import int64
+from fbpic.utils.threading import njit_parallel, prange
+import math
+import numpy as np
+# Import inline functions
+from .inline_functions import \
+    add_linear_gather_for_mode, add_cubic_gather_for_mode
+# Compile the inline functions for CPU
+add_linear_gather_for_mode = numba.njit( add_linear_gather_for_mode )
+add_cubic_gather_for_mode = numba.njit( add_cubic_gather_for_mode )
+
+@njit_parallel
+def erase_eb_numba( Ex, Ey, Ez, Bx, By, Bz ):
+    """
+    #TODO
+    """
+    for i in prange(len(Ex)):
+        Ex[i] = 0
+        Ey[i] = 0
+        Ez[i] = 0
+        Bx[i] = 0
+        By[i] = 0
+        Bz[i] = 0
+
+# -----------------------
+# Field gathering linear
+# -----------------------
+
+@njit_parallel
+def gather_field_numba_linear_one_mode(x, y, z,
+                    invdz, zmin, Nz,
+                    invdr, rmin, Nr,
+                    Er_m, Et_m, Ez_m,
+                    Br_m, Bt_m, Bz_m, m,
+                    Ex, Ey, Ez,
+                    Bx, By, Bz ):
+    """
+    Gathering of the fields (E and B) using numba with multi-threading.
+    Iterates over the particles, calculates the weighted amount
+    of fields acting on each particle based on its shape (linear).
+    Fields are gathered in cylindrical coordinates and then
+    transformed to cartesian coordinates.s
+
+    Parameters
+    ----------
+    x, y, z : 1darray of floats (in meters)
+        The position of the particles
+
+    invdz, invdr : float (in meters^-1)
+        Inverse of the grid step along the considered direction
+
+    zmin, rmin : float (in meters)
+        Position of the edge of the simulation box along the
+        direction considered
+
+    Nz, Nr : int
+        Number of gridpoints along the considered direction
+
+    Er_m, Et_m, Ez_m : 2darray of complexs
+        The electric fields on the interpolation grid for the mode m
+
+    Br_m, Bt_m, Bz_m : 2darray of complexs
+        The magnetic fields on the interpolation grid for the mode m
+
+    m: int
+        Index of the azimuthal mode
+
+    Ex, Ey, Ez : 1darray of floats
+        The electric fields acting on the particles
+        (is modified by this function)
+
+    Bx, By, Bz : 1darray of floats
+        The magnetic fields acting on the particles
+        (is modified by this function)
+    """
+    # Deposit the field per cell in parallel
+    for i in prange(x.shape[0]):
+        # Preliminary arrays for the cylindrical conversion
+        # --------------------------------------------
+        # Position
+        xj = x[i]
+        yj = y[i]
+        zj = z[i]
+
+        # Cylindrical conversion
+        rj = math.sqrt( xj**2 + yj**2 )
+        if (rj !=0. ) :
+            invr = 1./rj
+            cos = xj*invr  # Cosine
+            sin = yj*invr  # Sine
+        else :
+            cos = 1.
+            sin = 0.
+        exptheta_m = (cos - 1.j*sin)**m
+
+        # Get linear weights for the deposition
+        # -------------------------------------
+        # Positions of the particles, in the cell unit
+        r_cell =  invdr*(rj - rmin) - 0.5
+        z_cell =  invdz*(zj - zmin) - 0.5
+        # Original index of the uppper and lower cell
+        ir_lower = int(math.floor( r_cell ))
+        ir_upper = ir_lower + 1
+        iz_lower = int(math.floor( z_cell ))
+        iz_upper = iz_lower + 1
+        # Linear weight
+        Sr_lower = ir_upper - r_cell
+        Sr_upper = r_cell - ir_lower
+        Sz_lower = iz_upper - z_cell
+        Sz_upper = z_cell - iz_lower
+        # Set guard weights to zero
+        Sr_guard = 0.
+
+        # Treat the boundary conditions
+        # -----------------------------
+        # guard cells in lower r
+        if ir_lower < 0:
+            Sr_guard = Sr_lower
+            Sr_lower = 0.
+            ir_lower = 0
+        # absorbing in upper r
+        if ir_lower > Nr-1:
+            ir_lower = Nr-1
+        if ir_upper > Nr-1:
+            ir_upper = Nr-1
+        # periodic boundaries in z
+        # lower z boundaries
+        if iz_lower < 0:
+            iz_lower += Nz
+        if iz_upper < 0:
+            iz_upper += Nz
+        # upper z boundaries
+        if iz_lower > Nz-1:
+            iz_lower -= Nz
+        if iz_upper > Nz-1:
+            iz_upper -= Nz
+
+        # Precalculate Shapes
+        S_ll = Sz_lower*Sr_lower
+        S_lu = Sz_lower*Sr_upper
+        S_ul = Sz_upper*Sr_lower
+        S_uu = Sz_upper*Sr_upper
+        S_lg = Sz_lower*Sr_guard
+        S_ug = Sz_upper*Sr_guard
+
+        # E-Field
+        # -------
+        Fr = 0.
+        Ft = 0.
+        Fz = 0.
+        # Add contribution from mode m
+        Fr, Ft, Fz = add_linear_gather_for_mode( m,
+            Fr, Ft, Fz, exptheta_m, Er_m, Et_m, Ez_m,
+            iz_lower, iz_upper, ir_lower, ir_upper,
+            S_ll, S_lu, S_lg, S_ul, S_uu, S_ug )
+        # Convert to Cartesian coordinates
+        # and write to particle field arrays
+        Ex[i] += cos*Fr - sin*Ft
+        Ey[i] += sin*Fr + cos*Ft
+        Ez[i] += Fz
+
+        # B-Field
+        # -------
+        # Clear the placeholders for the
+        # gathered field for each coordinate
+        Fr = 0.
+        Ft = 0.
+        Fz = 0.
+        # Add contribution from mode m
+        Fr, Ft, Fz = add_linear_gather_for_mode( m,
+            Fr, Ft, Fz, exptheta_m, Br_m, Bt_m, Bz_m,
+            iz_lower, iz_upper, ir_lower, ir_upper,
+            S_ll, S_lu, S_lg, S_ul, S_uu, S_ug )
+        # Convert to Cartesian coordinates
+        # and write to particle field arrays
+        Bx[i] += cos*Fr - sin*Ft
+        By[i] += sin*Fr + cos*Ft
+        Bz[i] += Fz
+
+    return Ex, Ey, Ez, Bx, By, Bz
+
+# -----------------------
+# Field gathering cubic
+# -----------------------
+
+@njit_parallel
+def gather_field_numba_cubic_one_mode(x, y, z,
+                    invdz, zmin, Nz,
+                    invdr, rmin, Nr,
+                    Er_m, Et_m, Ez_m,
+                    Br_m, Bt_m, Bz_m, m,
+                    Ex, Ey, Ez,
+                    Bx, By, Bz,
+                    nthreads, ptcl_chunk_indices):
+    """
+    Gathering of the fields (E and B) using numba with multi-threading.
+    Iterates over the particles, calculates the weighted amount
+    of fields acting on each particle based on its shape (cubic).
+    Fields are gathered in cylindrical coordinates and then
+    transformed to cartesian coordinates.
+    Supports only mode 0 and 1.
+
+    Parameters
+    ----------
+    x, y, z : 1darray of floats (in meters)
+        The position of the particles
+
+    invdz, invdr : float (in meters^-1)
+        Inverse of the grid step along the considered direction
+
+    zmin, rmin : float (in meters)
+        Position of the edge of the simulation box along the
+        direction considered
+
+    Nz, Nr : int
+        Number of gridpoints along the considered direction
+
+    Er_m, Et_m, Ez_m : 2darray of complexs
+        The electric fields on the interpolation grid for the mode m
+
+    Br_m, Bt_m, Bz_m : 2darray of complexs
+        The magnetic fields on the interpolation grid for the mode m
+
+    m: int
+        Index of the azimuthal mode
+
+    Ex, Ey, Ez : 1darray of floats
+        The electric fields acting on the particles
+        (is modified by this function)
+
+    Bx, By, Bz : 1darray of floats
+        The magnetic fields acting on the particles
+        (is modified by this function)
+
+    nthreads : int
+        Number of CPU threads used with numba prange
+
+    ptcl_chunk_indices : array of int, of size nthreads+1
+        The indices (of the particle array) between which each thread
+        should loop. (i.e. divisions of particle array between threads)
+    """
+    # Gather the field per cell in parallel
+    for nt in prange( nthreads ):
+
+        # Create private arrays for each thread
+        # to store the particle index and shape
+        Sr = np.empty( 4 )
+        Sz = np.empty( 4 )
+
+        # Loop over all particles in thread chunk
+        for i in range( ptcl_chunk_indices[nt],
+                            ptcl_chunk_indices[nt+1] ):
+
+            # Preliminary arrays for the cylindrical conversion
+            # --------------------------------------------
+            # Position
+            xj = x[i]
+            yj = y[i]
+            zj = z[i]
+
+            # Cylindrical conversion
+            rj = math.sqrt(xj**2 + yj**2)
+            if (rj != 0.):
+                invr = 1./rj
+                cos = xj*invr  # Cosine
+                sin = yj*invr  # Sine
+            else:
+                cos = 1.
+                sin = 0.
+            exptheta_m = (cos - 1.j*sin)**m
+
+            # Get weights for the deposition
+            # --------------------------------------------
+            # Positions of the particle, in the cell unit
+            r_cell = invdr*(rj - rmin) - 0.5
+            z_cell = invdz*(zj - zmin) - 0.5
+
+            # Calculate the shape factors
+            ir_lowest = int64(math.floor(r_cell)) - 1
+            r_local = r_cell-ir_lowest
+            Sr[0] = -1./6. * (r_local-2.)**3
+            Sr[1] = 1./6. * (3.*(r_local-1.)**3 - 6.*(r_local-1.)**2 + 4.)
+            Sr[2] = 1./6. * (3.*(2.-r_local)**3 - 6.*(2.-r_local)**2 + 4.)
+            Sr[3] = -1./6. * (1.-r_local)**3
+            iz_lowest = int64(math.floor(z_cell)) - 1
+            z_local = z_cell-iz_lowest
+            Sz[0] = -1./6. * (z_local-2.)**3
+            Sz[1] = 1./6. * (3.*(z_local-1.)**3 - 6.*(z_local-1.)**2 + 4.)
+            Sz[2] = 1./6. * (3.*(2.-z_local)**3 - 6.*(2.-z_local)**2 + 4.)
+            Sz[3] = -1./6. * (1.-z_local)**3
+
+            # E-Field
+            # -------
+            Fr = 0.
+            Ft = 0.
+            Fz = 0.
+            # Add contribution from mode m
+            Fr, Ft, Fz = add_cubic_gather_for_mode( m,
+                Fr, Ft, Fz, exptheta_m, Er_m, Et_m, Ez_m,
+                ir_lowest, iz_lowest, Sr, Sz, Nr, Nz )
+            # Convert to Cartesian coordinates
+            # and write to particle field arrays
+            Ex[i] += cos*Fr - sin*Ft
+            Ey[i] += sin*Fr + cos*Ft
+            Ez[i] += Fz
+
+            # B-Field
+            # -------
+            # Clear the placeholders for the
+            # gathered field for each coordinate
+            Fr = 0.
+            Ft = 0.
+            Fz = 0.
+            # Add contribution from mode m
+            Fr, Ft, Fz = add_cubic_gather_for_mode( m,
+                Fr, Ft, Fz, exptheta_m, Br_m, Bt_m, Bz_m,
+                ir_lowest, iz_lowest, Sr, Sz, Nr, Nz )
+            # Convert to Cartesian coordinates
+            # and write to particle field arrays
+            Bx[i] += cos*Fr - sin*Ft
+            By[i] += sin*Fr + cos*Ft
+            Bz[i] += Fz
+
+    return Ex, Ey, Ez, Bx, By, Bz

--- a/fbpic/particles/gathering/threading_methods_one_mode.py
+++ b/fbpic/particles/gathering/threading_methods_one_mode.py
@@ -31,6 +31,7 @@ def erase_eb_numba( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
         Bx[i] = 0
         By[i] = 0
         Bz[i] = 0
+    return  Ex, Ey, Ez, Bx, By, Bz
 
 # -----------------------
 # Field gathering linear

--- a/fbpic/particles/gathering/threading_methods_one_mode.py
+++ b/fbpic/particles/gathering/threading_methods_one_mode.py
@@ -22,7 +22,13 @@ add_cubic_gather_for_mode = numba.njit( add_cubic_gather_for_mode )
 @njit_parallel
 def erase_eb_numba( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
     """
-    #TODO
+    Reset the arrays of fields (i.e. set them to 0)
+
+    Parameters
+    ----------
+    Ex, Ey, Ez, Bx, By, Bz: 1d arrays of floats
+        (One element per macroparticle)
+        Represents the fields on the macroparticles
     """
     for i in prange(Ntot):
         Ex[i] = 0

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -539,14 +539,15 @@ class Particles(object) :
                     erase_eb_cuda( self.Ex, self.Ey, self.Ez,
                                     self.Bx, self.By, self.Bz, self.Ntot )
                     for m in range(Nm):
-                        gather_field_gpu_linear_one_mode[dim_grid_1d, dim_block_1d](
-                             self.x, self.y, self.z,
-                             grid[m].invdz, grid[m].zmin, grid[m].Nz,
-                             grid[m].invdr, grid[m].rmin, grid[m].Nr,
-                             grid[m].Er, grid[m].Et, grid[m].Ez,
-                             grid[m].Br, grid[m].Bt, grid[m].Bz, m,
-                             self.Ex, self.Ey, self.Ez,
-                             self.Bx, self.By, self.Bz)
+                        gather_field_gpu_linear_one_mode[
+                            dim_grid_1d, dim_block_1d](
+                            self.x, self.y, self.z,
+                            grid[m].invdz, grid[m].zmin, grid[m].Nz,
+                            grid[m].invdr, grid[m].rmin, grid[m].Nr,
+                            grid[m].Er, grid[m].Et, grid[m].Ez,
+                            grid[m].Br, grid[m].Bt, grid[m].Bz, m,
+                            self.Ex, self.Ey, self.Ez,
+                            self.Bx, self.By, self.Bz)
             elif self.particle_shape == 'cubic':
                 if Nm == 2:
                     # Optimized version for 2 modes
@@ -565,7 +566,8 @@ class Particles(object) :
                     erase_eb_cuda( self.Ex, self.Ey, self.Ez,
                                     self.Bx, self.By, self.Bz, self.Ntot )
                     for m in range(Nm):
-                        gather_field_gpu_cubic_one_mode[dim_grid_1d, dim_block_1d](
+                        gather_field_gpu_cubic_one_mode[
+                            dim_grid_1d, dim_block_1d](
                             self.x, self.y, self.z,
                             grid[m].invdz, grid[m].zmin, grid[m].Nz,
                             grid[m].invdr, grid[m].rmin, grid[m].Nr,

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -35,6 +35,8 @@ if cuda_installed:
         deposit_J_gpu_linear, deposit_rho_gpu_cubic, deposit_J_gpu_cubic
     from .gathering.cuda_methods import gather_field_gpu_linear, \
         gather_field_gpu_cubic
+    from .gathering.cuda_methods_one_mode import erase_eb_cuda, \
+        gather_field_gpu_linear_one_mode, gather_field_gpu_cubic_one_mode
     from .utilities.cuda_sorting import write_sorting_buffer, \
         get_cell_idx_per_particle, sort_particles_per_cell, \
         prefill_prefix_sum, incl_prefix_sum
@@ -519,29 +521,58 @@ class Particles(object) :
             # Get the threads per block and the blocks per grid
             dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( self.Ntot, TPB=64 )
             # Call the CUDA Kernel for the gathering of E and B Fields
-            # for Mode 0 and 1 only.
             if self.particle_shape == 'linear':
-                gather_field_gpu_linear[dim_grid_1d, dim_block_1d](
-                     self.x, self.y, self.z,
-                     grid[0].invdz, grid[0].zmin, grid[0].Nz,
-                     grid[0].invdr, grid[0].rmin, grid[0].Nr,
-                     grid[0].Er, grid[0].Et, grid[0].Ez,
-                     grid[1].Er, grid[1].Et, grid[1].Ez,
-                     grid[0].Br, grid[0].Bt, grid[0].Bz,
-                     grid[1].Br, grid[1].Bt, grid[1].Bz,
-                     self.Ex, self.Ey, self.Ez,
-                     self.Bx, self.By, self.Bz)
+                if Nm == 2:
+                    # Optimized version for 2 modes
+                    gather_field_gpu_linear[dim_grid_1d, dim_block_1d](
+                         self.x, self.y, self.z,
+                         grid[0].invdz, grid[0].zmin, grid[0].Nz,
+                         grid[0].invdr, grid[0].rmin, grid[0].Nr,
+                         grid[0].Er, grid[0].Et, grid[0].Ez,
+                         grid[1].Er, grid[1].Et, grid[1].Ez,
+                         grid[0].Br, grid[0].Bt, grid[0].Bz,
+                         grid[1].Br, grid[1].Bt, grid[1].Bz,
+                         self.Ex, self.Ey, self.Ez,
+                         self.Bx, self.By, self.Bz)
+                else:
+                    # Generic version for arbitrary number of modes
+                    erase_eb_cuda( self.Ex, self.Ey, self.Ez,
+                                    self.Bx, self.By, self.Bz, self.Ntot )
+                    for m in range(Nm):
+                        gather_field_gpu_linear_one_mode[dim_grid_1d, dim_block_1d](
+                             self.x, self.y, self.z,
+                             grid[m].invdz, grid[m].zmin, grid[m].Nz,
+                             grid[m].invdr, grid[m].rmin, grid[m].Nr,
+                             grid[m].Er, grid[m].Et, grid[m].Ez,
+                             grid[m].Br, grid[m].Bt, grid[m].Bz, m,
+                             self.Ex, self.Ey, self.Ez,
+                             self.Bx, self.By, self.Bz)
             elif self.particle_shape == 'cubic':
-                gather_field_gpu_cubic[dim_grid_1d, dim_block_1d](
-                     self.x, self.y, self.z,
-                     grid[0].invdz, grid[0].zmin, grid[0].Nz,
-                     grid[0].invdr, grid[0].rmin, grid[0].Nr,
-                     grid[0].Er, grid[0].Et, grid[0].Ez,
-                     grid[1].Er, grid[1].Et, grid[1].Ez,
-                     grid[0].Br, grid[0].Bt, grid[0].Bz,
-                     grid[1].Br, grid[1].Bt, grid[1].Bz,
-                     self.Ex, self.Ey, self.Ez,
-                     self.Bx, self.By, self.Bz)
+                if Nm == 2:
+                    # Optimized version for 2 modes
+                    gather_field_gpu_cubic[dim_grid_1d, dim_block_1d](
+                         self.x, self.y, self.z,
+                         grid[0].invdz, grid[0].zmin, grid[0].Nz,
+                         grid[0].invdr, grid[0].rmin, grid[0].Nr,
+                         grid[0].Er, grid[0].Et, grid[0].Ez,
+                         grid[1].Er, grid[1].Et, grid[1].Ez,
+                         grid[0].Br, grid[0].Bt, grid[0].Bz,
+                         grid[1].Br, grid[1].Bt, grid[1].Bz,
+                         self.Ex, self.Ey, self.Ez,
+                         self.Bx, self.By, self.Bz)
+                else:
+                    # Generic version for arbitrary number of modes
+                    erase_eb_cuda( self.Ex, self.Ey, self.Ez,
+                                    self.Bx, self.By, self.Bz, self.Ntot )
+                    for m in range(Nm):
+                        gather_field_gpu_cubic_one_mode[dim_grid_1d, dim_block_1d](
+                            self.x, self.y, self.z,
+                            grid[m].invdz, grid[m].zmin, grid[m].Nz,
+                            grid[m].invdr, grid[m].rmin, grid[m].Nr,
+                            grid[m].Er, grid[m].Et, grid[m].Ez,
+                            grid[m].Br, grid[m].Bt, grid[m].Bz, m,
+                            self.Ex, self.Ey, self.Ez,
+                            self.Bx, self.By, self.Bz)
             else:
                 raise ValueError("`particle_shape` should be either \
                                   'linear' or 'cubic' \
@@ -564,7 +595,7 @@ class Particles(object) :
                 else:
                     # Generic version for arbitrary number of modes
                     erase_eb_numba( self.Ex, self.Ey, self.Ez,
-                                    self.Bx, self.By, self.Bz)
+                                    self.Bx, self.By, self.Bz, self.Ntot )
                     for m in range(Nm):
                         gather_field_numba_linear_one_mode(
                             self.x, self.y, self.z,
@@ -595,7 +626,7 @@ class Particles(object) :
                 else:
                     # Generic version for arbitrary number of modes
                     erase_eb_numba( self.Ex, self.Ey, self.Ez,
-                                    self.Bx, self.By, self.Bz )
+                                    self.Bx, self.By, self.Bz, self.Ntot )
                     for m in range(Nm):
                         gather_field_numba_cubic_one_mode(
                             self.x, self.y, self.z,

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -536,7 +536,8 @@ class Particles(object) :
                          self.Bx, self.By, self.Bz)
                 else:
                     # Generic version for arbitrary number of modes
-                    erase_eb_cuda( self.Ex, self.Ey, self.Ez,
+                    erase_eb_cuda[dim_grid_1d, dim_block_1d](
+                                    self.Ex, self.Ey, self.Ez,
                                     self.Bx, self.By, self.Bz, self.Ntot )
                     for m in range(Nm):
                         gather_field_gpu_linear_one_mode[
@@ -563,7 +564,8 @@ class Particles(object) :
                          self.Bx, self.By, self.Bz)
                 else:
                     # Generic version for arbitrary number of modes
-                    erase_eb_cuda( self.Ex, self.Ey, self.Ez,
+                    erase_eb_cuda[dim_grid_1d, dim_block_1d](
+                                    self.Ex, self.Ey, self.Ez,
                                     self.Bx, self.By, self.Bz, self.Ntot )
                     for m in range(Nm):
                         gather_field_gpu_cubic_one_mode[

--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -136,7 +136,7 @@ Nz = 200         # Number of gridpoints along z
 zmax = 40.e-6    # Length of the box along z (meters)
 Nr = 64          # Number of gridpoints along r
 rmax = 20.e-6    # Length of the box along r (meters)
-Nm = 2           # Number of modes used
+Nm = 3           # Number of modes used
 n_order = 16     # Order of the finite stencil
 # The simulation timestep
 dt = zmax/Nz/c   # Timestep (seconds)
@@ -154,7 +154,7 @@ p_nt = 8         # Number of particles per cell along theta
 # The plasma wave
 epsilon = 0.001    # Dimensionless amplitude of the wave in mode 0
 epsilon_1 = 0.001  # Dimensionless amplitude of the wave in mode 1
-epsilon_2 = 0.     # Dimensionless amplitude of the wave in mode 2
+epsilon_2 = 0.001  # Dimensionless amplitude of the wave in mode 2
 epsilons = [ epsilon, epsilon_1, epsilon_2 ]
 w0 = 5.e-6      # The transverse size of the plasma wave
 N_periods = 3   # Number of periods in the box


### PR DESCRIPTION
This implements the gathering functions for an arbitrary number of modes. Because the per-mode functions are usually slower than the functions for 2 modes, I duplicated the kernels. 

Also, when calling the gathering function for 2 modes, we overwrite the arrays of fields on the particles (these arrays typically contain the fields from the previous iteration, and so they *have* to be overwritten). However, when calling the per-mode kernel for each mode, we cannot overwrite the values anymore (otherwise calling the function for mode m=1 would overwrite for mode m=0). Therefore, I had to add a small kernel that sets the arrays of fields on the macroparticles to 0, and then the per-mode kernels *add* the value from each mode instead of overwriting.

I tested this and made sure that the new functions worked as expected.

Performance on GPU (GTX 1080 Ti), for the usual 2000x400 test (with 2 azimuthal modes):

- Using the usual functions for 2 modes:
gather_field_gpu_linear: 20.87 ms / iteration
gather_field_gpu_cubic: 80.52 ms / iteration

- Forcing the use of the per-mode kernel (thus these kernels are called twice per iteration - once per azimuthal mode):
(2x) gather_field_gpu_linear_one_mode: 26.3 ms / iteration
(2x) gather_field_gpu_cubic_one_mode: 86.52 ms / iteration
erase_eb_cuda: 1.42 ms / iteration
