### PR TITLE
Impose that the period of the diagnostics is an int

### DIFF
--- a/fbpic/openpmd_diag/generic_diag.py
+++ b/fbpic/openpmd_diag/generic_diag.py
@@ -56,7 +56,7 @@ class OpenPMDDiagnostic(object) :
             self.rank = 0
 
         # Register the arguments
-        self.period = period
+        self.period = int(round(period))  # Impose integer period
         self.iteration_min = iteration_min
         self.iteration_max = iteration_max
         self.comm = comm


### PR DESCRIPTION
It turns out that, if the user passes a float for `period`, then diagnostics are sometimes never written.

(This is because the code checks `iteration % period == 0` in order to determine whether to write a file at this iteration. If period is a float, then this operation is still defined. If `period` is nearly equal to an integer but not exactly (due to e.g. machine precision), then the above condition is sometimes never met.)