### PR TITLE
Close #222 Add automated test that check the accuracy of a restarted simulation

### DIFF
--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -223,9 +223,9 @@ def load_fields( grid, fieldtype, coord, ts, iteration ):
     # Get the new positions of the bounds of the simulation
     # (and check that the box keeps the same length)
     length_old = grid.zmax - grid.zmin
-    dz = length_old/grid.Nz
-    grid.zmin = info.zmin
-    grid.zmax = info.zmax+dz
+    dz = info.dz
+    grid.zmin = info.zmin - 0.5*dz
+    grid.zmax = info.zmax + 0.5*dz
     length_new = grid.zmax - grid.zmin
     assert np.allclose( length_old, length_new )
 


### PR DESCRIPTION
This pull request modifies the automated test that runs the example file `lwfa_script.py`, so as to make a more thorough check of the restarted simulation:
- The script first runs this script for `2*N_step` steps (with `N_step=200`).
- A new simulation is then run from a checkpoint file at `N_step` running up to `2*N_step` (i.e. the last N_step from the previous simulation are run again)
- Then the fields in the openPMD files of the 2 simulations are automatically compared.

In addition, the file for this automated test has been refactored to avoid duplications:
- Since the above test is performed for 1 MPI proc and then for 2 MPI procs, I wrote a generic function that takes the number of MPI procs as argument (the function used to be duplicated for 1 and 2 MPI procs)
- The code used to test the presence of a string in the text, and replace that string, in two different parts of the code ; I grouped this into one function.

Finally, this tests showed that the restart mechanism was not fully accurate (i.e. the test fails with the code from the current dev). This is because the restarting code identifies `zmin` from openPMD-viewer to the `zmin` from FBPIC. In reality, these coordinates are shifted by half a cell. (In openPMD-viewer, `zmin` is the position of the leftmost **gridpoint**, whereas, in FBPIC, `zmin` is the position of boundary of the domain). This PR also fixes this.