### PR TITLE
Initialize injection positions at the beginning of step

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -310,6 +310,13 @@ class Simulation(object):
             # This is because use_true_rho requires the guard cells of
             # rho to be exchanged while correct_currents requires the opposite.
 
+        # Initialize the positions for continuous injection by moving window
+        if self.comm.moving_win is not None:
+            for species in self.ptcl:
+                if species.continuous_injection:
+                    species.injector.initialize_injection_positions(
+                        self.comm, self.comm.moving_win.v, species.z, self.dt )
+
         # Initialize variables to measure the time taken by the simulation
         if show_progress and self.comm.rank==0:
             progress_bar = ProgressBar( N )
@@ -778,8 +785,7 @@ class Simulation(object):
                 DeprecationWarning)
 
         # Attach the moving window to the boundary communicator
-        self.comm.moving_win = MovingWindow( self.fld.interp, self.comm,
-            self.dt, self.ptcl, v, self.time )
+        self.comm.moving_win = MovingWindow( self.comm, self.dt, v, self.time )
 
 def adapt_to_grid( x, p_xmin, p_xmax, p_nx, ncells_empty=0 ):
     """

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -273,6 +273,10 @@ def load_species( species, name, ts, iteration, comm ):
         species.track( comm )
         species.tracker.overwrite_ids( pid, comm )
 
+    # Reset the injection positions (for continuous injection)
+    if species.continuous_injection:
+        species.injector.reset_injection_positions()
+
     # As a safe-guard, check that the loaded data is in float64
     for attr in ['x', 'y', 'z', 'ux', 'uy', 'uz', 'w', 'inv_gamma' ]:
         assert getattr( species, attr ).dtype == np.float64


### PR DESCRIPTION
In the current `dev` branch, the positions that keep track of plasma injection are initialized when `set_moving_window` is called.

However, this is not ideal, since it relies on `set_moving_window` being called after all continuously-injected species are created. With `add_new_species`, users might inadvertently create new species after the moving window is set.

Therefore, this PR moves the initialization of these positions at the beginning of `step`. Note that, if `step` is called multiple times, these variables are not reinitialized (because of the `if self.z_inject is None` condition).

On the other hand, in the rare case where a user calls `step`, then does a restart, and then calls `step` again, these variables to need to be reinitialized. I added a new method `reset_injection_position` for this purpose, which gets called when doing a restart.