### PR TITLE
Fix bunch initialization

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -706,7 +706,8 @@ class Simulation(object):
             # Automatically convert input quantities to the boosted frame
             if self.boost is not None:
                 beta0 = uz_m/( 1.+uz_m**2 )**0.5
-                p_zmin, p_zmax = self.boost.static_length([ p_zmin, p_zmax ])
+                p_zmin, p_zmax = self.boost.copropag_length(
+                    [ p_zmin, p_zmax ], beta_object=beta0 )
                 n, = self.boost.copropag_density([ n ], beta_object=beta0 )
                 uz_m, = self.boost.longitudinal_momentum([ uz_m ])
 

--- a/tests/test_beam_focusing.py
+++ b/tests/test_beam_focusing.py
@@ -111,11 +111,11 @@ def simulate_beam_focusing( z_injection_plane, write_dir ):
         The directory where the boosted diagnostics are written.
     """
     # Initialize the simulation object
-    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-        p_zmin=0., p_zmax=0., p_rmin=0., p_rmax=0.,
-        p_nz=0, p_nr=0, p_nt=0, n_e=0., zmin=zmin,
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
         gamma_boost=gamma_boost, boundaries='open',
         use_cuda=use_cuda, v_comoving=v_comoving )
+    # Note: no macroparticles get created because we do not pass 
+    # the density and number of particle per cell
 
     # Remove the plasma particles
     sim.ptcl = []

--- a/tests/test_compton.py
+++ b/tests/test_compton.py
@@ -86,8 +86,6 @@ def run_simulation( gamma_boost, show ):
     # Initialize the simulation object
     zmax, zmin = boost.copropag_length( [zmax_lab, zmin_lab], beta_object=1. )
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-        p_zmin=0, p_zmax=0, p_rmin=0, p_rmax=0,
-        p_nz=1, p_nr=1, p_nt=1, n_e=1,
         dens_func=None, zmin=zmin, boundaries='periodic',
         use_cuda=use_cuda )
     # Remove particles that were previously created


### PR DESCRIPTION
This PR fixes a few bugs in the bunch initialization:

- for the function `add_elec_bunch` (i.e. uniform bunch), `p_zmin` and `p_zmax` were not properly transformed in boosted-frame simulations. This is fixed by taking into account the `beta` of the plasma inside `add_new_species`.

- for the function `add_elec_bunch_from_arrays`, the particles were selected in the local domain *before* they were Lorentz-transformed. Because the local domain boundaries are expressed in the boosted frame, this was incorrect. In order to fix this bug, I had to fix the function `boost_particles`, so that it can take arrays as inputs (instead of taking a `Particles` object)

In addition, the method `add_new_species` is now also used when creating the particles from arrays. More precisely, an empty species is created (no macroparticles), and then the arrays are reallocated, by using the function `reallocate_and_copy_old`, which is also used in Compton/ionization. This avoids code duplication, and also automatically handles particle tracking of the newly created particles. 
Note that I did have to modify the function `reallocate_and_copy_old` in order to detect if the arrays are currently on CPU or GPU. (This is because, even when `use_cuda` is True, `add_new_species` creates the particles on CPU)