### PR TITLE
Correct round-off errors in GPU deposition

### DIFF
--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -6,7 +6,7 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the deposition methods for rho and J for linear and cubic
 order shapes on the GPU using CUDA.
 """
-from numba import cuda, int64
+from numba import cuda
 import math
 from scipy.constants import c
 import numpy as np
@@ -18,7 +18,7 @@ import numpy as np
 # Linear shapes
 @cuda.jit(device=True, inline=True)
 def z_shape_linear(cell_position, index):
-    iz = int64(math.floor(cell_position))
+    iz = int(math.ceil(cell_position)) - 1
     if index == 0:
         return iz+1.-cell_position
     if index == 1:
@@ -27,7 +27,7 @@ def z_shape_linear(cell_position, index):
 @cuda.jit(device=True, inline=True)
 def r_shape_linear(cell_position, index):
     flip_factor = 1.
-    ir = int64(math.floor(cell_position))
+    ir = int(math.ceil(cell_position)) - 1
     if index == 0:
         if ir < 0:
             flip_factor = -1.
@@ -38,7 +38,7 @@ def r_shape_linear(cell_position, index):
 # Cubic shapes
 @cuda.jit(device=True, inline=True)
 def z_shape_cubic(cell_position, index):
-    iz = int64(math.floor(cell_position)) - 1
+    iz = int(math.ceil(cell_position)) - 2
     if index == 0:
         return (-1./6.)*((cell_position-iz)-2)**3
     if index == 1:
@@ -51,7 +51,7 @@ def z_shape_cubic(cell_position, index):
 @cuda.jit(device=True, inline=True)
 def r_shape_cubic(cell_position, index):
     flip_factor = 1.
-    ir = int64(math.floor(cell_position)) - 1
+    ir = int(math.ceil(cell_position)) - 2
     if index == 0:
         if ir < 0:
             flip_factor = -1.

--- a/tests/test_cpu_gpu_deposition.py
+++ b/tests/test_cpu_gpu_deposition.py
@@ -1,0 +1,141 @@
+# Copyright 2018, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This test file is part of FB-PIC (Fourier-Bessel Particle-In-Cell).
+
+It makes sure that the current and charge deposition give the same results on
+CPU and GPU. This is only relevant on a GPU plateform. (The test is skipped
+on a CPU plateform.)
+
+Usage :
+from the top-level directory of FBPIC run
+$ python tests/test_cpu_gpu_deposition.py
+"""
+# -------
+# Imports
+# -------
+import numpy as np
+import os, shutil
+from scipy.constants import c
+# Import the relevant structures in FBPIC
+from fbpic.main import Simulation
+from fbpic.openpmd_diag import FieldDiagnostic
+from fbpic.utils.cuda import cuda_installed
+from opmd_viewer import OpenPMDTimeSeries
+
+# Parameters
+# ----------
+# The simulation box
+Nz = 100         # Number of gridpoints along z
+zmax = 30.e-6    # Right end of the simulation box (meters)
+zmin = -10.e-6   # Left end of the simulation box (meters)
+Nr = 50          # Number of gridpoints along r
+rmax = 20.e-6    # Length of the box along r (meters)
+Nm = 2           # Number of modes used
+
+# The simulation timestep
+dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
+N_step = 3     # Number of iterations to perform
+
+# The particles: initialized only in a narrow ring
+p_zmin = 0.e-6  # Position of the beginning of the plasma (meters)
+p_zmax = (zmax-zmin)/Nz  # Position of the end of the plasma (meters)
+p_rmin = 10*rmax/Nr      # Minimal radial position of the plasma (meters)
+p_rmax = 11*rmax/Nr  # Maximal radial position of the plasma (meters)
+n_e = 4.e18*1.e6 # Density (electrons.meters^-3)
+p_nz = 1         # Number of particles per cell along z
+p_nr = 1         # Number of particles per cell along r
+p_nt = 4         # Number of particles per cell along theta
+
+# The diagnostics and the checkpoints
+diag_period = 1
+
+# Test function
+# -------------
+def test_cpu_gpu_deposition(show=False):
+    "Function that is run by py.test, when doing `python setup.py test`"
+
+    # Skip this test if cuda is not installed
+    if not cuda_installed:
+        return
+
+    # Perform deposition for a few timesteps, with both the CPU and GPU
+    for hardware in ['cpu', 'gpu']:
+        if hardware=='cpu':
+            use_cuda = False
+        elif hardware=='gpu':
+            use_cuda = True
+
+        # Initialize the simulation object
+        sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
+            p_zmin, p_zmax, p_rmin, p_rmax, p_nz, p_nr, p_nt, n_e,
+            zmin=zmin, use_cuda=use_cuda )
+
+        # Tweak the velocity of the electron bunch
+        gamma0 = 10.
+        sim.ptcl[0].ux = sim.ptcl[0].x
+        sim.ptcl[0].uy = sim.ptcl[0].y
+        sim.ptcl[0].uz = np.sqrt(
+            gamma0**2 - sim.ptcl[0].ux**2 - sim.ptcl[0].uy**2 - 1 )
+        sim.ptcl[0].inv_gamma = 1./gamma0 * np.ones_like( sim.ptcl[0].x )
+        sim.ptcl[0].m = 1e10
+
+        # Add a field diagnostic
+        sim.diags = [ FieldDiagnostic( diag_period, sim.fld,
+            fieldtypes=['rho', 'J'], comm=sim.comm,
+            write_dir=os.path.join('tests',hardware) )]
+
+        ### Run the simulation
+        sim.step( N_step )
+
+    # Check that the results are identical
+    ts_cpu = OpenPMDTimeSeries('tests/cpu/hdf5')
+    ts_gpu = OpenPMDTimeSeries('tests/gpu/hdf5')
+    for iteration in ts_cpu.iterations:
+        for field, coord in [('rho',''), ('J','x'), ('J','z')]:
+            # Jy is not tested because it is zero
+            print('Testing %s at iteration %d' %(field+coord, iteration))
+            F_cpu, info = ts_cpu.get_field( field, coord, iteration=iteration )
+            F_gpu, info = ts_gpu.get_field( field, coord, iteration=iteration )
+            tolerance = 1.e-13*( abs(F_cpu).max() + abs(F_gpu).max() )
+            if not show:
+                assert np.allclose( F_cpu, F_gpu, atol=tolerance )
+            else:
+                if not np.allclose( F_cpu, F_gpu, atol=tolerance ):
+                    plot_difference( field, coord, iteration,
+                                     F_cpu, F_gpu, info)
+
+    # Remove the files used
+    shutil.rmtree('tests/cpu')
+    shutil.rmtree('tests/gpu')
+
+def plot_difference( field, coord, iteration, F_cpu, F_gpu, info ):
+    """
+    Plots the simulation results on CPU and GPU
+    """
+    import matplotlib.pyplot as plt
+    plt.figure()
+    plt.suptitle( field + coord )
+    plt.subplot(311)
+    plt.imshow( F_gpu, aspect='auto',
+                origin='lower', extent=1.e6*info.imshow_extent )
+    plt.colorbar()
+    plt.title('GPU')
+    plt.subplot(312)
+    plt.imshow( F_cpu, aspect='auto',
+                origin='lower', extent=1.e6*info.imshow_extent )
+    plt.colorbar()
+    plt.title('CPU')
+    plt.subplot(313)
+    plt.imshow( F_cpu - F_gpu, aspect='auto',
+                origin='lower', extent=1.e6*info.imshow_extent )
+    plt.colorbar()
+    plt.title('Difference')
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == '__main__' :
+
+    test_cpu_gpu_deposition(show=True)


### PR DESCRIPTION
In [PR #182](https://github.com/fbpic/fbpic/pull/182), the calculation of the particle index (for sorting on the GPU) was switched from using the lower index (with `math.floor`) to using the upper index (with `math.ceil`).

Then when doing the charge/current deposition, this index is used in order to extract the radial and longitudinal index at which the particles should deposit their charge/current. However, when computing the shape factors, the radial and longitudinal index are **recomputed independently**. In theory, this could lead to discrepancies, unless these radial and longitudinal indices are computed **exactly in the same way** in the sorting algorithm and in the shape factors.

Right now, the indices **in the shape factors** are computed use the `math.floor` function. This will agree with the indices extracted from the sorting index (which used `math.ceil`) **under the assumption that** `math.ceil(x) = math.floor(x) + 1`. This is true for any `x`, except **when `x` is exactly an integer**. In practice, this indeed occurs for particles that are exactly at the boundary between two cells. In this case, there is a discrepancy between the two kind of indices, and the deposited current/charge is wrong (and shows differences with the one calculated on CPU).

In order to fix this, I simply now use the `ceil` function in the shape factor, so that the indices from sorting and indices from the shape factor are calculated in exactly the same way.

I also added an automated test that compares the deposited charge/current on CPU and GPU (running for only a few steps, and with only a few particles). This test fails with the current dev branch, but passes with this PR.
