### PR TITLE
Add various tips in the documentation

### DIFF
--- a/docs/source/advanced/boosted_frame.rst
+++ b/docs/source/advanced/boosted_frame.rst
@@ -64,6 +64,30 @@ paper on this technique <https://journals.aps.org/prl/abstract/10.1103/PhysRevLe
     comparable to the total number of self-injected particles),
     self-injection may not occur at all in the boosted-frame simulation.
 
+    More generally, for simulations involving injection, it is good practice
+    to occasionally compare the results with different :math:`\gamma_b`,
+    in order to make sure that the simulation is properly converged.
+
+
+.. warning::
+
+    In lab-frame simulations, the ions are essentially motionless and the
+    current :math:`\boldsymbol{j}` that they produce is negligeable compared to
+    that of the electrons. For this reason (and because the PIC algorithm
+    essentially only uses the current :math:`\boldsymbol{j}` in order to update the
+    fields: see :doc:`../overview`), the ions are often omitted from the simulation,
+    in order to save computational time. (And in fact, the argument
+    ``initialize_ions`` in the :any:`Simulation` object is set to
+    ``False`` by default.)
+
+    However, this is no longer valid in boosted-frame simulation, because
+    in this case the ions move with relativistic speed and do produce a
+    non-negligible current :math:`\boldsymbol{j}`. Therefore, **in boosted-frame
+    simulations, the ions are required**. Make sure to include them, either
+    by setting the flag ``initialize_ions=True`` in the :any:`Simulation`
+    object, or by adding them separately with :any:`add_new_species`.
+
+
 Converting input parameters from the lab frame to the boosted frame
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/advanced/parameter_scans.rst
+++ b/docs/source/advanced/parameter_scans.rst
@@ -13,7 +13,9 @@ the same GPU, while the other GPUs will be left idle.
 Therefore, FBPIC provides the possibility to launch these different simulations
 as a single command with ``mpirun``, whereby each MPI rank will perform a separate
 PIC simulation, and FBPIC will make sure that each simulation runs on a separate
-GPU.
+GPU. This feature is activated by setting ``use_all_mpi_ranks=False`` in the
+:any:`Simulation` object, in order to instruct FBPIC to use only one MPI rank per
+simulation instead of *all* MPI ranks for a single simulation.
 
 Here is an example on how to structure the input script and specify the parameter
 to be varied between the separate simulations:

--- a/docs/source/advanced/profiling.rst
+++ b/docs/source/advanced/profiling.rst
@@ -41,7 +41,6 @@ and then open the file ``cpu.prof`` with `snakeviz <https://jiffyclub.github.io/
 
    snakeviz cpu.prof
 
-
 Profiling the code executed on GPU
 ----------------------------------
 
@@ -103,15 +102,18 @@ And click ``File > Open``, in order to select the file ``gpu.prof``.
     become very large. Therefore we recommend to profile the code only
     on a small number of PIC iterations (<1000).
 
-Profiling MPI simulations (CPU-side only)
------------------------------------------
+Profiling MPI simulations
+-------------------------
 
 One way to profile MPI simulations is to write **one file per MPI rank**. In
 this case, each file will contain only the profiling data of the corresponding
 MPI process.
 
-There is no simple way to create one file per MPI rank, from the command line.
-Instead, you need to **modify your FBPIC script**, in the following way:
+Profiling the CPU code
+~~~~~~~~~~~~~~~~~~~~~~
+
+One way to create one file per MPI rank is to **modify your FBPIC script**,
+in the following way:
 
 - Add the following lines at the beginning of the file:
 
@@ -153,3 +155,26 @@ Then run your FBPIC script with MPI as usual, e.g. with 4 MPI ranks:
     ::
 
         mpirun -np 4 python fbpic_script.py
+
+
+Profiling the GPU code
+~~~~~~~~~~~~~~~~~~~~~~
+
+Use the following command:
+
+::
+
+    mpirun -np 2 nvprof -o gpu_%q{<RANK>}.prof python fbpic_script.py
+
+where ``<RANK>`` should be replaced by the following name depending on
+your MPI distribution:
+
+    - For openmpi: ``OMPI_COMM_WORLD_RANK``
+    - For mpich: ``PMI_RANK``
+
+(If you are unsure which name to use, type ``mpirun -np 2 printenv | grep RANK``.)
+
+``nvprof`` will then create one profile file per MPI rank. You can load these
+files on the same timeline within ``nvvp`` by clicking
+``File > Import > Nvprof > Multiple processes > Browse``. For more information,
+see `this page <https://devblogs.nvidia.com/cuda-pro-tip-profiling-mpi-applications/>`__.

--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -38,8 +38,12 @@ zmin = -20.e-6
 Nr = 75          # Number of gridpoints along r
 rmax = 150.e-6   # Length of the box along r (meters)
 Nm = 2           # Number of modes used
+# Boosted frame
+gamma_boost = 15.
 # The simulation timestep
-dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
+dt = min( rmax/(2*gamma_boost*Nr), (zmax-zmin)/Nz/c )  # Timestep (seconds)
+# (See the section Advanced use > Running boosted-frame simulation
+# of the FBPIC documentation for an explanation of the above calculation of dt)
 N_step = 101     # Number of iterations to perform
                  # (increase this number for a real simulation)
 
@@ -54,8 +58,7 @@ N_step = 101     # Number of iterations to perform
 # See https://arxiv.org/abs/1611.05712 for more information.
 n_order = -1
 
-# Boosted frame
-gamma_boost = 15.
+# Boosted frame converter
 boost = BoostConverter(gamma_boost)
 
 # The laser (conversion to boosted frame is done inside 'add_laser')

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -57,8 +57,10 @@ class Simulation(object):
         Initializes a simulation.
 
         By default the simulation contains:
-        - an electron species
-        - (if ``initialize_ions`` is True) an ion species (Hydrogen 1+)
+
+            - an electron species
+            - (if ``initialize_ions`` is True) an ion species (Hydrogen 1+)
+
         These species are stored in the attribute ``ptcl`` of ``Simulation``
         (which is a Python list, containing the different species).
 
@@ -647,6 +649,13 @@ class Simulation(object):
         as been passed to the `Simulation` object), all quantities that
         are explicitly mentioned to be in the lab frame below are
         automatically converted to the boosted frame.
+
+        .. note::
+
+            For the arguments below, it is recommended to have at least
+            ``p_nt = 4*Nm``, i.e. the required number of macroparticles
+            along `theta` (in order for the simulation to be properly resolved)
+            increases with the number of azimuthal modes used.
 
         Parameters
         ----------


### PR DESCRIPTION
This adds various tips in the documentation, mainly based on feedback from users:

- Mentions that the number of particles should be increased when increasing the number of azimuthal modes.
- Mentions that boosted-frame simulations should include ions, and that it is good to check the convergence with lower gamma.
- Insists on using the parameter ``use_all_mpi_ranks`` when doing parameter scans (easily overlooked in the documentation)
- Mentions how to profile multi-GPU code
- Prevents the timestep from being too big in the example boosted-frame simulation.

The updated documentation can be seen here: http://www.normalesup.org/~lehe/html_fbpic/