### PR TITLE
Automate and generalize the test for linear laser-wakefield

### DIFF
--- a/tests/test_linear_wakefield.py
+++ b/tests/test_linear_wakefield.py
@@ -64,9 +64,12 @@ def test_linear_wakefield( Nm=1, show=False ):
     Nm: int
         The number of azimuthal modes used in the simulation (Use 1, 2 or 3)
         This also determines the profile of the driving laser:
-        - Nm=1: azimuthally-polarized annular laser (entirely in mode m=0)
-        - Nm=2: linearly-polarized Gaussian laser (entirely in mode m=1)
-        - Nm=3: linearly-polarized Laguerre-Gauss laser (in mode m=0 and m=2)
+        - Nm=1: azimuthally-polarized annular laser 
+          (laser in mode m=0, wakefield in mode m=0)
+        - Nm=2: linearly-polarized Gaussian laser
+          (laser in mode m=1, wakefield in mode m=0)
+        - Nm=3: linearly-polarized Laguerre-Gauss laser
+          (laser in mode m=0 and m=2, wakefield in mode m=0 and m=2, 
 
     show: bool
         Whether to have pop-up windows show the comparison between

--- a/tests/test_linear_wakefield.py
+++ b/tests/test_linear_wakefield.py
@@ -304,7 +304,7 @@ use_cuda = True
 # The simulation box
 Nz = 800         # Number of gridpoints along z
 zmax = 40.e-6    # Length of the box along z (meters)
-Nr = 60          # Number of gridpoints along r
+Nr = 120          # Number of gridpoints along r
 rmax = 60.e-6    # Length of the box along r (meters)
 # The simulation timestep
 dt = zmax/Nz/c   # Timestep (seconds)
@@ -325,7 +325,7 @@ a0 = 0.01        # Laser amplitude
 w0 = 20.e-6       # Laser waist
 ctau = 6.e-6     # Laser duration
 tau = ctau/c
-z0 = 27.e-6      # Laser centroid
+z0 = 22.e-6      # Laser centroid
 
 # Plasma and laser wavenumber
 kp = 1./c * np.sqrt( n_e * e**2 / (m_e * epsilon_0) )

--- a/tests/test_linear_wakefield.py
+++ b/tests/test_linear_wakefield.py
@@ -144,9 +144,15 @@ def compare_fields(sim, Nm, show) :
             Er_sim += 2 * gathered_grids[m].Er.real
             # The factor 2 comes from the definitions in FBPIC
 
+        # Show the fields if required by the user
         if show:
             plot_compare_wakefields(Ez_analytical, Er_analytical,
                                     Ez_sim, Er_sim, gathered_grids[0])
+        # Automatically check the accuracy
+        assert np.allclose( Ez_sim, Ez_analytical,
+                            atol=0.08*abs(Ez_analytical).max() )
+        assert np.allclose( Er_sim, Er_analytical,
+                            atol=0.11*abs(Er_analytical).max() )
 
 # -------------------
 # Analytical solution

--- a/tests/test_linear_wakefield.py
+++ b/tests/test_linear_wakefield.py
@@ -280,19 +280,19 @@ def plot_compare_wakefields(Ez_analytic, Er_analytic, Ez_sim, Er_sim, grid):
 
     # Plot lineouts of Ez (simulation and analytical solution)
     plt.subplot(325)
-    plt.plot(1.e6*z, Ez_sim[:,0].real,
+    plt.plot(1.e6*z, Ez_sim[:,10].real,
         color = 'b', label = 'Simulation')
-    plt.plot(1.e6*z, Ez_analytic[:,0], color = 'r', label = 'Analytical')
+    plt.plot(1.e6*z, Ez_analytic[:,10], color = 'r', label = 'Analytical')
     plt.xlabel('z')
     plt.ylabel('Ez')
     plt.legend(loc=0)
-    plt.title('PIC vs. Analytical - On-axis lineout of Ez')
+    plt.title('PIC vs. Analytical - Off-axis lineout of Ez')
 
     # Plot lineouts of Er (simulation and analytical solution)
     plt.subplot(326)
-    plt.plot(1.e6*z, Er_sim[:,5].real,
+    plt.plot(1.e6*z, Er_sim[:,10].real,
         color = 'b', label = 'Simulation')
-    plt.plot(1.e6*z, Er_analytic[:,5], color = 'r', label = 'Analytical')
+    plt.plot(1.e6*z, Er_analytic[:,10], color = 'r', label = 'Analytical')
     plt.xlabel('z')
     plt.ylabel('Er')
     plt.legend(loc=0)

--- a/tests/test_linear_wakefield.py
+++ b/tests/test_linear_wakefield.py
@@ -209,7 +209,7 @@ def compare_fields(sim) :
     Gather the results and compare them with the analytical predicitions
     """
     # Gather all the modes
-    gathered_grids = [ sim.comm.gather_grid(sim.fld.interp[0]) \
+    gathered_grids = [ sim.comm.gather_grid(sim.fld.interp[m]) \
                            for m in range(Nm) ]
     if sim.comm.rank==0 :
         z = gathered_grids[0].z

--- a/tests/test_linear_wakefield.py
+++ b/tests/test_linear_wakefield.py
@@ -16,7 +16,7 @@ Theory:
 This test considers a laser of the form
 $$ \vec{a} = a_0 e^{-(xi-xi_0)^2/(c\tau)^2}\vec{f}(r, \theta) $$
 where $f$ represents the transverse profile of the laser, and is either
-a radially polarized annular beam, or a linear polarized Laguerre-Gauss pulse.
+a azimuthally polarized annular beam, or linear polarized Laguerre-Gauss pulse
 
 Then, in the linear regime, the pseudo-potential is given by:
 $$ \psi = \frac{k_p}{2}\int^xi_{-\infty} \langle \vec{a}^2 \rangle
@@ -70,7 +70,7 @@ def Ez( z, r, t) :
                         args = ( z[iz]-c*t,), limit=30 )[0]
     # Transverse profile
     if Nm in [1, 3]:
-        trans_profile = 2 * (r/w0)**2 * np.exp( -2*r**2/w0**2 )
+        trans_profile = 4 * (r/w0)**2 * np.exp( -2*r**2/w0**2 )
     elif Nm == 2:
         trans_profile = np.exp( -2*r**2/w0**2 )
 
@@ -99,7 +99,7 @@ def Er( z, r, t) :
                         args = (z[iz]-c*t,), limit=200 )[0]
     # Transverse profile: gradient of transverse intensity
     if Nm in [1, 3]:
-        trans_profile = 4*(r/w0**2) * (1-2*r**2/w0**2) * np.exp(-2*r**2/w0**2)
+        trans_profile = 8*(r/w0**2) * (1-2*r**2/w0**2) * np.exp(-2*r**2/w0**2)
     elif Nm == 2:
         trans_profile = -4*r/w0**2 * np.exp(-2*r**2/w0**2)
 
@@ -221,8 +221,8 @@ use_cuda = True
 # The simulation box
 Nz = 800         # Number of gridpoints along z
 zmax = 40.e-6    # Length of the box along z (meters)
-Nr = 50          # Number of gridpoints along r
-rmax = 50.e-6    # Length of the box along r (meters)
+Nr = 60          # Number of gridpoints along r
+rmax = 60.e-6    # Length of the box along r (meters)
 Nm = 1           # Number of modes used
 # The simulation timestep
 dt = zmax/Nz/c   # Timestep (seconds)
@@ -233,7 +233,7 @@ N_step = 1500
 p_zmin = 39.e-6  # Position of the beginning of the plasma (meters)
 p_zmax = 41.e-6  # Position of the end of the plasma (meters)
 p_rmin = 0.      # Minimal radial position of the plasma (meters)
-p_rmax = 45.e-6  # Maximal radial position of the plasma (meters)
+p_rmax = 55.e-6  # Maximal radial position of the plasma (meters)
 n_e = 8.e24      # Density (electrons.meters^-3)
 p_nz = 2         # Number of particles per cell along z
 p_nr = 2         # Number of particles per cell along r
@@ -249,7 +249,7 @@ z0 = 27.e-6      # Laser centroid
 # Diagnostics
 write_fields = False
 write_particles = False
-diag_period = 5
+diag_period = 50
 
 # Plasma and laser wavenumber
 kp = 1./c * np.sqrt( n_e * e**2 / (m_e * epsilon_0) )
@@ -262,11 +262,11 @@ sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
 
 # Create the relevant laser profile
 if Nm == 1:
-    # Build a radially-polarized pulse from 2 Laguerre-Gauss profiles
-    profile = LaguerreGaussLaser( 0, 1, 0.5*a0, w0, tau, z0,
-                                  theta_pol=0., theta0=0. ) \
-            + LaguerreGaussLaser( 0, 1, 0.5*a0, w0, tau, z0,
-                                  theta_pol=np.pi/2, theta0=np.pi/2 )
+    # Build an azimuthally-polarized pulse from 2 Laguerre-Gauss profiles
+    profile = LaguerreGaussLaser( 0, 1, a0, w0, tau, z0,
+                                  theta_pol=np.pi/2, theta0=0. ) \
+            + LaguerreGaussLaser( 0, 1, a0, w0, tau, z0,
+                                  theta_pol=0., theta0=-np.pi/2 )
 elif Nm == 2:
     profile = GaussianLaser(a0=a0, waist=w0, tau=tau, z0=z0 )
 elif Nm == 3:


### PR DESCRIPTION
I modified the linear laser-wakefield test so that:
- It can test the wakefield generated in different azimuthal modes (including m=2)
- It checks the accuracy of the wakefield (profile and amplitude) automatically
- The test runs for each push (but only using m=0, in this case, for faster tests)

Regarding the first point (wakefield generated in different azimuthal modes), I modified the script so that it tests the following situations: (For each situation, the 3D image shows the laser (red-orange) and Ez in the wakefield (blue-yellow).)

- **Donut-shaped laser, polarized along theta**: in this case, both the laser and the wakefield are donut-shaped, and entirely contained in mode m=0. So only one azimuthal mode is used in the calculation. (This is the case which is automatically tested for each push.)
<img width="491" alt="screen shot 2018-02-07 at 10 36 27 pm" src="https://user-images.githubusercontent.com/6685781/35958980-6208ee3a-0c58-11e8-934d-48675c5671bb.png">

- **Linearly-polarized Gaussian laser**: This is the standard LWFA case (laser in mode m=1, wakefield in mode m=0). This uses 2 modes.
<img width="432" alt="screen shot 2018-02-07 at 10 32 14 pm" src="https://user-images.githubusercontent.com/6685781/35959022-9397695e-0c58-11e8-8c70-0224d79b3831.png">

- **Linearly-polarized Laguerre-Gauss laser**: This illustrates the new capabilities of the higher-order modes. Here the laser and the wakefield are in mode m=0 and m=2. The simulation uses 3 modes.
<img width="486" alt="3_modes" src="https://user-images.githubusercontent.com/6685781/35959062-c43bfe3a-0c58-11e8-8653-a6cceb6a0113.png">

Although the Travis CI tests only tests the first situation (the cheapest one, computationally), one can test all three configurations by doing `python test_linear_wakefield.py`. I ran it on CPU and GPU and checked that it produced the correct wakefield, including in the case involving m=2.

Note: This makes the Travis tests longer by ~3-4 min, but I think that this is an important test to have, as it is the closest to simulations that we actually use in production.