### PR TITLE
Close #200: Better error handling when reaching out-of-memory

### DIFF
--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -9,6 +9,7 @@ import numpy as np
 import numba
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.printing import catch_gpu_memory_error
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
@@ -180,6 +181,7 @@ def remove_particles_cpu(species, fld, n_guard, left_proc, right_proc):
     # Return the sending buffers
     return(float_send_left, float_send_right, uint_send_left, uint_send_right)
 
+@catch_gpu_memory_error
 def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     """
     Remove the particles that are outside of the physical domain (i.e.
@@ -434,7 +436,7 @@ def add_buffers_cpu( species, float_recv_left, float_recv_right,
     species.Ntot = species.Ntot + float_recv_left.shape[1] \
                                 + float_recv_right.shape[1]
 
-
+@catch_gpu_memory_error
 def add_buffers_gpu( species, float_recv_left, float_recv_right,
                             uint_recv_left, uint_recv_right):
     """

--- a/fbpic/particles/elementary_process/compton/compton.py
+++ b/fbpic/particles/elementary_process/compton/compton.py
@@ -14,6 +14,7 @@ from ..cuda_numba_utils import allocate_empty, reallocate_and_copy_old, \
                                 perform_cumsum, generate_new_ids
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.printing import catch_gpu_memory_error
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
     from numba.cuda.random import create_xoroshiro128p_states
@@ -133,6 +134,7 @@ class ComptonScatterer(object):
         self.batch_size = 10
         self.use_cuda = source_species.use_cuda
 
+    @catch_gpu_memory_error
     def handle_scattering( self, elec, t ):
         """
         Handle Compton scattering, either on CPU or GPU

--- a/fbpic/particles/elementary_process/ionization/ionizer.py
+++ b/fbpic/particles/elementary_process/ionization/ionizer.py
@@ -39,6 +39,7 @@ from ..cuda_numba_utils import allocate_empty, reallocate_and_copy_old, \
 
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.printing import catch_gpu_memory_error
 if cuda_installed:
     from pyculib.rand import PRNG
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
@@ -157,6 +158,7 @@ class Ionizer(object):
         if self.use_cuda:
             self.prng = PRNG()
 
+    @catch_gpu_memory_error
     def handle_ionization( self, ion ):
         """
         Handle ionization, either on CPU or GPU

--- a/fbpic/utils/printing.py
+++ b/fbpic/utils/printing.py
@@ -294,3 +294,38 @@ def print_gpu_meminfo(gpu):
         meminfo = cuda.current_context().get_memory_info()
         print("GPU: %s, free: %s Mbytes, total: %s Mbytes \
               " % (gpu, meminfo[0]*1e-6, meminfo[1]*1e-6))
+
+def catch_gpu_memory_error( f ):
+    """
+    Decorator that calls the function `f` and catches any GPU memory
+    error, during the execution of f.
+
+    If a memory error occurs, this decorator prints a corresponding message
+    and aborts the simulation (using MPI abort if needed)
+    """
+    # Redefine the original function by calling it within a try/except
+    def g(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except cuda.cudadrv.driver.CudaAPIError as e:
+            handle_cuda_memory_error( e, f.__name__ )
+    # Decorator: return the new function
+    return(g)
+
+def handle_cuda_memory_error( exception, function_name ):
+    """
+    Print a message indicating which GPU went out of memory,
+    and abort the simulation (using MPI Abort if needed)
+    """
+    # Print a useful message
+    message = '\nERROR: GPU reached OUT_OF_MEMORY'
+    if MPI.COMM_WORLD.size > 1:
+        message += ' on MPI rank %d' %MPI.COMM_WORLD.rank
+    message += '\n(Error occured in fbpic function `%s`)\n' %function_name
+    sys.stdout.write(message)
+    sys.stdout.flush()
+    # Abort the simulation
+    if MPI.COMM_WORLD.size > 1:
+        MPI.COMM_WORLD.Abort()
+    else:
+        raise( exception )


### PR DESCRIPTION
In the current `dev` branch, for multi-GPU simulations, the simulation just hangs when one GPU reaches out-of-memory. This is obviously a waste, when using allocated resources on a cluster.

The current pull request modifies the code, so that `fbpic` catches the out-of-memory error and calls MPI Abort, so as to stop the simulation. In addition, a message is printed, which typically looks like this:
```
ERROR: GPU reached OUT_OF_MEMORY on MPI rank 11
(Error occured in function add_buffers_gpu)
```

Regarding the implementation: this is done by creating a decorator which catches the out-of-memory error in the decorated function. This decorator is then added to a couple of functions in fbpic which are likely to lead to out-of-memory (basically functions that create new particle arrays).
If an out-of-memory occurs outside of these functions, it will not be caught.
