### PR TITLE
Increase default values for damping and guard region size

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -89,7 +89,7 @@ class BoundaryCommunicator(object):
             region at these areas (left / right of moving window) is
             extended by n_damp (N=n_guard+n_damp) in order to smoothly
             damp the fields such that they do not wrap around.
-            (Defaults to 30)
+            (Defaults to 64)
 
         exchange_period: int, optional
             Number of iterations before which the particles are exchanged.
@@ -150,10 +150,10 @@ class BoundaryCommunicator(object):
         # for given order (n_order)
         if n_guard == None:
             if n_order == -1:
-                # Set n_guard to fixed value of 30 in case of
+                # Set n_guard to fixed value of 64 in case of
                 # open boundaries and infinite order stencil
                 # (if not defined otherwise by user)
-                self.n_guard = 30
+                self.n_guard = 64
                 # Raise error if user tries to use parallel MPI computation
                 # with an infinite order stencil. This would give wrong results
                 if self.size != 1:

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -47,7 +47,7 @@ class Simulation(object):
                  n_order=-1, dens_func=None, filter_currents=True,
                  v_comoving=None, use_galilean=True,
                  initialize_ions=False, use_cuda=False,
-                 n_guard=None, n_damp=30, exchange_period=None,
+                 n_guard=None, n_damp=64, exchange_period=None,
                  current_correction='curl-free', boundaries='periodic',
                  gamma_boost=None, use_all_mpi_ranks=True,
                  particle_shape='linear', verbose_level=1 ):
@@ -155,7 +155,7 @@ class Simulation(object):
             region at these areas (left / right of moving window) is
             extended by n_damp (N=n_guard+n_damp) in order to smoothly
             damp the fields such that they do not wrap around.
-            (Defaults to 30)
+            (Defaults to 64)
         exchange_period: int, optional
             Number of iterations before which the particles are exchanged.
             If set to None, the maximum exchange period is calculated


### PR DESCRIPTION
Closes #204 

I increased the default values for n_damp and n_guard from 30 to 64.
I've chosen 64 (and not 50 as written in the Issue) because it is a power of 2.

Reasons to increase the values although this might give performance degradation for very small simulation box sizes:

**Damping region**
With 30 n_damp cells, only 10 cells are actually performing the damping whereas the remaining 2/3 of the cells are set to 1. I think a damping region of only 30 is a little bit to small as a default value and increasing this will give robustness in cases where this could matter. However, I have no evidence that the current setting can cause problems. If we change the default value to 64 it might also be beneficial to enlarge the real damping area to 1/2 of n_damp instead of only 1/3 of n_damp. In this case we would have 32 cells at a damping factor of 1 and 32 cells with a sinusoidal**2 decrease. (instead of 10 and 20 cells as it is now). Having a 1/2 distribution and a value that is a power of 2 might also be more logical than the current 1/3 and 2/3 distribution. @RemiLehe Any comments on that?

**Guard region**
In this case, increasing the standard guard region size from 30 to 64 in case of infinite order stencil simulations will not change anything in terms of numerical or physical accuracy. However, the code can then automatically choose a larger exchange_period. Instead of an exchange_period of only 6, the code will use an exchange_period of 14, which can surely be better in terms of performance. So I would highly recommend to use this as a new default value for the number of guard cells.

Performance difference caused by the increased exchange_period when using a larger guard region:
Standard benchmark script (2048x400 on a single K80 with n_damp=64 and n_guard=64):

exchange_period = 6 (current dev): 333 ms avg/step
exchange_period = 14 (this PR): 307 ms avg/step