### PR TITLE
Close #187 Document ionization module and add an example script 

### DIFF
--- a/docs/source/api_reference/api_reference.rst
+++ b/docs/source/api_reference/api_reference.rst
@@ -8,6 +8,7 @@ the ``fbpic`` package, and which are used to set up a simulation.
    :maxdepth: 1
 
    simulation
+   particles
    diagnostics
    checkpoint_restart
    lpa_utilities/lpa_utilities

--- a/docs/source/api_reference/particles.rst
+++ b/docs/source/api_reference/particles.rst
@@ -1,0 +1,7 @@
+Particles object
+================
+
+.. py:class:: fbpic.particles.Particles
+
+   .. automethod:: track
+   .. automethod:: make_ionizable

--- a/docs/source/api_reference/particles.rst
+++ b/docs/source/api_reference/particles.rst
@@ -1,7 +1,24 @@
-Particles object
-================
+The Particles class
+===================
+
+A :any:`Simulation` object may contain several particle species. Each species is
+represented by an instance of the :any:`Particles` class, and is stored in
+the list ``Simulation.ptcl``.
+
+.. note::
+
+    It is **not** recommended to initialize a :any:`Particles` object directly.
+    Instead, use the method :any:`Simulation.add_new_species`. This will
+    append a new instance of :any:`Particles` to the list ``Simulation.ptcl``.
+    This new instance will also be directly returned by the function, so
+    that so that you can use its methods below.
 
 .. py:class:: fbpic.particles.Particles
+
+    An instance of `Particles` stores a set of macroparticles that have the
+    same charge and mass. (Note that for ionizable species, ions in different
+    states of ionization - i.e. different levels - are stored in
+    the same `Particles` object.)
 
    .. automethod:: track
    .. automethod:: make_ionizable

--- a/docs/source/api_reference/particles.rst
+++ b/docs/source/api_reference/particles.rst
@@ -11,7 +11,7 @@ the list ``Simulation.ptcl``.
     Instead, use the method :any:`Simulation.add_new_species`. This will
     append a new instance of :any:`Particles` to the list ``Simulation.ptcl``.
     This new instance will also be directly returned by the function, so
-    that so that you can use its methods below.
+    that you can use its methods below.
 
 .. py:class:: fbpic.particles.Particles
 

--- a/docs/source/api_reference/simulation.rst
+++ b/docs/source/api_reference/simulation.rst
@@ -1,15 +1,12 @@
 The Simulation class
 ======================
 
-The `Simulation` class is top-level class in FBPIC. It contains all
-the simulation data, and has the high-level methods to perform the PIC cycle.
+The :any:`Simulation` class is top-level class in FBPIC. It contains all
+the simulation data, and has the high-level method :any:`step`
+that performs the PIC cycle.
 
-    The `Simulation` class has several important attributes:
-
-    - `fld`, a `Fields` object which contains the field information
-    - `ptcl`, a list of `Particles` objects (one per species)
-    - `diags`, a list of diagnostics to be run during the simulation
-    - `comm`, a `BoundaryCommunicator`, which contains the MPI decomposition
+In addition, its method :any:`add_new_species` allows to create new particle
+species, and its method :any:`set_moving_window` activates the moving window.
 
 .. autoclass:: fbpic.main.Simulation
-   :members: step, set_moving_window, add_new_species
+   :members: step, add_new_species, set_moving_window

--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -5,9 +5,7 @@ laser-wakefield acceleration using FBPIC.
 Usage
 -----
 - Modify the parameters below to suit your needs
-- Type "python -i boosted_frame_script.py" in a terminal
-- When the simulation finishes, the python session will *not* quit.
-    Therefore the simulation can be continued by running sim.step()
+- Type "python boosted_frame_script.py" in a terminal
 
 Help
 ----
@@ -149,7 +147,7 @@ track_bunch = False  # Whether to tag and track the particles of the bunch
 # Carrying out the simulation
 # ---------------------------
 # NB: The code below is only executed when running the script,
-# (`python -i boosted_frame_sim.py`), but not when importing it.
+# (`python boosted_frame_sim.py`), but not when importing it.
 if __name__ == '__main__':
 
     # Initialize the simulation object

--- a/docs/source/example_input/ionization_script.py
+++ b/docs/source/example_input/ionization_script.py
@@ -45,7 +45,7 @@ Nm = 2           # Number of modes used
 
 # The simulation timestep
 dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
-N_step = 200     # Number of iterations to perform
+N_step = 100     # Number of iterations to perform
 
 # Order of the stencil for z derivatives in the Maxwell solver.
 # Use -1 for infinite order, i.e. for exact dispersion relation in

--- a/docs/source/example_input/ionization_script.py
+++ b/docs/source/example_input/ionization_script.py
@@ -1,0 +1,142 @@
+"""
+This is an input script that runs a simulation of
+laser-wakefield acceleration with ionization, using FBPIC.
+
+More precisely, this uses a mix of Helium and Nitrogen atoms. To save
+computational time, the Helium is assumed to be already pre-ionized
+up to level 1 (He+) and the Nitrogen is assumed to be pre-ionized up to
+level 5 (N 5+)
+
+Usage
+-----
+- Modify the parameters below to suit your needs
+- Type "python ionization_script.py" in a terminal
+
+Help
+----
+All the structures implemented in FBPIC are internally documented.
+Enter "print(fbpic_object.__doc__)" to have access to this documentation,
+where fbpic_object is any of the objects or function of FBPIC.
+"""
+# -------
+# Imports
+# -------
+import numpy as np
+from scipy.constants import c, e, m_e, m_p
+# Import the relevant structures from fbpic
+from fbpic.main import Simulation
+from fbpic.lpa_utils.laser import add_laser
+from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic
+
+# ----------
+# Parameters
+# ----------
+
+# Whether to use the GPU
+use_cuda = True
+
+# The simulation box
+Nz = 800         # Number of gridpoints along z
+zmax = 10.e-6     # Right end of the simulation box (meters)
+zmin = -30.e-6   # Left end of the simulation box (meters)
+Nr = 50          # Number of gridpoints along r
+rmax = 20.e-6    # Length of the box along r (meters)
+Nm = 2           # Number of modes used
+
+# The simulation timestep
+dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
+N_step = 200     # Number of iterations to perform
+
+# Order of the stencil for z derivatives in the Maxwell solver.
+# Use -1 for infinite order, i.e. for exact dispersion relation in
+# all direction (adviced for single-GPU/single-CPU simulation).
+# Use a positive number (and multiple of 2) for a finite-order stencil
+# (required for multi-GPU/multi-CPU with MPI). A large `n_order` leads
+# to more overhead in MPI communications, but also to a more accurate
+# dispersion relation for electromagnetic waves. (Typically,
+# `n_order = 32` is a good trade-off.)
+# See https://arxiv.org/abs/1611.05712 for more information.
+n_order = -1
+
+# The particles
+p_zmin = 0.e-6   # Position of the beginning of the plasma (meters)
+n_He = 2.e24     # Density of Helium atoms
+n_N = 1.e24      # Density of Nitrogen atoms
+p_nz = 1         # Number of particles per cell along z
+p_nr = 2         # Number of particles per cell along r
+p_nt = 4         # Number of particles per cell along theta
+
+# The laser
+a0 = 4.          # Laser amplitude
+w0 = 5.e-6       # Laser waist
+ctau = 5.e-6     # Laser duration
+z0 = -5.e-6      # Laser centroid
+z_foc = 20.e-6   # Focal position
+
+# The moving window
+v_window = c       # Speed of the window
+
+# The diagnostics and the checkpoints/restarts
+diag_period = 10         # Period of the diagnostics in number of timesteps
+ramp_length = 20.e-6
+# The density profile
+def dens_func( z, r ) :
+    """Returns relative density at position z and r"""
+    # Allocate relative density
+    n = np.ones_like(z)
+    # Make sine-like ramp
+    n = np.where( z<ramp_length, np.sin(np.pi/2*z/ramp_length)**2, n )
+    # Supress density before the ramp
+    n = np.where( z<0, 0., n )
+    return(n)
+
+# ---------------------------
+# Carrying out the simulation
+# ---------------------------
+if __name__ == '__main__':
+
+    # Initialize the simulation object
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
+        zmin=zmin, boundaries='open', initialize_ions=False,
+        n_order=n_order, use_cuda=use_cuda )
+    # By default the simulation initializes an electron species (sim.ptcl[0])
+    # Because we did not pass the arguments `n`, `p_nz`, `p_nr`, `p_nz`,
+    # this electron species does not contain any macroparticles.
+    # It is okay to just remove it from the list of species.
+    sim.ptcl = []
+
+    # Add the Helium ions (pre-ionized up to level 1),
+    # the Nitrogen ions (pre-ionized up to level 5)
+    # and the associated electrons (from the pre-ionized levels)
+    atoms_He = sim.add_new_species( q=e, m=4.*m_p, n=n_He,
+        dens_func=dens_func, p_nz=p_nz, p_nr=p_nr, p_nt=p_nt, p_zmin=p_zmin )
+    atoms_N = sim.add_new_species( q=5*e, m=14.*m_p, n=n_N,
+        dens_func=dens_func, p_nz=p_nz, p_nr=p_nr, p_nt=p_nt, p_zmin=p_zmin )
+    # Important: the electron density from N5+ is 5x larger than that from He+
+    n_e = n_He + 5*n_N
+    elec = sim.add_new_species( q=-e, m=m_e, n=n_e,
+        dens_func=dens_func, p_nz=p_nz, p_nr=p_nr, p_nt=p_nt, p_zmin=p_zmin )
+
+    # Activate ionization of He ions (for levels above 1).
+    # Store the created electrons in the species `elec`
+    atoms_He.make_ionizable( 'He', target_species=elec, level_start=1 )
+
+    # Activate ionization of N ions (for levels above 5).
+    # Store the created electrons in a new dedicated electron species that
+    # does not contain any macroparticles initially
+    elec_from_N = sim.add_new_species( q=-e, m=m_e )
+    atoms_N.make_ionizable( 'N', target_species=elec_from_N, level_start=5 )
+
+    # Add a laser to the fields of the simulation
+    add_laser( sim, a0, w0, ctau, z0, zf=z_foc )
+
+    # Configure the moving window
+    sim.set_moving_window( v=v_window )
+
+    # Add a diagnostics
+    sim.diags = [ FieldDiagnostic( diag_period, sim.fld, comm=sim.comm ),
+                ParticleDiagnostic( diag_period,
+                    {"e- from N": elec_from_N, "e-": elec}, comm=sim.comm ) ]
+
+    ### Run the simulation
+    sim.step( N_step )

--- a/docs/source/example_input/lwfa_script.py
+++ b/docs/source/example_input/lwfa_script.py
@@ -5,9 +5,7 @@ laser-wakefield acceleration using FBPIC.
 Usage
 -----
 - Modify the parameters below to suit your needs
-- Type "python -i lwfa_script.py" in a terminal
-- When the simulation finishes, the python session will *not* quit.
-    Therefore the simulation can be continued by running sim.step()
+- Type "python lwfa_script.py" in a terminal
 
 Help
 ----
@@ -59,7 +57,7 @@ n_order = -1
 
 # The particles
 p_zmin = 25.e-6  # Position of the beginning of the plasma (meters)
-p_zmax = 31.e-6  # Position of the end of the plasma (meters)
+p_zmax = 500.e-6 # Position of the end of the plasma (meters)
 p_rmin = 0.      # Minimal radial position of the plasma (meters)
 p_rmax = 18.e-6  # Maximal radial position of the plasma (meters)
 n_e = 4.e18*1.e6 # Density (electrons.meters^-3)
@@ -102,7 +100,7 @@ def dens_func( z, r ) :
 # ---------------------------
 
 # NB: The code below is only executed when running the script,
-# (`python -i lpa_sim.py`), but not when importing it (`import lpa_sim`).
+# (`python lwfa_script.py`), but not when importing it (`import lwfa_script`).
 if __name__ == '__main__':
 
     # Initialize the simulation object
@@ -126,7 +124,7 @@ if __name__ == '__main__':
     # Configure the moving window
     sim.set_moving_window( v=v_window )
 
-    # Add a field diagnostic
+    # Add diagnostics
     sim.diags = [ FieldDiagnostic( diag_period, sim.fld, comm=sim.comm ),
                 ParticleDiagnostic( diag_period, {"electrons" : sim.ptcl[0]},
                                 select={"uz" : [1., None ]}, comm=sim.comm ) ]

--- a/docs/source/how_to_run.rst
+++ b/docs/source/how_to_run.rst
@@ -12,6 +12,7 @@ You can download examples of FBPIC scripts below (which you can then modify
 to suit your needs):
 
 - Standard simulation of laser-wakefield acceleration: :download:`lwfa_script.py <example_input/lwfa_script.py>`
+- Laser-wakefield acceleration with ionization: :download:`ionization_script.py <example_input/ionization_script.py>`
 - Boosted-frame simulation of laser-wakefield acceleration: :download:`boosted_frame_script.py <example_input/boosted_frame_script.py>`
 
 (See the section :doc:`advanced/boosted_frame` for more information on the above script.)

--- a/docs/source/how_to_run.rst
+++ b/docs/source/how_to_run.rst
@@ -15,10 +15,11 @@ to suit your needs):
 - Laser-wakefield acceleration with ionization: :download:`ionization_script.py <example_input/ionization_script.py>`
 - Boosted-frame simulation of laser-wakefield acceleration: :download:`boosted_frame_script.py <example_input/boosted_frame_script.py>`
 
-(See the section :doc:`advanced/boosted_frame` for more information on the above script.)
+(See the documentation of :any:`Particles.make_ionizable` for more information on ionization,
+and the section :doc:`advanced/boosted_frame` for more information on the boosted frame.)
 
-The different FBPIC objects that are used in the simulation scripts are defined
-in the section :doc:`api_reference/api_reference`.
+The different FBPIC objects that are used in the above simulation scripts are
+defined in the section :doc:`api_reference/api_reference`.
 
 Running the simulation
 ----------------------

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -43,8 +43,9 @@ class Simulation(object):
     - `comm`, a `BoundaryCommunicator`, which contains the MPI decomposition
     """
 
-    def __init__(self, Nz, zmax, Nr, rmax, Nm, dt, p_zmin, p_zmax,
-                 p_rmin, p_rmax, p_nz, p_nr, p_nt, n_e, zmin=0.,
+    def __init__(self, Nz, zmax, Nr, rmax, Nm, dt,
+                 p_zmin=-np.inf, p_zmax=np.inf, p_rmin=0, p_rmax=np.inf,
+                 p_nz=None, p_nr=None, p_nt=None, n_e=None, zmin=0.,
                  n_order=-1, dens_func=None, filter_currents=True,
                  v_comoving=None, use_galilean=True,
                  initialize_ions=False, use_cuda=False,

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -54,11 +54,13 @@ class Simulation(object):
                  gamma_boost=None, use_all_mpi_ranks=True,
                  particle_shape='linear', verbose_level=1 ):
         """
-        Initializes a simulation, by creating the following structures:
+        Initializes a simulation.
 
-        - the `Fields` object, which contains the field data on the grids
-        - a set of electrons
-        - a set of ions (if initialize_ions is True)
+        By default the simulation contains:
+        - an electron species
+        - (if ``initialize_ions`` is True) an ion species (Hydrogen 1+)
+        These species are stored in the attribute ``ptcl`` of ``Simulation``
+        (which is a Python list, containing the different species).
 
         .. note::
 
@@ -626,9 +628,10 @@ class Simulation(object):
                             p_rmin=0, p_rmax=np.inf, uz_m=0.,
                             continuous_injection=True ):
         """
-        Create a new species with charge `q` and mass `m`,
-        add it to the simulation (i.e. to the list `Simulation.ptcl`), and
-        return it, so that the specific methods of that species can be used.
+        Create a new species (i.e. an instance of `Particles`) with
+        charge `q` and mass `m`. Add it to the simulation (i.e. to the list
+        `Simulation.ptcl`), and return it, so that the methods of the
+        `Particles` class can be used, for this particular species.
 
         In addition, if `n` is set, then new macroparticles will be created
         within this species (in an evenly-spaced manner).
@@ -685,6 +688,10 @@ class Simulation(object):
         continuous_injection : bool, optional
            Whether to continuously inject the particles,
            in the case of a moving window
+
+        Returns
+        -------
+        new_species: an instance of the `Particles` class
         """
         # Check if any macroparticle need to be injected
         if n is not None:

--- a/fbpic/particles/elementary_process/ionization/read_atomic_data.py
+++ b/fbpic/particles/elementary_process/ionization/read_atomic_data.py
@@ -9,7 +9,7 @@ import re, os
 import numpy as np
 from scipy.constants import e
 
-cashed_ionization_energies = {}
+cached_ionization_energies = {}
 
 def get_ionization_energies( element ):
     """
@@ -17,7 +17,7 @@ def get_ionization_energies( element ):
     array element per ionization state.
 
     If the same element was requested previously, the ionization energy
-    is obtained from a cashed dictionary (`cashed_ionization_energies`)
+    is obtained from a cached dictionary (`cached_ionization_energies`)
     otherwise the energies are read from a data file.
 
     Parameters
@@ -32,14 +32,13 @@ def get_ionization_energies( element ):
     ionization energy in Joules, or None if the element was not found in
     the file.
     """
-    # Lookup in the cashed dictionary
-    if element in cashed_ionization_energies.keys():
-        print('Getting cashed ionization energy for %s.' %element )
-        return( cashed_ionization_energies[element] )
+    # Lookup in the cached dictionary
+    if element in cached_ionization_energies.keys():
+        return( cached_ionization_energies[element] )
     else:
         energies = read_ionization_energies(element)
-        # Record energies in the cashed dictionary
-        cashed_ionization_energies[element] = energies
+        # Record energies in the cached dictionary
+        cached_ionization_energies[element] = energies
         return( energies )
 
 def read_ionization_energies( element ):

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -351,8 +351,8 @@ class Particles(object) :
     def track( self, comm ):
         """
         Activate particle tracking for the current species
-        (i.e. allocates an array of ids, that is communicated through MPI
-        and sorting, and is output in the openPMD file)
+        (i.e. allocates an array of unique IDs for each macroparticle;
+        these IDs are written in the openPMD file)
 
         Parameters
         ----------
@@ -416,12 +416,19 @@ class Particles(object) :
 
     def make_ionizable( self, element, target_species, level_start=0):
         """
-        Make this species ionizable
+        Make this species ionizable.
 
-        The implemented ionization model is the ADK model.
-        See `Chen, JCP 236 (2013)
-        <https://www.sciencedirect.com/science/article/pii/S0021999112007097>`_,
-        equation (2)
+        The implemented ionization model is the **ADK model**
+        (using the **instantaneous** electric field, i.e. **without** averaging
+        over the laser period).
+
+        The expression of the ionization rate can be found in
+        `Chen, JCP 236 (2013), equation 2
+        <https://www.sciencedirect.com/science/article/pii/S0021999112007097>`_.
+
+        Note that the implementation in FBPIC evaluates this ionization rate
+        *in the reference frame of each macroparticle*, and is thus valid
+        in lab-frame simulations as well as boosted-frame simulation.
 
         Parameters
         ----------
@@ -430,9 +437,8 @@ class Particles(object) :
             (e.g. 'He', 'N' ;  do not use 'Helium' or 'Nitrogen')
 
         target_species: an fbpic.Particles object
-            This object is not modified when creating the class, but
-            it is modified when ionization occurs
-            (i.e. more particles are created)
+            Stores the electron macroparticles that are created in
+            the ionization process.
 
         level_start: int
             The ionization level at which the macroparticles are initially

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -419,7 +419,9 @@ class Particles(object) :
         Make this species ionizable
 
         The implemented ionization model is the ADK model.
-        See Chen, JCP 236 (2013), equation (2)
+        See `Chen, JCP 236 (2013)
+        <https://www.sciencedirect.com/science/article/pii/S0021999112007097>`_,
+        equation (2)
 
         Parameters
         ----------

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -354,8 +354,8 @@ class Particles(object) :
         (i.e. allocates an array of ids, that is communicated through MPI
         and sorting, and is output in the openPMD file)
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         comm: an fbpic.BoundaryCommunicator object
             Contains information about the number of processors
         """

--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -201,7 +201,6 @@ def test_parametric_sim_twoproc():
     # Modify the script so as to enable checkpoints
     script = replace_string( script, 'save_checkpoints = False',
                                 'save_checkpoints = True')
-    script = replace_string( script, 'n_order = -1', 'n_order = 16')
     with open(script_filename, 'w') as f:
         f.write(script)
 
@@ -233,6 +232,37 @@ def test_parametric_sim_twoproc():
         # expected one.
         a0_in_diag = ts.get_a0( iteration=80, pol='x' )
         assert abs( (a0 - a0_in_diag)/a0 ) < 1.e-2
+
+    # Suppress the temporary directory
+    shutil.rmtree( temporary_dir )
+
+def test_ionization_script_twoproc():
+    "Test the example script with two proc in `docs/source/example_input`"
+
+    temporary_dir = './tests/tmp_test_dir'
+
+    # Create a temporary directory for the simulation
+    # and copy the example script into this directory
+    if os.path.exists( temporary_dir ):
+        shutil.rmtree( temporary_dir )
+    os.mkdir( temporary_dir )
+    shutil.copy(
+        './docs/source/example_input/ionization_script.py', temporary_dir )
+    script_filename = os.path.join( temporary_dir, 'ionization_script.py' )
+
+    # Read the script
+    with open(script_filename) as f:
+        script = f.read()
+    # Modify the script so as to enable MPI simulation
+    script = replace_string( script, 'n_order = -1', 'n_order = 16')
+    # Write the script
+    with open(script_filename, 'w') as f:
+        f.write(script)
+
+    # Launch the modified script from the OS, with 2 proc
+    response = os.system(
+        'cd %s; mpirun -np 2 python ionization_script.py' %temporary_dir )
+    assert response==0
 
     # Suppress the temporary directory
     shutil.rmtree( temporary_dir )
@@ -290,6 +320,7 @@ def compare_simulations( ts1, ts2 ):
 
 
 if __name__ == '__main__':
+    test_ionization_script_twoproc()
     test_lpa_sim_singleproc_restart()
     test_lpa_sim_twoproc_restart()
     test_parametric_sim_twoproc()

--- a/tests/test_ionization.py
+++ b/tests/test_ionization.py
@@ -119,7 +119,7 @@ def run_simulation( gamma_boost ):
         boundaries='open', use_cuda=use_cuda )
     elec = sim.ptcl[0]
     # Add the N atoms
-    atoms = sim.add_new_species( q=e, m=14.*m_p, n=0.2*n_e,
+    atoms = sim.add_new_species( q=0, m=14.*m_p, n=0.2*n_e,
                         p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
                         p_zmin=p_zmin, p_zmax=p_zmax,
                         p_rmin=p_rmin, p_rmax=p_rmax,

--- a/tests/test_ionization.py
+++ b/tests/test_ionization.py
@@ -26,7 +26,7 @@ import shutil, math
 import numpy as np
 from scipy.constants import c, m_e, m_p, e
 # Import the relevant structures in FBPIC
-from fbpic.main import Simulation, adapt_to_grid
+from fbpic.main import Simulation
 from fbpic.lpa_utils.external_fields import ExternalField
 from fbpic.lpa_utils.boosted_frame import BoostConverter
 from fbpic.openpmd_diag import ParticleDiagnostic, BoostedParticleDiagnostic
@@ -111,9 +111,8 @@ def run_simulation( gamma_boost ):
     diag_period = N_step-1 # Period of the diagnostics in number of timesteps
 
     # Initialize the simulation object, with the electrons
+    # No macroparticles created because we do not pass n, p_nz, p_nr, etc
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-        p_zmax, p_zmax, # No particles get created because we do not pass n,
-        p_rmin, p_rmax, p_nz, p_nr, p_nt, n_e,
         zmin=zmin, initialize_ions=False,
         v_comoving=v_plasma, use_galilean=False,
         boundaries='open', use_cuda=use_cuda )

--- a/tests/test_ionization.py
+++ b/tests/test_ionization.py
@@ -27,7 +27,6 @@ import numpy as np
 from scipy.constants import c, m_e, m_p, e
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation, adapt_to_grid
-from fbpic.particles import Particles
 from fbpic.lpa_utils.external_fields import ExternalField
 from fbpic.lpa_utils.boosted_frame import BoostConverter
 from fbpic.openpmd_diag import ParticleDiagnostic, BoostedParticleDiagnostic
@@ -111,28 +110,23 @@ def run_simulation( gamma_boost ):
     # The diagnostics
     diag_period = N_step-1 # Period of the diagnostics in number of timesteps
 
-    # Initialize the simulation object
+    # Initialize the simulation object, with the electrons
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-        p_zmax, p_zmax, # No electrons get created because we pass p_zmin=p_zmax
+        p_zmax, p_zmax, # No particles get created because we do not pass n,
         p_rmin, p_rmax, p_nz, p_nr, p_nt, n_e,
         zmin=zmin, initialize_ions=False,
         v_comoving=v_plasma, use_galilean=False,
         boundaries='open', use_cuda=use_cuda )
-    sim.set_moving_window( v=v_plasma )
-
+    elec = sim.ptcl[0]
     # Add the N atoms
-    p_zmin, p_zmax, Npz = adapt_to_grid( sim.fld.interp[0].z,
-                                         p_zmin, p_zmax, p_nz )
-    p_rmin, p_rmax, Npr = adapt_to_grid( sim.fld.interp[0].r,
-                                         p_rmin, p_rmax, p_nr )
-    sim.ptcl.append(
-        Particles(q=e, m=14.*m_p, n=0.2*n_e, Npz=Npz, zmin=p_zmin,
-                  zmax=p_zmax, Npr=Npr, rmin=p_rmin, rmax=p_rmax,
-                  Nptheta=p_nt, dt=dt, use_cuda=use_cuda, uz_m=uz_m,
-                  grid_shape=sim.fld.interp[0].Ez.shape,
-                  continuous_injection=False ) )
-    sim.ptcl[1].make_ionizable(element='N', level_start=0,
-                               target_species=sim.ptcl[0])
+    atoms = sim.add_new_species( q=e, m=14.*m_p, n=0.2*n_e,
+                        p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
+                        p_zmin=p_zmin, p_zmax=p_zmax,
+                        p_rmin=p_rmin, p_rmax=p_rmax,
+                        continuous_injection=False, uz_m=uz_m )
+    atoms.make_ionizable(element='N', level_start=0, target_species=elec)
+    # Set the moving window
+    sim.set_moving_window( v=v_plasma )
 
     # Add a laser to the fields of the simulation (external fields)
     sim.external_fields = [


### PR DESCRIPTION
This PR update and expands the documentation by:
- Encouraging the user to use the new function `add_new_species`
- Adding a section on the `Particles` object, which includes the documentation of the `make_ionizable` method. Note that the `__init__` method of the `Particles` object is **not** documented.
- Adding a new downloadable script for ionization simulation. Note that `add_new_species` makes this script much simpler than it would have been in the previous fbpic release. This script is now also automatically tested in `test_example_doc_scripts.py`. Note that `add_new_species` is now also used in the automated test `test_ionization.py`.

The modified documentation can be seen here: http://www.normalesup.org/~lehe/html_fbpic/

This PR also makes a number of arguments of the `Simulation` object optional (those that correspond to the creation of macroparticles at the beginning of the simulation). The defaults values are the same as of the `add_new_species` method. Omitting these arguments is useful/natural for scripts with ionization.

Finally, this PR also removes the messages of the type `Getting cashed ionization energy` that appear when running ionization simulations.