### PR TITLE
Close #117 Each species should have its own `prefix_sum_shift`

### DIFF
--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -111,9 +111,10 @@ class MovingWindow(object):
 
         # Because the grids have just been shifted, there is a shift
         # in the cell indices that are used for the prefix sum.
-        if fld.use_cuda:
-            fld.prefix_sum_shift += n_move
-            # This quantity is reset to 0 whenever prefix_sum is recalculated
+        for species in ptcl:
+            if species.use_cuda:
+                species.prefix_sum_shift += n_move
+                # This quantity is reset to 0 whenever prefix_sum is recalculated
 
         # Prepare the positions of injection for the particles
         # (The actual creation of particles is done when the routine

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -229,9 +229,9 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     Nz = fld.Nz
     Nr = fld.Nr
     # Find the z index of the first cell for which particles are kept
-    iz_min = max( n_guard + fld.prefix_sum_shift, 0 )
+    iz_min = max( n_guard + species.prefix_sum_shift, 0 )
     # Find the z index of the first cell for which particles are removed again
-    iz_max = min( Nz - n_guard + fld.prefix_sum_shift + 1, Nz )
+    iz_max = min( Nz - n_guard + species.prefix_sum_shift + 1, Nz )
     # Find the corresponding indices in the particle array
     # Reminder: prefix_sum[i] is the cumulative sum of the number of particles
     # in cells 0 to i (where cell i is included)

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -198,11 +198,6 @@ class Fields(object) :
             {'J': False, 'rho_prev': False, 'rho_new': False,
                 'rho_next_xy': False, 'rho_next_z': False }
 
-        # Initialize the needed prefix sum array for sorting
-        if self.use_cuda:
-            # Shift in the indices, induced by the moving window
-            self.prefix_sum_shift = 0
-
         # Generate duplicated deposition arrays, when using threading
         # (One copy per thread ; 2 guard cells on each side in z and r,
         # in order to store contributions from, at most, cubic shape factors ;

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -663,7 +663,7 @@ class ParticleCatcher:
             dz = self.fld.interp[0].dz
             zmin = self.fld.interp[0].zmin
             pref_sum = species.prefix_sum
-            pref_sum_shift = self.fld.prefix_sum_shift
+            pref_sum_shift = species.prefix_sum_shift
             Nz, Nr = species.grid_shape
             # Calculate cell area to get particles from
             # - Get z indices of the slices in which to get the particles

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -213,6 +213,9 @@ class Particles(object) :
             self.sorting_buffer = np.empty( Ntot, dtype=np.float64 )
             Nz, Nr = grid_shape
             self.prefix_sum = np.empty( Nz*(Nr+1), dtype=np.int32 )
+            # Register integer thta records shift in the indices,
+            # induced by the moving window
+            self.prefix_sum_shift = 0
             # Register boolean that records if the particles are sorted or not
             self.sorted = False
 
@@ -994,7 +997,7 @@ class Particles(object) :
         # arrays.
         sort_particles_per_cell(self.cell_idx, self.sorted_idx)
         # Reset the old prefix sum
-        fld.prefix_sum_shift = 0
+        self.prefix_sum_shift = 0
         prefill_prefix_sum[dim_grid_2d_flat, dim_block_2d_flat](
             self.cell_idx, self.prefix_sum, self.Ntot )
         # Perform the inclusive parallel prefix sum


### PR DESCRIPTION
When shifting the moving window, we avoid having to sort the particles again (as long as the particles are not pushed by the particle pusher) by setting the `prefix_sum_shift` variable, which keeps track of the number of cells that the moving window moved, since the last time that the particles were sorted.

Currently, this is a single attribute for all particle species. However, this assumes that all species are always sorted at the same time. This is not necessarily the case, e.g. because some species could be involved in boosted-diagnostics (which involve particle sorting in order to extract particle slices) whereas others are not.

For this reason, `prefix_sum_shift` is now a per-species attribute.

I successfully ran the automated tests on GPU, for this PR.