### PR TITLE
Close #213  Restart does not work for ionizable species

### DIFF
--- a/docs/source/example_input/ionization_script.py
+++ b/docs/source/example_input/ionization_script.py
@@ -26,7 +26,8 @@ from scipy.constants import c, e, m_e, m_p
 # Import the relevant structures from fbpic
 from fbpic.main import Simulation
 from fbpic.lpa_utils.laser import add_laser
-from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic
+from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic, \
+     set_periodic_checkpoint, restart_from_checkpoint
 
 # ----------
 # Parameters
@@ -78,8 +79,13 @@ v_window = c       # Speed of the window
 
 # The diagnostics and the checkpoints/restarts
 diag_period = 10         # Period of the diagnostics in number of timesteps
-ramp_length = 20.e-6
+save_checkpoints = False # Whether to write checkpoint files
+checkpoint_period = 50   # Period for writing the checkpoints
+use_restart = False      # Whether to restart from a previous checkpoint
+track_electrons = False  # Whether to track and write particle ids
+
 # The density profile
+ramp_length = 20.e-6
 def dens_func( z, r ) :
     """Returns relative density at position z and r"""
     # Allocate relative density
@@ -130,6 +136,14 @@ if __name__ == '__main__':
     # Add a laser to the fields of the simulation
     add_laser( sim, a0, w0, ctau, z0, zf=z_foc )
 
+    if use_restart is False:
+        # Track electrons if required (species 0 correspond to the electrons)
+        if track_electrons:
+            elec.track( sim.comm )
+    else:
+        # Load the fields and particles from the latest checkpoint file
+        restart_from_checkpoint( sim )
+
     # Configure the moving window
     sim.set_moving_window( v=v_window )
 
@@ -137,6 +151,9 @@ if __name__ == '__main__':
     sim.diags = [ FieldDiagnostic( diag_period, sim.fld, comm=sim.comm ),
                 ParticleDiagnostic( diag_period,
                     {"e- from N": elec_from_N, "e-": elec}, comm=sim.comm ) ]
+    # Add checkpoints
+    if save_checkpoints:
+        set_periodic_checkpoint( sim, checkpoint_period )
 
     ### Run the simulation
     sim.step( N_step )

--- a/docs/source/example_input/ionization_script.py
+++ b/docs/source/example_input/ionization_script.py
@@ -148,9 +148,12 @@ if __name__ == '__main__':
     sim.set_moving_window( v=v_window )
 
     # Add a diagnostics
-    sim.diags = [ FieldDiagnostic( diag_period, sim.fld, comm=sim.comm ),
+    sim.diags = [
+                FieldDiagnostic( diag_period, sim.fld, comm=sim.comm ),
                 ParticleDiagnostic( diag_period,
-                    {"e- from N": elec_from_N, "e-": elec}, comm=sim.comm ) ]
+                    {"electrons from N": elec_from_N, "electrons": elec},
+                    comm=sim.comm )
+                ]
     # Add checkpoints
     if save_checkpoints:
         set_periodic_checkpoint( sim, checkpoint_period )

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -279,7 +279,7 @@ def load_species( species, name, ts, iteration, comm ):
         # Reallocate the ionization_level, and reset it with the right value
         species.ionizer.ionization_level = np.empty( Ntot, dtype=np.uint64 )
         q, = ts.get_particle( ['charge'], iteration=iteration, species=name)
-        ionization_level[:] = np.uint64( np.round( q/e ) )
+        species.ionizer.ionization_level[:] = np.uint64( np.round( q/e ) )
         # Set the auxiliary array
         species.ionizer.w_times_level = \
                     species.w * species.ionizer.ionization_level

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -9,6 +9,7 @@ as well as reload a simulation from a set of checkpoints.
 """
 import os, re
 import numpy as np
+from scipy.constants import e
 from .field_diag import FieldDiagnostic
 from .particle_diag import ParticleDiagnostic
 from fbpic.utils.mpi import comm
@@ -272,6 +273,16 @@ def load_species( species, name, ts, iteration, comm ):
         pid, = ts.get_particle( ['id'], iteration=iteration, species=name )
         species.track( comm )
         species.tracker.overwrite_ids( pid, comm )
+
+    # If the species is ionizable, set the proper arrays
+    if species.ionizer is not None:
+        # Reallocate the ionization_level, and reset it with the right value
+        species.ionizer.ionization_level = np.empty( Ntot, dtype=np.uint64 )
+        q, = ts.get_particle( ['charge'], iteration=iteration, species=name)
+        ionization_level[:] = np.uint64( np.round( q/e ) )
+        # Set the auxiliary array
+        species.ionizer.w_times_level = \
+                    species.w * species.ionizer.ionization_level
 
     # Reset the injection positions (for continuous injection)
     if species.continuous_injection:

--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -155,7 +155,7 @@ def run_sim( script_name, n_MPI, checked_fields ):
     print('Checking particle ids...')
     start_time = time.time()
     for iteration in ts1.iterations:
-        pid, = ts1.get_particle(["id"], iteration=iteration)
+        pid, = ts1.get_particle(["id"], iteration=iteration, species="electrons")
         assert len(np.unique(pid)) == len(pid)
     end_time = time.time()
     print( "%.2f seconds" %(end_time-start_time))
@@ -198,7 +198,7 @@ def test_boosted_frame_sim_twoproc():
     print('Checking particle ids...')
     start_time = time.time()
     for iteration in ts.iterations:
-        pid, = ts.get_particle(["id"], iteration=iteration)
+        pid, = ts.get_particle(["id"], iteration=iteration )
         assert len(np.unique(pid)) == len(pid)
     end_time = time.time()
     print( "%.2f seconds" %(end_time-start_time))

--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -28,15 +28,15 @@ from opmd_viewer.addons import LpaDiagnostics
 
 def test_lpa_sim_singleproc_restart():
     "Test the example input script with one proc in `docs/source/example_input`"
-    run_lpa_sim( n_MPI=1 )
+    run_sim( 'lwfa_script.py', n_MPI=1 )
 
 def test_lpa_sim_twoproc_restart():
     "Test the example input script with two proc in `docs/source/example_input`"
-    run_lpa_sim( n_MPI=2 )
+    run_sim( 'lwfa_script.py', n_MPI=2 )
 
-def run_lpa_sim( n_MPI ):
+def run_sim( script_name, n_MPI ):
     """
-    Runs the standard lwfa script from the folder docs/source/example_input,
+    Runs the script `script_name` from the folder docs/source/example_input,
     with `n_MPI` MPI processes. The simulation is then restarted with
     the same number of processes ; the code checks that the restarted results
     are identical.
@@ -53,10 +53,10 @@ def run_lpa_sim( n_MPI ):
     if os.path.exists( temporary_dir ):
         shutil.rmtree( temporary_dir )
     os.mkdir( temporary_dir )
-    shutil.copy('./docs/source/example_input/lwfa_script.py',
+    shutil.copy('./docs/source/example_input/%s' %script_name,
                     temporary_dir )
     # Shortcut for the script file, which is repeatedly changed
-    script_filename = os.path.join( temporary_dir,'lwfa_script.py' )
+    script_filename = os.path.join( temporary_dir, script_name )
 
     # Read the script and check
     with open(script_filename) as f:
@@ -81,9 +81,9 @@ def run_lpa_sim( n_MPI ):
     # Launch the script from the OS
     command_line = 'cd %s' %temporary_dir
     if n_MPI == 1:
-        command_line += '; python lwfa_script.py'
+        command_line += '; python %s' %script_name
     else:
-        command_line += '; mpirun -np %d python lwfa_script.py' %n_MPI
+        command_line += '; mpirun -np %d python %s' %(n_MPI, script_name)
     response = os.system( command_line )
     assert response==0
 
@@ -238,34 +238,7 @@ def test_parametric_sim_twoproc():
 
 def test_ionization_script_twoproc():
     "Test the example script with two proc in `docs/source/example_input`"
-
-    temporary_dir = './tests/tmp_test_dir'
-
-    # Create a temporary directory for the simulation
-    # and copy the example script into this directory
-    if os.path.exists( temporary_dir ):
-        shutil.rmtree( temporary_dir )
-    os.mkdir( temporary_dir )
-    shutil.copy(
-        './docs/source/example_input/ionization_script.py', temporary_dir )
-    script_filename = os.path.join( temporary_dir, 'ionization_script.py' )
-
-    # Read the script
-    with open(script_filename) as f:
-        script = f.read()
-    # Modify the script so as to enable MPI simulation
-    script = replace_string( script, 'n_order = -1', 'n_order = 16')
-    # Write the script
-    with open(script_filename, 'w') as f:
-        f.write(script)
-
-    # Launch the modified script from the OS, with 2 proc
-    response = os.system(
-        'cd %s; mpirun -np 2 python ionization_script.py' %temporary_dir )
-    assert response==0
-
-    # Suppress the temporary directory
-    shutil.rmtree( temporary_dir )
+    run_sim( 'ionization_script.py', n_MPI=2 )
 
 
 def replace_string( text, old_string, new_string ):


### PR DESCRIPTION
The restart mechanism was incorrect for ionizable species, because the associated quantities (ionization level, weight multiplied by the level) were not set during the restart.

This PR fixes the issue, and adds an automated test that restart an ionization simulation and checks that the results are *close* to those of a simulation without restart. Note that, because of the randomness of the ionization (which is *not* controlled by the `numpy` random seed, but instead by some seed inside `numba`), the restarted simulation will not give the same results, and the tolerance with which the fields are checked must be adapted.