### PR TITLE
Allow the use of `use_true_rho` in parallel

### DIFF
--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -186,5 +186,5 @@ if __name__ == '__main__':
                     ]
 
     ### Run the simulation
-    sim.step( N_step )
+    sim.step( N_step, use_true_rho=True )
     print('')

--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -186,5 +186,5 @@ if __name__ == '__main__':
                     ]
 
     ### Run the simulation
-    sim.step( N_step, use_true_rho=True )
+    sim.step( N_step )
     print('')

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -213,6 +213,12 @@ class Fields(object) :
             on the grid is used only to correct the currents, and
             the simulation can be run without the neutralizing ions.
         """
+        # Ensure consistency: fields should be exchanged
+        assert self.exchanged_source['J'] == True
+        if use_true_rho:
+            assert self.exchanged_source['rho_prev'] == True
+            assert self.exchanged_source['rho_next'] == True
+
         # Push each azimuthal grid individually, by passing the
         # corresponding psatd coefficients
         for m in range(self.Nm) :

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -215,8 +215,8 @@ class Fields(object) :
             on the grid is used only to correct the currents, and
             the simulation can be run without the neutralizing ions.
         check_exchanges: bool, optional
-            Check whether the fields rho and J have been properly
-            exchanged via MPI
+            Check whether the guard cells of the fields rho and J
+            have been properly exchanged via MPI
         """
         if check_exchanges:
             # Ensure consistency: fields should be exchanged
@@ -239,8 +239,8 @@ class Fields(object) :
         Parameter
         ---------
         check_exchanges: bool
-            Check whether the fields rho and J have been properly
-            exchanged via MPI
+            Check whether the guard cells of the fields rho and J
+            have been properly exchanged via MPI
         """
         if check_exchanges:
             # Ensure consistency (charge and current should

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -454,7 +454,7 @@ class Simulation(object):
             self.deposit('rho_next', exchange=(use_true_rho is True))
             # Correct the currents (requires rho at t = (n+1) dt )
             if correct_currents:
-                fld.correct_currents( check_exchanges=(self.comm > 1) )
+                fld.correct_currents( check_exchanges=(self.comm.size > 1) )
                 if self.comm.size > 1:
                     # Exchange the guard cells of corrected J between domains
                     # (If correct_currents is False, the exchange of J
@@ -465,7 +465,7 @@ class Simulation(object):
                 fld.exchanged_source['J'] = True
 
             # Push the fields E and B on the spectral grid to t = (n+1) dt
-            fld.push( use_true_rho, check_exchanges=(self.comm > 1) )
+            fld.push( use_true_rho, check_exchanges=(self.comm.size > 1) )
             if correct_divE:
                 fld.correct_divE()
             # Move the grids if needed

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -329,8 +329,10 @@ class Simulation(object):
         if self.comm.size > 1 and correct_divE:
             raise ValueError('correct_divE cannot be used in multi-proc mode.')
         if self.comm.size > 1 and use_true_rho and correct_currents:
-            raise ValueError('use_true cannot be used together '
-                            'with correct_currents in multi-proc mode.')
+            raise ValueError('`use_true_rho` cannot be used together '
+                            'with `correct_currents` in multi-proc mode.')
+            # This is because use_true_rho requires the guard cells of
+            # rho to be exchanged while correct_currents requires the opposite.
 
         # Initialize variables to measure the time taken by the simulation
         if show_progress and self.comm.rank==0:
@@ -383,7 +385,7 @@ class Simulation(object):
                 # Reproject the charge on the interpolation grid
                 # (Since particles have been removed / added to the simulation;
                 # otherwise rho_prev is obtained from the previous iteration.)
-                self.deposit('rho_prev', exchange=(correct_currents is False))
+                self.deposit('rho_prev', exchange=(use_true_rho is True))
 
             # For the field diagnostics of the first step: deposit J
             # (Note however that this is not the *corrected* current)
@@ -449,7 +451,7 @@ class Simulation(object):
                 self.shift_galilean_boundaries()
 
             # Get the charge density at t = (n+1) dt
-            self.deposit('rho_next', exchange=(correct_currents is False))
+            self.deposit('rho_next', exchange=(use_true_rho is True))
             # Correct the currents (requires rho at t = (n+1) dt )
             if correct_currents:
                 fld.correct_currents( check_exchanges=(self.comm > 1) )


### PR DESCRIPTION
In principle `use_true_rho` could be used in parallel if the charge density is properly exchanged. This can be advantageous, e.g. to run boosted-frame simulations with the Galilean method and multiple MPI.

This PR implements the corresponding changes:
- Instead of preventing `use_true_rho` whenever multiple MPI ranks are used, this only prevents in the case where both current correction and multiple MPI ranks are used. (Because in this case, the exchange requirements for rho are contradictory.)
- As an additional safeguard measure, this PR checks that the fields rho and J have been exchanged, just before pusing E and B. This check is only done when using multiple MPI  ranks.
- The guard cells of rho are now exchanged whenever rho is deposited.