### PR TITLE
Close #147 Add injection of relativistic particles through a plane

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -417,7 +417,7 @@ class Simulation(object):
             # Push the particles' positions and velocities to t = (n+1/2) dt
             if move_momenta:
                 for species in ptcl:
-                    species.push_p()
+                    species.push_p( self.time + 0.5*self.dt )
             if move_positions:
                 for species in ptcl:
                     species.halfpush_x()

--- a/fbpic/particles/injection/__init__.py
+++ b/fbpic/particles/injection/__init__.py
@@ -1,0 +1,7 @@
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It imports objects that handle continuous particle injection during
+the simulation.
+"""
+from .ballistic_before_plane import BallisticBeforePlane
+__all__ = ['BallisticBeforePlane']

--- a/fbpic/particles/injection/ballistic_before_plane.py
+++ b/fbpic/particles/injection/ballistic_before_plane.py
@@ -1,0 +1,60 @@
+# Copyright 2017, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines a class for particle injection "through a plane".
+"""
+from scipy.constants import c
+
+class BallisticBeforePlane( object ):
+    """
+    Class that defines particle injection "though a plane".    
+    In practice, when using this injection method, particles 
+    move ballistically before crossing a given plane. 
+
+    This is useful when running boosted-frame simulation, whereby a 
+    relativistic particle beam is initialized in vacuum and later enters the 
+    plasma. In this case, the particle beam may feel its own space charge 
+    force for a long distance (in the boosted-frame), which may alter its 
+    properties. Imposing that particles move ballistically before a plane 
+    (which corresponds to the entrance of the plasma) ensures that the 
+    particles do not feel this space charge force.
+    """
+
+    def __init__(self, z_plane_lab, boost):
+        """
+        Initialize the parameters of the plane.
+        
+        Parameters
+        ----------
+        z_plane_lab: float (in meters)
+            The (fixed) position of the plane, in the lab frame
+
+        boost: a BoostConverter object, optional
+            Defines the Lorentz boost of the simulation.
+        """
+        # Register the parameters of the plane
+        self.z_plane_lab = z_plane_lab
+        if boost is not None:
+            self.inv_gamma_boost = 1./boost.gamma0
+            self.beta_boost = boost.beta0
+        else:
+            self.gamma0 = 1.
+            
+
+    def get_current_plane_position( self, t ):
+        """
+        Get the current position of the plane, in the frame of the simulation 
+        
+        Parameters:
+        -----------
+        t: float (in seconds)
+            The time in the frame of the simulation
+        Returns:
+        --------
+        z_plane: float (in meters)
+            The position of the plane at t
+        """
+        z_plane = self.inv_gamma_boost*self.z_plane_lab - self.beta_boost*c*t
+        return( z_plane )

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -11,10 +11,13 @@ from scipy.constants import e
 from .tracking import ParticleTracker
 from .elementary_process.ionization import Ionizer
 from .elementary_process.compton import ComptonScatterer
+from .injection import BallisticBeforePlane
+
 # Load the utility methods
 from .utilities.utility_methods import unalign_angles
 # Load the numba methods
-from .push.numba_methods import push_p_numba, push_p_ioniz_numba, push_x_numba
+from .push.numba_methods import push_p_numba, push_p_ioniz_numba, \
+                                push_p_after_plane_numba, push_x_numba
 from .gathering.threading_methods import gather_field_numba_linear, \
         gather_field_numba_cubic
 from .gathering.threading_methods_one_mode import erase_eb_numba, \
@@ -30,7 +33,8 @@ from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     # Load the CUDA methods
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
-    from .push.cuda_methods import push_p_gpu, push_p_ioniz_gpu, push_x_gpu
+    from .push.cuda_methods import push_p_gpu, push_p_ioniz_gpu, \
+                                push_p_after_plane_gpu, push_x_gpu
     from .deposition.cuda_methods import deposit_rho_gpu_linear, \
         deposit_J_gpu_linear, deposit_rho_gpu_cubic, deposit_J_gpu_cubic
     from .deposition.cuda_methods_one_mode import \
@@ -150,6 +154,9 @@ class Particles(object) :
         self.Nptheta = Nptheta
         self.dens_func = dens_func
         self.continuous_injection = continuous_injection
+        # The particle injector stores information that is useful in order
+        # to continuously inject particles during the simulation
+        self.injector = None
 
         # Initialize the momenta
         self.uz = uz_m * np.ones(Ntot) + uz_th * np.random.normal(size=Ntot)
@@ -485,7 +492,7 @@ class Particles(object) :
             # Assign the old particle data array to the particle buffer
             self.int_sorting_buffer = particle_array
 
-    def push_p( self ) :
+    def push_p( self, t ) :
         """
         Advance the particles' momenta over one timestep, using the Vay pusher
         Reference : Vay, Physics of Plasmas 15, 056701 (2008)
@@ -493,23 +500,32 @@ class Particles(object) :
         This assumes that the momenta (ux, uy, uz) are initially one
         half-timestep *behind* the positions (x, y, z), and it brings
         them one half-timestep *ahead* of the positions.
+
+        Parameters
+        ----------
+        t: float
+            The current simulation time
+            (Useful for particles that are ballistic before a given plane)
         """
         # Skip push for neutral particles (e.g. photons)
         if self.q == 0:
             return
+        # For particles that are ballistic before a plane,
+        # get the current position of the plane
+        if isinstance( self.injector, BallisticBeforePlane ):
+            z_plane = self.injector.get_current_plane_position( t )
+            if self.ionizer is not None:
+                raise NotImplementedError('Ballistic injection before a plane '
+                    'is not implemented for ionizable particles.')
+        else:
+            z_plane = None
 
         # GPU (CUDA) version
         if self.use_cuda:
             # Get the threads per block and the blocks per grid
             dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( self.Ntot )
             # Call the CUDA Kernel for the particle push
-            if self.ionizer is None:
-                push_p_gpu[dim_grid_1d, dim_block_1d](
-                    self.ux, self.uy, self.uz, self.inv_gamma,
-                    self.Ex, self.Ey, self.Ez,
-                    self.Bx, self.By, self.Bz,
-                    self.q, self.m, self.Ntot, self.dt )
-            else:
+            if self.ionizer is not None:
                 # Ionizable species can have a charge that depends on the
                 # macroparticle, and hence require a different function
                 push_p_ioniz_gpu[dim_grid_1d, dim_block_1d](
@@ -517,18 +533,46 @@ class Particles(object) :
                     self.Ex, self.Ey, self.Ez,
                     self.Bx, self.By, self.Bz,
                     self.m, self.Ntot, self.dt, self.ionizer.ionization_level )
-        # CPU version
-        else:
-            if self.ionizer is None:
-                push_p_numba(self.ux, self.uy, self.uz, self.inv_gamma,
-                    self.Ex, self.Ey, self.Ez, self.Bx, self.By, self.Bz,
+            elif z_plane is not None:
+                # Particles that are ballistic before a plane also
+                # require a different pusher
+                push_p_after_plane_gpu[dim_grid_1d, dim_block_1d](
+                    self.z, z_plane,
+                    self.ux, self.uy, self.uz, self.inv_gamma,
+                    self.Ex, self.Ey, self.Ez,
+                    self.Bx, self.By, self.Bz,
                     self.q, self.m, self.Ntot, self.dt )
             else:
+                # Standard pusher
+                push_p_gpu[dim_grid_1d, dim_block_1d](
+                    self.ux, self.uy, self.uz, self.inv_gamma,
+                    self.Ex, self.Ey, self.Ez,
+                    self.Bx, self.By, self.Bz,
+                    self.q, self.m, self.Ntot, self.dt )
+
+        # CPU version
+        else:
+            if self.ionizer is not None:
                 # Ionizable species can have a charge that depends on the
                 # macroparticle, and hence require a different function
                 push_p_ioniz_numba(self.ux, self.uy, self.uz, self.inv_gamma,
                     self.Ex, self.Ey, self.Ez, self.Bx, self.By, self.Bz,
                     self.m, self.Ntot, self.dt, self.ionizer.ionization_level )
+            elif z_plane is not None:
+                # Particles that are ballistic before a plane also
+                # require a different pusher
+                push_p_after_plane_numba(
+                    self.z, z_plane,
+                    self.ux, self.uy, self.uz, self.inv_gamma,
+                    self.Ex, self.Ey, self.Ez,
+                    self.Bx, self.By, self.Bz,
+                    self.q, self.m, self.Ntot, self.dt )
+            else:
+                # Standard pusher
+                push_p_numba(self.ux, self.uy, self.uz, self.inv_gamma,
+                    self.Ex, self.Ey, self.Ez, self.Bx, self.By, self.Bz,
+                    self.q, self.m, self.Ntot, self.dt )
+
 
     def halfpush_x( self ) :
         """

--- a/fbpic/particles/push/cuda_methods.py
+++ b/fbpic/particles/push/cuda_methods.py
@@ -132,6 +132,39 @@ def push_p_gpu( ux, uy, uz, inv_gamma,
             ux[ip], uy[ip], uz[ip], inv_gamma[ip],
             Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip], econst, bconst)
 
+
+@cuda.jit
+def push_p_after_plane_gpu( z, z_plane, ux, uy, uz, inv_gamma,
+                Ex, Ey, Ez, Bx, By, Bz, q, m, Ntot, dt ) :
+    """
+    Advance the particles' momenta, using cuda on the GPU.
+    Only the particles that are located beyond the plane z=z_plane 
+    have their momentum modified ; the others particles move ballistically.
+
+    Parameters
+    ----------
+    z: 1darray of floats
+        The position of the particles in the z direction
+        
+    z_plane: float
+        Position beyond which the particles should be 
+        
+    For the other parameters, see the docstring of push_p_gpu
+    """
+    # Set a few constants
+    econst = q*dt/(m*c)
+    bconst = 0.5*q*dt/m
+
+    # Cuda 1D grid
+    ip = cuda.grid(1)
+
+    # Loop over the particles
+    if ip < Ntot and z[ip] > z_plane:
+        ux[ip], uy[ip], uz[ip], inv_gamma[ip] = push_p_vay(
+            ux[ip], uy[ip], uz[ip], inv_gamma[ip],
+            Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip], econst, bconst)
+
+
 @cuda.jit
 def push_p_ioniz_gpu( ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz,
@@ -143,31 +176,11 @@ def push_p_ioniz_gpu( ux, uy, uz, inv_gamma,
 
     Parameters
     ----------
-    ux, uy, uz : 1darray of floats
-        The velocity of the particles
-        (is modified by this function)
-
-    inv_gamma : 1darray of floats
-        The inverse of the relativistic gamma factor
-
-    Ex, Ey, Ez : 1darray of floats
-        The electric fields acting on the particles
-
-    Bx, By, Bz : 1darray of floats
-        The magnetic fields acting on the particles
-
-    m : float
-        The mass of the particle species
-
-    Ntot : int
-        The total number of particles
-
-    dt : float
-        The time by which the momenta is advanced
-
     ionization_level : 1darray of ints
         The number of electrons that each ion is missing
         (compared to a neutral atom)
+        
+    For the other parameters, see the docstring of push_p_gpu
     """
     #Cuda 1D grid
     ip = cuda.grid(1)

--- a/fbpic/particles/push/numba_methods.py
+++ b/fbpic/particles/push/numba_methods.py
@@ -49,6 +49,26 @@ def push_p_numba( ux, uy, uz, inv_gamma,
     return ux, uy, uz, inv_gamma
 
 @njit_parallel
+def push_p_after_plane_numba( z, z_plane, ux, uy, uz, inv_gamma,
+                Ex, Ey, Ez, Bx, By, Bz, q, m, Ntot, dt ) :
+    """
+    Advance the particles' momenta, using numba.
+    Only the particles that are located beyond the plane z=z_plane 
+    have their momentum modified ; the others particles move ballistically.
+    """
+    # Set a few constants
+    econst = q*dt/(m*c)
+    bconst = 0.5*q*dt/m
+
+    # Loop over the particles (in parallel if threading is installed)
+    for ip in prange(Ntot) :
+        if z[ip] > z_plane:
+            ux[ip], uy[ip], uz[ip], inv_gamma[ip] = push_p_vay(
+                ux[ip], uy[ip], uz[ip], inv_gamma[ip],
+                Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip], econst, bconst)
+
+
+@njit_parallel
 def push_p_ioniz_numba( ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz, m, Ntot, dt, ionization_level ) :
     """

--- a/tests/test_beam_focusing.py
+++ b/tests/test_beam_focusing.py
@@ -1,0 +1,152 @@
+# Copyright 2018, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This test file is part of FB-PIC (Fourier-Bessel Particle-In-Cell).
+
+It tests the routines that initialize a Gaussian beam, by making
+sure that they produce the right RMS beam at focus.
+
+More precisely, the simulations are run in the boosted frame, and
+the beam is propagated up to the focal position, under its own space-charge
+field. Typically, because of the space charge field acting on long
+distances in the boosted frame, the intended RMS beam size is not reached.
+However, by using the ballistic injection before the focal plane, the
+beam does not feel these forces and reaches the right focus.
+"""
+# -------
+# Imports
+# -------
+import numpy as np
+from scipy.constants import c
+import shutil
+# Import the relevant structures in FBPIC
+from fbpic.main import Simulation
+from fbpic.lpa_utils.bunch import add_elec_bunch_gaussian
+from fbpic.lpa_utils.boosted_frame import BoostConverter
+from fbpic.openpmd_diag import BoostedParticleDiagnostic
+from opmd_viewer import OpenPMDTimeSeries
+
+# ----------
+# Parameters
+# ----------
+use_cuda = True
+
+# The simulation box
+Nz = 100
+zmax = 0.e-6
+zmin = -20.e-6
+Nr = 200
+rmax = 20.e-6
+Nm = 1
+# The simulation timestep
+dt = (zmax-zmin)/Nz/c
+N_step = 101
+
+# Boosted frame
+gamma_boost = 15.
+boost = BoostConverter( gamma_boost )
+
+# The bunch
+sigma_r = 1.e-6
+sigma_z = 3.e-6
+Q = 200.e-12
+gamma0 = 100.
+sigma_gamma = 0.
+n_emit = 0.1e-6
+z_focus = 2000.e-6
+z0 = -10.e-6
+N = 40000
+
+# The diagnostics
+diag_period = 5
+Ntot_snapshot_lab = 21
+dt_snapshot_lab = 2*(z_focus-z0)/c/20
+v_comoving = c*np.sqrt(1.-1./gamma0**2)
+
+def test_beam_focusing( show=False ):
+    """
+    Runs the simulation of a focusing charged beam, in a boosted-frame,
+    with and without the injection through a plane.
+    The value of the RMS radius at focus is automatically checked.
+    """
+    # Simulate beam focusing with injection through plane or not
+    simulate_beam_focusing( None, 'direct' )
+    simulate_beam_focusing( z_focus, 'through_plane' )
+
+    # Analyze the results and show that the beam reaches
+    # the right RMS radius at focus
+    ts1 = OpenPMDTimeSeries('./direct/hdf5/')
+    r1 = get_rms_radius( ts1 )
+    ts2 = OpenPMDTimeSeries('./through_plane/hdf5/')
+    r2 = get_rms_radius( ts2 )
+    if show:
+        import matplotlib.pyplot as plt
+        plt.plot( 1.e3*c*ts1.t, 1.e6*r1 )
+        plt.plot( 1.e3*c*ts2.t, 1.e6*r2 )
+        plt.xlabel( 'z (mm)' )
+        plt.ylabel( 'RMS radius (microns)' )
+        plt.show()
+    # Find the index of the output at z_focus
+    i = np.argmin( abs( c*ts2.t - z_focus ) )
+    # With injection through plane, we get the right RMS value at focus
+    assert abs( r2[i] - sigma_r ) < 0.05e-6
+    # Without injection through plane, the RMS value is significantly different
+    assert abs( r1[i] - sigma_r ) > 0.5e-6
+
+    # Clean up the data folders
+    shutil.rmtree( 'direct' )
+    shutil.rmtree( 'through_plane' )
+
+def simulate_beam_focusing( z_injection_plane, write_dir ):
+    """
+    Simulate a focusing beam in the boosted frame
+
+    Parameters
+    ----------
+    z_injection_plane: float or None
+        when this is not None, the injection through a plane is
+        activated.
+    write_dir: string
+        The directory where the boosted diagnostics are written.
+    """
+    # Initialize the simulation object
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
+        p_zmin=0., p_zmax=0., p_rmin=0., p_rmax=0.,
+        p_nz=0, p_nr=0, p_nt=0, n_e=0., zmin=zmin,
+        gamma_boost=gamma_boost, boundaries='open',
+        use_cuda=use_cuda, v_comoving=v_comoving )
+
+    # Remove the plasma particles
+    sim.ptcl = []
+
+    # Initialize the bunch, along with its space charge
+    add_elec_bunch_gaussian( sim, sigma_r, sigma_z, n_emit, gamma0,
+        sigma_gamma, Q, N, tf=(z_focus-z0)/c, zf=z_focus, boost=boost,
+        z_injection_plane=z_injection_plane )
+
+    # Configure the moving window
+    sim.set_moving_window( v=c, gamma_boost=gamma_boost )
+
+    # Add a field diagnostic
+    sim.diags = [
+        BoostedParticleDiagnostic( zmin, zmax, c, dt_snapshot_lab,
+            Ntot_snapshot_lab, gamma_boost, period=100, fldobject=sim.fld,
+            species={'bunch':sim.ptcl[0]}, comm=sim.comm, write_dir=write_dir)
+        ]
+
+    # Run the simulation
+    sim.step( N_step )
+
+def get_rms_radius(ts):
+    """
+    Calculate the RMS radius at the different iterations of the timeseries.
+    """
+    r = []
+    for iteration in ts.iterations:
+        x, w = ts.get_particle( ['x', 'w'], iteration=iteration )
+        r.append( np.sqrt( np.average( x**2, weights=w ) ) )
+    return( 1.e-6*np.array(r) )
+
+if __name__ == '__main__':
+    test_beam_focusing( show=True )


### PR DESCRIPTION
This add the ability to inject relativistic particles through a plane that has a fixed position in the lab frame (as a consequence the plane moves in the boosted frame). More precisely, the particles will have a ballistic motion before the plane (i.e. they do not feel the fields) and will have a non-ballistic motion after the plane. These particles still deposit their charge and currents both before and after the plane.

The API of the functions that inject a bunch have been modified so that the user can pass the position of the plane (in the lab frame).

This implementation also introduces a generic `injector` attributes for any instance of `Particles`. Right now, the `BallisticBeforePlane` is the only possible injector, but in the future, I would like to refactor the code that does continuous injection and make it another possible type of `injector`. Right now, all this `injector` logic is internal to the code, and is not intended to be used/initialized directly by the user.

TODO:
- [x] Add an automated test for this capability.