### PR TITLE
Prevent out-of-bound in CPU charge/current deposition

### DIFF
--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -167,7 +167,8 @@ def deposit_rho_numba_linear(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
             # Index of the lowest cell of `global_array` that gets modified
             # by this particle (note: `global_array` has 2 guard cells)
-            ir_cell = int(math.floor( r_cell )) + 2
+            # (`min` function avoids out-of-bounds access at high r)
+            ir_cell = min( int(math.floor(r_cell))+2, Nr+2 )
             iz_cell = int(math.floor( z_cell )) + 2
 
             # Add contribution of this particle to the global array
@@ -295,7 +296,8 @@ def deposit_J_numba_linear(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
             # Index of the lowest cell of `global_array` that gets modified
             # by this particle (note: `global_array` has 2 guard cells)
-            ir_cell = int(math.floor( r_cell )) + 2
+            # (`min` function avoids out-of-bounds access at high r)
+            ir_cell = min( int(math.floor(r_cell))+2, Nr+2 )
             iz_cell = int(math.floor( z_cell )) + 2
 
             # Add contribution of this particle to the global array
@@ -416,7 +418,8 @@ def deposit_rho_numba_cubic(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
             # Index of the lowest cell of `global_array` that gets modified
             # by this particle (note: `global_array` has 2 guard cells)
-            ir_cell = int(math.floor( r_cell )) + 1
+            # (`min` function avoids out-of-bounds access at high r)
+            ir_cell = min( int(math.floor(r_cell))+1, Nr+1 )
             iz_cell = int(math.floor( z_cell )) + 1
 
             # Add contribution of this particle to the global array
@@ -560,7 +563,8 @@ def deposit_J_numba_cubic(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
             # Index of the lowest cell of `global_array` that gets modified
             # by this particle (note: `global_array` has 2 guard cells)
-            ir_cell = int(math.floor( r_cell )) + 1
+            # (`min` function avoids out-of-bounds access at high r)
+            ir_cell = min( int(math.floor(r_cell))+1, Nr+1 )
             iz_cell = int(math.floor( z_cell )) + 1
 
             # Add contribution of this particle to the global array


### PR DESCRIPTION
In the latest release of fbpic, there is a bug caused by PR #137 ("Simplify current deposition on CPU and generalize it for multi-mode") : when performing charge/current deposition, particles that are at high radius can potentially do out-of-bound array access. 

This only affects the code on CPU, but can have drastic effect, as in the typical simulations of laser-wakefield below: (My guess is that the out-of-bound access can result in accessing array indices that normally correspond to low-radius, hence the observed spurious high density close to the axis)

- **fbpic 0.7.0, on CPU**:

<img width="432" alt="screen shot 2018-01-28 at 7 56 37 pm" src="https://user-images.githubusercontent.com/6685781/35493054-61d09dc8-0465-11e8-9ffe-7d99b7d218bd.png">

- **fbpic 0.7.0, on GPU**:

<img width="447" alt="screen shot 2018-01-28 at 7 57 04 pm" src="https://user-images.githubusercontent.com/6685781/35493067-75863f12-0465-11e8-8c0a-4f884ed4281e.png">

The current pull request fixes this:

- **Current PR, on CPU**

<img width="420" alt="screen shot 2018-01-28 at 8 00 26 pm" src="https://user-images.githubusercontent.com/6685781/35493125-ea47f016-0465-11e8-94ff-b4a06e66daff.png">
