### PR TITLE
Modify test_periodic_plasma so that it can be run in parallel

### DIFF
--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -203,10 +203,11 @@ def simulate_periodic_plasma_wave( particle_shape, show=False ):
     # Run the simulation
     sim.step( N_step, correct_currents=True )
 
-    # Test check that div(E) - rho = 0 (directly in spectral space)
-    check_charge_conservation( sim, rho_ions )
     # Plot the results and compare with analytical theory
     compare_fields( sim, show )
+    # Test check that div(E) - rho = 0 (directly in spectral space)
+    check_charge_conservation( sim, rho_ions )
+
 
 # -----------------------------------------
 # Analytical solutions for the plasma wave


### PR DESCRIPTION
This modification was previously made on the `cross_deposition` branch.
Because this change is not specific to the `cross_deposition`, I implement it separately here.

Note that, because we currently do not have a charge-conserving algorithm for parallel simulations, this test fails when run in parallel (but is successful when run in serial).