### PR TITLE
Remove the arrays `z` and `r` from the `Interpolation` class

### DIFF
--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -173,7 +173,6 @@ class MovingWindow(object):
             Nm = len(fld.interp)
             for m in range(Nm):
                 # Modify the values of the corresponding z's
-                fld.interp[m].z += n_move*fld.interp[m].dz
                 fld.interp[m].zmin += n_move*fld.interp[m].dz
                 fld.interp[m].zmax += n_move*fld.interp[m].dz
                 # Shift/move fields by n_move cells in spectral space

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -616,9 +616,7 @@ class InterpolationGrid(object) :
         Nz = len(z)
         Nr = len(r)
         self.Nz = Nz
-        self.z = z.copy()
         self.Nr = Nr
-        self.r = r.copy()
         self.m = m
 
         # Register a few grid properties
@@ -629,10 +627,10 @@ class InterpolationGrid(object) :
         self.invdr = 1./dr
         self.invdz = 1./dz
         # rmin, rmax, zmin, zmax correspond to the edge of cells
-        self.rmin = self.r.min() - 0.5*dr
-        self.rmax = self.r.max() + 0.5*dr
-        self.zmin = self.z.min() - 0.5*dz
-        self.zmax = self.z.max() + 0.5*dz
+        self.rmin = r.min() - 0.5*dr
+        self.rmax = r.max() + 0.5*dr
+        self.zmin = z.min() - 0.5*dz
+        self.zmax = z.max() + 0.5*dz
         # Cell volume (assuming an evenly-spaced grid)
         vol = np.pi*dz*( (r+0.5*dr)**2 - (r-0.5*dr)**2 )
         # NB : No Verboncoeur-type correction required
@@ -656,6 +654,16 @@ class InterpolationGrid(object) :
         # Replace the invvol array by an array on the GPU, when using cuda
         if self.use_cuda :
             self.d_invvol = cuda.to_device( self.invvol )
+
+    @property
+    def z(self):
+        """Returns the 1d array of z, when the user queries self.z"""
+        return( self.zmin + (0.5+np.arange(self.Nz))*self.dz )
+
+    @property
+    def r(self):
+        """Returns the 1d array of r, when the user queries self.r"""
+        return( self.rmin + (0.5+np.arange(self.Nr))*self.dr )
 
     def send_fields_to_gpu( self ):
         """

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -598,7 +598,6 @@ class Simulation(object):
         for m in range(self.fld.Nm):
             self.fld.interp[m].zmin += shift_distance
             self.fld.interp[m].zmax += shift_distance
-            self.fld.interp[m].z += shift_distance
 
 
     def set_moving_window( self, v=c, ux_m=0., uy_m=0., uz_m=0.,


### PR DESCRIPTION
Each instance of the `Interpolation` class keeps a copy of the `1d` arrays `z` and `r`. This is not very good practice, since these arrays can be recomputed from other attributes of the `Interpolation` class (and thus constitute a case of duplication of information). In addition, this duplication is annoying because the full array `z` needs to be updated whenever the moving window moves, whenever the Galilean grid shifts, or whenever there is a restart (we don't even do the last one! - and thus the current code is buggy from that point of view)

In order to avoid these issues, I removed the array `z` and `r` from the `Interpolation`. However, since a few (rare) parts of the code need these arrays, I included two functions that compute them on the fly, from the other known attributes of the `Interpolation` class.
For backward compatibility, these functions are automatically called whenever the user tries to access `interp.z` or `interp.r` - this is done by using the `@property` decorator.
