### PR TITLE
Avoid initializing macroparticles with zero weight

### DIFF
--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -165,7 +165,7 @@ class Particles(object) :
             w = n * r * dtheta*dr*dz
             # Modulate it by the density profile
             if dens_func is not None :
-                w *= dens_func( self.z, r )
+                w *= dens_func( z, r )
 
             # Select the particles that have a non-zero weight
             selected = (w != 0)


### PR DESCRIPTION
Initializing macroparticles with zero weight can be extremely inefficient - especially in cases where the `dens_func` for a given species is non-zero only in a restricted area of space.

This PR prevents the code from initializing these useless macroparticles (since they do not contribute to the physics). 

Here is the results of a small test, where the `dens_func` is 0 outside of the range 25 microns - 40 microns. Note that this PR is compatible with the moving window (in this test, the initial box spanned over the range -10 microns - 30 microns).
![test_particle_injection](https://user-images.githubusercontent.com/6685781/37360813-7e1d44a2-26ae-11e8-83a7-df9ae79e0e13.png)

One disadvantage of this PR is that the code will refuse to create "tracer" particles (a.k.a. "test" particles), which, by definition, have zero weight. However, since use cases for tracer particles are (in my mind) rather rare, I think that the advantages of this PR outweighs this disadvantage. Also, a user could still initialize particles with extremely small density to have them act (effectively) as tracers.