### PR TITLE
Remove matplotlib requirements for automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ install:
   - python setup.py install
 before_script:
   - python -m pyflakes .
-  - pip install matplotlib openPMD-viewer
+  - pip install openPMD-viewer
 script:
   - "python setup.py test"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     maintainer_email='remi.lehe@normalesup.org',
     license='BSD-3-Clause-LBNL',
     packages=find_packages('.'),
-    tests_require=['pytest', 'matplotlib', 'openpmd_viewer'],
+    tests_require=['pytest', 'openpmd_viewer'],
     cmdclass={'test': PyTest},
     install_requires=install_requires,
     include_package_data=True,

--- a/tests/test_boosted.py
+++ b/tests/test_boosted.py
@@ -27,7 +27,6 @@ $ python setup.py test
 # -------
 import numpy as np
 from scipy.constants import c
-import matplotlib.pyplot as plt
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
 
@@ -125,6 +124,7 @@ def test_cherenkov_instability( show=False ):
 
         # Check/plot the results
         if show:
+            import matplotlib.pyplot as plt
             # Add a plot
             plt.semilogy( t, Er_rms, '-', label=scheme )
             plt.ylabel('RMS(Er)')

--- a/tests/test_continuous_injection.py
+++ b/tests/test_continuous_injection.py
@@ -19,7 +19,6 @@ $ python tests/test_continuous_injection.py
 """
 from scipy.constants import c, e
 from fbpic.main import Simulation
-import matplotlib.pyplot as plt
 import numpy as np
 
 # Parameters
@@ -134,6 +133,7 @@ def check_density( sim, gamma_boost, dens_func, show ):
 
     # Show the results
     if show:
+        import matplotlib.pyplot as plt
         extent = 1.e6*np.array([ gathered_grid.zmin, gathered_grid.zmax,
                    gathered_grid.rmin, gathered_grid.rmax ])
 

--- a/tests/test_external_fields.py
+++ b/tests/test_external_fields.py
@@ -11,7 +11,6 @@ $ python tests/test_external_fields.py
 
 """
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy.constants import e, m_e, c
 from fbpic.main import Simulation
 from fbpic.lpa_utils.external_fields import ExternalField
@@ -102,6 +101,7 @@ def test_external_laser_field(show=False):
 
     # Show the results
     if show:
+        import matplotlib.pyplot as plt
         plt.figure(figsize=(10,5))
 
         plt.subplot(211)

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -35,7 +35,6 @@ or
 $ python setup.py test
 """
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy.constants import c, m_e, e
 from scipy.optimize import curve_fit
 from fbpic.main import Simulation
@@ -249,6 +248,7 @@ def propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
         w[it], E[it] = fit_fields( sim.fld, m )
         # Plot the fields during the simulation
         if show==True and it%N_show == 0 :
+            import matplotlib.pyplot as plt
             plt.clf()
             sim.fld.interp[m].show('Er')
             plt.show()
@@ -263,6 +263,7 @@ def propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
 
     # Either plot the results and check them manually
     if show is True:
+        import matplotlib.pyplot as plt
         plt.suptitle('Diffraction of a pulse in the mode %d' %m)
         plt.subplot(121)
         plt.plot( 1.e6*z_prop, 1.e6*w, 'o', label='Simulation' )

--- a/tests/test_laser_antenna.py
+++ b/tests/test_laser_antenna.py
@@ -26,7 +26,6 @@ or
 $ python setup.py test
 """
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy.optimize import curve_fit
 from scipy.constants import c, m_e, e
 from fbpic.main import Simulation
@@ -125,6 +124,7 @@ def run_and_check_laser_antenna(gamma_b, show, write_files):
         sim.step( N_step, show_progress=False )
         # Plot the fields during the simulation
         if show==True :
+            import matplotlib.pyplot as plt
             plt.clf()
             sim.fld.interp[1].show('Et')
             plt.show()
@@ -196,6 +196,7 @@ def check_fields( interp1_complex, z, r, info_in_real_part, gamma_b,
                                         z0_b+Lprop_b, ctau_b, lambda0_b )
     # Plot the difference
     if show_difference:
+        import matplotlib.pyplot as plt
         plt.subplot(311)
         plt.imshow( interp1.T )
         plt.colorbar()

--- a/tests/test_linear_wakefield.py
+++ b/tests/test_linear_wakefield.py
@@ -33,7 +33,6 @@ $$ E_r = -\frac{m c^2 k_p a_0^2}{4e} \partial_r f^2(r, \theta) \left[ \int^
 xi_{-\infty} e^{-2(xi-xi_0)^2/(c\tau)^2}\sin(kp(xi-xi'))dxi'\right] $$
 """
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy.constants import c, e, m_e, epsilon_0
 from scipy.integrate import quad
 # Import the relevant structures in FBPIC
@@ -239,6 +238,7 @@ def plot_compare_wakefields(Ez_analytic, Er_analytic, Ez_sim, Er_sim, grid):
     extent = extent/1.e-6
 
     # Create figure
+    import matplotlib.pyplot as plt
     plt.figure(figsize=(10,7))
     plt.suptitle('Analytical vs. PIC Simulation for Ez and Er')
 

--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -118,7 +118,6 @@ where $\epsilon$ is the dimensionless amplitude of the mode 0 and
 $\epsilon_1$, $\epsilon_2$ are the dimensionless amplitudes of modes 1 and 2.
 """
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy.constants import c, e, m_e, epsilon_0
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
@@ -411,6 +410,7 @@ def check_E_field( E_simulation, rgrid, zgrid, epsilons,
                'over the whole simulation box.'  )
     else:
         # Show the images to the user
+        import matplotlib.pyplot as plt
         plt.figure(figsize=(8,10))
         plt.suptitle('%s field' %field)
 

--- a/tests/test_uniform_rho_deposition.py
+++ b/tests/test_uniform_rho_deposition.py
@@ -18,7 +18,6 @@ $ python tests/test_uniform_rho_deposition.py
 """
 from scipy.constants import c, e
 from fbpic.main import Simulation
-import matplotlib.pyplot as plt
 import numpy as np
 
 # Parameters
@@ -78,6 +77,7 @@ def uniform_electron_plasma(shape, show=False):
 
     # Show the results
     else:
+        import matplotlib.pyplot as plt
         plt.title('Uniform plasma, mode 0')
         sim.fld.interp[0].show('rho')
         plt.show()
@@ -124,6 +124,7 @@ def neutral_plasma_shifted(shape, show=False):
 
     # Show the results
     else:
+        import matplotlib.pyplot as plt
         plt.title('Shifted plasma, mode 0')
         sim.fld.interp[0].show('rho')
         plt.show()


### PR DESCRIPTION
In the current `dev` version, `matplotlib` is required in order to run the tests. 

However, it is unnecessary since the tests automatically check the results, instead of producing plots. In addition, on some plateforms, matplotlib can be difficult to install. Therefore, I suggest that we remove matplotlib from the requirements of the automated tests.

With this PR, matplotlib is only imported when the flag `show` is `True`. This typically happens when running the tests directly with python (e.g. `python test_boosted.py`) but not when running the tests through `python setup.py test`. 