### PR TITLE
Add new way to initialize particles

### DIFF
--- a/docs/source/api_reference/simulation.rst
+++ b/docs/source/api_reference/simulation.rst
@@ -12,4 +12,4 @@ the simulation data, and has the high-level methods to perform the PIC cycle.
     - `comm`, a `BoundaryCommunicator`, which contains the MPI decomposition
 
 .. autoclass:: fbpic.main.Simulation
-   :members: step, set_moving_window
+   :members: step, set_moving_window, add_new_species

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -232,18 +232,11 @@ class BoundaryCommunicator(object):
                 if cuda_installed:
                     self.d_right_damp = cuda.to_device( self.right_damp )
 
-    def divide_into_domain( self, p_zmin, p_zmax ):
+    def divide_into_domain( self ):
         """
         Divide the global simulation into domain and add local guard cells.
 
-        Return the new size of the local domain (zmin, zmax) and the
-        boundaries of the initial plasma (p_zmin, p_zmax)
-
-        Parameters:
-        ------------
-        p_zmin, p_zmax: floats
-            Positions between which the plasma will be initialized, in
-            the global simulation box.
+        Return the new size of the local domain (zmin, zmax)
 
         Returns:
         ---------
@@ -251,23 +244,10 @@ class BoundaryCommunicator(object):
         zmin, zmax: floats
             Positions of the edges of the local simulation box
             (with guard cells and damp cells)
-
-        p_zmin, p_zmax: floats
-           Positions between which the plasma will be initialized, in
-           the local simulation box.
-           (NB: no plasma will be initialized in the guard cells)
-
         Nz_enlarged: int
            The number of cells in the local simulation box
            (with guard cells and damp cells)
         """
-        # Calculate the new limits (p_zmin and p_zmax)
-        # for adding particles to this domain
-        zmin_local_domain, zmax_local_domain = self.get_zmin_zmax(
-            local=True, with_damp=False, with_guard=False, rank=self.rank )
-        p_zmin_local_domain = max( zmin_local_domain, p_zmin)
-        p_zmax_local_domain = min( zmax_local_domain, p_zmax)
-
         # Calculate the enlarged boundaries (i.e. including guard cells
         # and damp cells), which are passed to the fields object.
         zmin_local_enlarged, zmax_local_enlarged = self.get_zmin_zmax(
@@ -282,8 +262,7 @@ class BoundaryCommunicator(object):
                                a smaller number of guard cells.')
 
         # Return the new boundaries to the simulation object
-        return( zmin_local_enlarged, zmax_local_enlarged,
-                p_zmin_local_domain, p_zmax_local_domain, Nz_enlarged )
+        return( zmin_local_enlarged, zmax_local_enlarged, Nz_enlarged )
 
     def get_Nz_and_iz( self, local, with_damp, with_guard, rank=None ):
         """

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -571,8 +571,7 @@ class Simulation(object):
     def add_new_species( self, q, m, n=None, dens_func=None,
                             p_nz=None, p_nr=None, p_nt=None,
                             p_zmin=-np.inf, p_zmax=np.inf,
-                            p_rmin=0, p_rmax=np.inf,
-                            ux_m=0., uy_m=0., uz_m=0.,
+                            p_rmin=0, p_rmax=np.inf, uz_m=0.,
                             continuous_injection=True ):
         """
         Create a new species with charge `q` and mass `m`,
@@ -614,15 +613,22 @@ class Simulation(object):
         p_nt: int, optional
             The number of macroparticles along the theta direction
 
-        p_zmin, p_zmax: floats (in meters), optional
-           Positions in z between which the particles are initialized
-           (in the lab frame). Default: particles fill the simulation box.
-        p_rmin, p_rmax: floats (in meters), optional
-           Positions in r between which the particles are initialized.
+        p_zmin: float (in meters), optional
+            The minimal z position above which the particles are initialized
+            (in the lab frame). Default: left edge of the simulation box.
+        p_zmax: float (in meters), optional
+            The maximal z position below which the particles are initialized
+            (in the lab frame). Default: right edge of the simulation box.
+        p_rmin: float (in meters), optional
+            The minimal r position above which the particles are initialized
+            (in the lab frame). Default: 0
+        p_rmax: floats (in meters), optional
+            The maximal r position below which the particles are initialized
+            (in the lab frame). Default: upper edge of the simulation box.
 
-        ux_m, uy_m, uz_m: floats (dimensionless), optional
-           Normalized mean momenta (in the lab frame)
-           of the injected particles in each direction
+        uz_m: float (dimensionless), optional
+           Normalized momentum (in the lab frame)
+           of the injected particles in the z direction
 
         continuous_injection : bool, optional
            Whether to continuously inject the particles,
@@ -640,8 +646,9 @@ class Simulation(object):
 
             # Automatically convert input quantities to the boosted frame
             if self.boost is not None:
+                beta0 = uz_m/( 1.+uz_m**2 )**0.5
                 p_zmin, p_zmax = self.boost.static_length([ p_zmin, p_zmax ])
-                n, = self.boost.static_density([ n ])
+                n, = self.boost.copropag_density([ n ], beta_object=beta0 )
                 uz_m, = self.boost.longitudinal_momentum([ uz_m ])
 
             # Modify input particle bounds, in order to only initialize the
@@ -671,8 +678,7 @@ class Simulation(object):
         new_species = Particles( q=q, m=m, n=n, dens_func=dens_func,
                         Npz=Npz, zmin=p_zmin, zmax=p_zmax,
                         Npr=Npr, rmin=p_rmin, rmax=p_rmax,
-                        Nptheta=p_nt, dt=self.dt,
-                        ux_m=ux_m, uy_m=uy_m, uz_m=uz_m,
+                        Nptheta=p_nt, dt=self.dt, uz_m=uz_m,
                         particle_shape=self.particle_shape,
                         use_cuda=self.use_cuda, grid_shape=self.grid_shape,
                         continuous_injection=continuous_injection )

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -671,7 +671,7 @@ class Simulation(object):
             # but which will result in no macroparticles being injected
             n = 0
             p_zmin = p_zmax = p_rmin = p_rmax = 0
-            Npz = Npr = 0
+            Npz = Npr = p_nt = 0
             continuous_injection = False
 
         # Create the new species

--- a/tests/test_compton.py
+++ b/tests/test_compton.py
@@ -19,7 +19,6 @@ from scipy.constants import e, c, h, m_e, epsilon_0
 # Import the relevant structures in FBPIC
 from fbpic.lpa_utils.boosted_frame import BoostConverter
 from fbpic.main import Simulation
-from fbpic.particles import Particles
 from fbpic.lpa_utils.bunch import add_elec_bunch_gaussian
 from fbpic.openpmd_diag import ParticleDiagnostic
 
@@ -102,15 +101,7 @@ def run_simulation( gamma_boost, show ):
     elec = sim.ptcl[0]
     print( 'Initialized electron bunch' )
     # Add a photon species
-    photons = Particles( q=0, m=0, n=0, Npz=1, zmin=0, zmax=0,
-                    Npr=1, rmin=0, rmax=0, Nptheta=1, dt=sim.dt,
-                    ux_m=0., uy_m=0., uz_m=0.,
-                    ux_th=0., uy_th=0., uz_th=0.,
-                    dens_func=None, continuous_injection=False,
-                    grid_shape=sim.fld.interp[0].Ez.shape,
-                    particle_shape='linear',
-                    use_cuda=sim.use_cuda)
-    sim.ptcl.append( photons )
+    sim.add_new_species( q=0, m=0 )
     print( 'Initialized photons' )
 
     # Activate Compton scattering for electrons of the bunch

--- a/tests/test_compton.py
+++ b/tests/test_compton.py
@@ -101,7 +101,7 @@ def run_simulation( gamma_boost, show ):
     elec = sim.ptcl[0]
     print( 'Initialized electron bunch' )
     # Add a photon species
-    sim.add_new_species( q=0, m=0 )
+    photons = sim.add_new_species( q=0, m=0 )
     print( 'Initialized photons' )
 
     # Activate Compton scattering for electrons of the bunch


### PR DESCRIPTION
In the current `dev` branch, the only way to initialize a new species is by using the `Particles` object directly.
However, there are many pitfalls when using this object directly (esp. when doing boosted-frame simulation, or multi-CPU/multi-GPU simulations). 

This PR solves this issue by creating a helper function `add_new_species`, which takes automatically takes care of these issues.

Note that this helper function is a temporary, backward-compatible patch: in the future (`fbpic 1.0`) we hope to have a better (but non-backward-compatible) API.