### PR TITLE
Better message warnings, including when generating negative particle densities

### DIFF
--- a/fbpic/__init__.py
+++ b/fbpic/__init__.py
@@ -9,6 +9,7 @@ See the fbpic.main.Simulation class to set up a simulation.
 
 # Change the default formatting for warnings within fbpic
 import warnings
-warnings.showwarning = \
-    lambda message, category, filename, lineno, *args, **kwargs: \
-    print('\nWarning: %s:%s:\n%s\n' %(filename, lineno, message))
+def modified_formatting(message, category, filename, lineno, line=None):
+    """Format a warning so that the code line `line` is not shown`."""
+    return('\nWarning: %s:%s:\n%s\n' %(filename, lineno, message))
+warnings.formatwarning = modified_formatting

--- a/fbpic/__init__.py
+++ b/fbpic/__init__.py
@@ -6,3 +6,9 @@ Usage
 -----
 See the fbpic.main.Simulation class to set up a simulation.
 """
+
+# Change the default formatting for warnings within fbpic
+import warnings
+warnings.showwarning = \
+    lambda message, category, filename, lineno, *args, **kwargs: \
+    print('\nWarning: %s:%s:\n%s\n' %(filename, lineno, message))

--- a/fbpic/__init__.py
+++ b/fbpic/__init__.py
@@ -11,5 +11,5 @@ See the fbpic.main.Simulation class to set up a simulation.
 import warnings
 def modified_formatting(message, category, filename, lineno, line=None):
     """Format a warning so that the code line `line` is not shown`."""
-    return('\nWarning: %s:%s:\n%s\n' %(filename, lineno, message))
+    return('\n%s: %s:%s:\n%s\n'%(category.__name__, filename, lineno, message))
 warnings.formatwarning = modified_formatting

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -5,6 +5,7 @@
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the structure and methods associated with the fields.
 """
+import warnings
 import numpy as np
 from scipy.constants import c, mu_0, epsilon_0
 from .numba_methods import numba_push_eb_standard, numba_push_eb_comoving, \
@@ -116,8 +117,9 @@ class Fields(object) :
         # Define wether or not to use the GPU
         self.use_cuda = use_cuda
         if (self.use_cuda==True) and (cuda_installed==False) :
-            print('*** Cuda not available for the fields.')
-            print('*** Performing the field operations on the CPU.')
+            warnings.warn(
+                'Cuda not available for the fields.\n'
+                'Performing the field operations on the CPU.' )
             self.use_cuda = False
 
         # Infer the values of the z and kz grid

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -20,6 +20,7 @@ if cuda_installed:
     mpi_select_gpus( MPI )
 
 # Import the rest of the requirements
+import warnings
 import numba
 from scipy.constants import m_e, m_p, e, c
 from .utils.printing import ProgressBar, print_simulation_setup
@@ -200,9 +201,9 @@ class Simulation(object):
         # Check whether to use CUDA
         self.use_cuda = use_cuda
         if (self.use_cuda==True) and (cuda_installed==False):
-            # Print warning if use_cuda = True but CUDA is not available
-            print('*** Cuda not available for the simulation.')
-            print('*** Performing the simulation on CPU.')
+            warnings.warn(
+                'Cuda not available for the simulation.\n'
+                'Performing the simulation on CPU.' )
             self.use_cuda = False
         # CPU multi-threading
         self.use_threading = threading_enabled

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -169,13 +169,19 @@ class Particles(object) :
             if dens_func is not None :
                 w *= dens_func( z, r )
 
-            # Select the particles that have a non-zero weight
-            selected = (w != 0)
+            # Select the particles that have a positive weight
+            selected = (w > 0)
             Ntot = int(selected.sum())
             self.x = x[ selected ]
             self.y = y[ selected ]
             self.z = z[ selected ]
             self.w = w[ selected ]
+            if np.any(w < 0):
+                warnings.warn(
+                'The specified particle density returned negative densities.\n'
+                'No particles were generated in areas of negative density.\n'
+                'Please check the validity of the `dens_func`.')
+
         else:
             # No particles are initialized ; the arrays are still created
             Ntot = 0

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -5,6 +5,7 @@
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the structure and methods associated with the particles.
 """
+import warnings
 import numpy as np
 import numba
 from scipy.constants import e
@@ -133,8 +134,9 @@ class Particles(object) :
         # Define whether or not to use the GPU
         self.use_cuda = use_cuda
         if (self.use_cuda==True) and (cuda_installed==False) :
-            print('*** Cuda not available for the particles.')
-            print('*** Performing the particle operations on the CPU.')
+            warnings.warn(
+                'Cuda not available for the particles.\n'
+                'Performing the particle operations on the CPU.')
             self.use_cuda = False
 
         # Generate the particles and eliminate the ones that have zero weight ;

--- a/fbpic/utils/mpi.py
+++ b/fbpic/utils/mpi.py
@@ -21,9 +21,12 @@ try:
 
 except ImportError:
     # If MPI is not installed, define dummy replacements
-    print("*** MPI is not properly installed.")
-    print("*** In order to diagnose the problem, type:")
-    print("*** `mpirun -np 2 python -c `from mpi4py.MPI import COMM_WORLD`")
+    import warnings
+    warnings.warn(
+        'MPI is not properly installed.\n'
+        'Simulations without domain decomposition will still run properly.\n'
+        'In order to diagnose the problem, type:\n'
+        'mpirun -np 2 python -c "from mpi4py.MPI import COMM_WORLD"')
 
     class DummyCommunicator(object):
         """Dummy replacement for COMM_WORLD when mpi4py is not installed."""

--- a/fbpic/utils/threading.py
+++ b/fbpic/utils/threading.py
@@ -6,6 +6,7 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines a set of generic functions for multithreaded CPU execution.
 """
 import os, sys
+import warnings
 import numpy as np
 from numba import njit
 
@@ -25,16 +26,18 @@ if threading_enabled:
     try:
         # Try to import the threading function prange
         from numba import prange as numba_prange
-        # Check that numba is version 0.34 or higher than 0.36 
+        # Check that numba is version 0.34 or higher than 0.36
         # (other versions fail)
         import numba
         numba_minor_version = int(numba.__version__.split('.')[1])
         assert ( numba_minor_version==34 or numba_minor_version >= 36 )
     except (ImportError, AssertionError):
         threading_enabled = False
-        print('*** Threading not available for the simulation.')
-        print('*** (Please ensure that numba 0.34 or >=0.36 is installed,')
-        print('***  e.g. by typing `conda update numba` in a terminal)')
+        warnings.warn(
+            'Threading not available for the simulation.\n'
+            'Simulations will still run, but using only 1 thread on CPU.\n'
+            'Please ensure that numba 0.34 or >=0.36 is installed.\n'
+            '(e.g. by typing `conda update numba` in a terminal)')
 
 # Set the function njit_parallel and prange to the correct object
 if not threading_enabled:


### PR DESCRIPTION
Users can sometimes make the mistake of creating `dens_func` with negative densities. It is nice to let them know about this (with a proper warning), and to avoid initializing the corresponding particles.

In the case of a negative density, the user will see the following printed message:
```
UserWarning: /Users/rlehe/Desktop/fbpic/fbpic/main.py:205:
Cuda not available for the simulation.
Performing the simulation on CPU.


FBPIC (0.8.0)

Running on CPU (4 threads per process) 

Initializing laser pulse on the mesh...
Done.

|█                                  | 7/200, calc. ETA..., 71 ms/step
UserWarning: /Users/rlehe/Desktop/fbpic/fbpic/particles/particles.py:181:
The specified particle density returned negative densities.
No particles were generated in areas of negative density.
Please check the validity of the `dens_func`.

|███████████████████████████████████| 200/200, 0:00:00 left, 72 ms/step
Total time taken (with compilation): 0:00:27
Average time per iteration (with compilation): 137 ms
```

Note that I also modified most of the printed messages and made them warnings (since this is cleaner). 

I also redefined the formatting of warnings, because the default formatting is confusing (it prints the code that generates the warning, after the warning message.) This modification has to be done in `__init__.py` so that it gets defined before any other import. (Otherwise `import .utils.mpi` is one of the first things that get imported, and any warning from this module will not be properly formatted.)