### PR TITLE
Close #190 Restarting is buggy because `_zmin_global_domain` needs to be set

### DIFF
--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -123,6 +123,9 @@ def restart_from_checkpoint( sim, iteration=None ):
         name = 'species %d' %i
         load_species( sim.ptcl[i], name, ts, iteration, sim.comm )
 
+    # Record position of grid before restart
+    zmin_old = sim.fld.interp[0].zmin
+
     # Load the fields
     # Loop through the different modes
     for m in range( sim.fld.Nm ):
@@ -131,6 +134,10 @@ def restart_from_checkpoint( sim, iteration=None ):
             for coord in ['r', 't', 'z']:
                 load_fields( sim.fld.interp[m], fieldtype,
                              coord, ts, iteration )
+    # Record position after restart (`zmin` is modified by `load_fields`)
+    # and shift the global domain position in the BoundaryCommunicator
+    zmin_new = sim.fld.interp[0].zmin
+    sim.comm.shift_global_domain_positions( zmin_new - zmin_old )
 
 def check_restart( sim, iteration ):
     """Verify that the restart is valid."""


### PR DESCRIPTION
PR #179 introduced the the new variable `_zmin_global_domain`. This variable needs to be updated when performing a restart. 

In the current `dev` branch, this is not the case. As a result, the moving window and continuous injection of plasma will behave strangely, as in this example (with a restart at iteration 100, and continuous injection of a plasma with a density ramp):
<img width="577" alt="screen shot 2018-01-29 at 7 50 30 am" src="https://user-images.githubusercontent.com/6685781/35519651-b644327a-04c9-11e8-9ee6-051963e1411d.png">

On the other hand, this PR updates `_zmin_global_domain` (by calling the function `shift_global_domain_positions`), and results in correct injection:
<img width="596" alt="screen shot 2018-01-29 at 7 51 15 am" src="https://user-images.githubusercontent.com/6685781/35519719-dd29d50c-04c9-11e8-993b-f3c8a81935f3.png">
