### PR TITLE
Install pyculib from standard conda channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pip install fbpic
 - **Optional:** in order to run on GPU, install the additional package
 `pyculib`:
 ```
-conda install -c numba pyculib
+conda install pyculib
 ```
 
 - **Optional:** in order to run on a CPU which is **not** an Intel model, you

--- a/docs/source/install/install_jureca.rst
+++ b/docs/source/install/install_jureca.rst
@@ -45,7 +45,7 @@ Then install the dependencies of FBPIC:
 ::
 
    conda install numba mkl
-   conda install -c numba pyculib
+   conda install pyculib
 
 It is important that the following packages are **NOT** installed
 directly with Anaconda: ``mpich``, ``mpi4py``, ``hdf5`` and ``h5py``

--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -58,7 +58,7 @@ Installation of FBPIC and its dependencies
 
        conda install numba scipy h5py mkl
        conda install -c conda-forge mpi4py
-       conda install -c numba pyculib
+       conda install pyculib
 
 
 -  Install ``fbpic``

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -33,7 +33,7 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
    ::
 
-       conda install -c numba pyculib
+       conda install pyculib
 
 
 -  **Optional:** In order to run on a CPU which is **not** an Intel model, you need to install `pyfftw`, in order to replace the MKL FFT:

--- a/docs/source/install/install_titan.rst
+++ b/docs/source/install/install_titan.rst
@@ -58,7 +58,7 @@ Installation of FBPIC and its dependencies
   ::
 
     conda install numba scipy h5py mkl
-    conda install -c numba pyculib
+    conda install pyculib
 
 -  Clone and install the ``fbpic`` repository using git
 


### PR DESCRIPTION
The current installation instructions recommend
```
conda install -c numba pyculib
```
It turns out that this automatically installs cuda **version 9.1** (as a package named `cudatoolkit`). Because this is the most recent version of cuda, most users will have a driver that **does not** support cuda 9.1, and fbpic will typically fail to run, with the following error:
```
pyculib.blas.binding.CuBLASError: CUBLAS_STATUS_NOT_INITIALIZED
```

By contrast, when typing
```
cuda install pyculib
```
the installed version of cuda is 8.0. This is much less likely to cause bugs due to (relatively) old driver.

As a consequence, this PR updates the instructions to remove `-c numba`.