### PR TITLE
Add laser profile for flattened Gaussian laser

### DIFF
--- a/docs/source/api_reference/lpa_utilities/laser.rst
+++ b/docs/source/api_reference/lpa_utilities/laser.rst
@@ -49,22 +49,14 @@ Laser profiles
 
 This section lists the available laser profiles in FBPIC. Note that you can
 also combine these laser profiles (by summing them), or even create your
-own custom laser profiles (see the end of this section).
+own custom laser profiles.
 
-Gaussian profile
-****************
+.. toctree::
+    :maxdepth: 1
 
-.. autoclass:: fbpic.lpa_utils.laser.GaussianLaser
-
-Laguerre-Gauss profile
-**********************
-
-.. autoclass:: fbpic.lpa_utils.laser.LaguerreGaussLaser
-
-Flattened Gaussian profile
-**************************
-
-.. autoclass:: fbpic.lpa_utils.laser.FlattenedGaussianLaser
+    laser_profiles/gaussian
+    laser_profiles/laguerre
+    laser_profiles/flattened
 
 Combining (summing) laser profiles
 **********************************

--- a/docs/source/api_reference/lpa_utilities/laser.rst
+++ b/docs/source/api_reference/lpa_utilities/laser.rst
@@ -61,6 +61,11 @@ Laguerre-Gauss profile
 
 .. autoclass:: fbpic.lpa_utils.laser.LaguerreGaussLaser
 
+Focused Flattened Gaussian profile
+**********************************
+
+.. autoclass:: fbpic.lpa_utils.laser.FocusedFlattenedLaser
+
 Combining (summing) laser profiles
 **********************************
 

--- a/docs/source/api_reference/lpa_utilities/laser.rst
+++ b/docs/source/api_reference/lpa_utilities/laser.rst
@@ -61,10 +61,10 @@ Laguerre-Gauss profile
 
 .. autoclass:: fbpic.lpa_utils.laser.LaguerreGaussLaser
 
-Focused Flattened Gaussian profile
-**********************************
+Flattened Gaussian profile
+**************************
 
-.. autoclass:: fbpic.lpa_utils.laser.FocusedFlattenedLaser
+.. autoclass:: fbpic.lpa_utils.laser.FlattenedGaussianLaser
 
 Combining (summing) laser profiles
 **********************************

--- a/docs/source/api_reference/lpa_utilities/laser_profiles/flattened.rst
+++ b/docs/source/api_reference/lpa_utilities/laser_profiles/flattened.rst
@@ -1,0 +1,4 @@
+Flattened Gaussian profile
+**************************
+
+.. autoclass:: fbpic.lpa_utils.laser.FlattenedGaussianLaser

--- a/docs/source/api_reference/lpa_utilities/laser_profiles/gaussian.rst
+++ b/docs/source/api_reference/lpa_utilities/laser_profiles/gaussian.rst
@@ -1,0 +1,4 @@
+Gaussian profile
+****************
+
+.. autoclass:: fbpic.lpa_utils.laser.GaussianLaser

--- a/docs/source/api_reference/lpa_utilities/laser_profiles/laguerre.rst
+++ b/docs/source/api_reference/lpa_utilities/laser_profiles/laguerre.rst
@@ -1,0 +1,4 @@
+Laguerre-Gauss profile
+**********************
+
+.. autoclass:: fbpic.lpa_utils.laser.LaguerreGaussLaser

--- a/fbpic/lpa_utils/laser/__init__.py
+++ b/fbpic/lpa_utils/laser/__init__.py
@@ -4,7 +4,7 @@ It imports functions which are useful when initializing a laser pulse
 """
 from .laser import add_laser, add_laser_pulse
 from .laser_profiles import GaussianLaser, LaguerreGaussLaser, \
-                            FocusedFlattenedLaser
+                            FlattenedGaussianLaser
 
 __all__ = ['add_laser', 'add_laser_pulse',
-            'GaussianLaser', 'LaguerreGaussLaser', 'FocusedFlattenedLaser']
+            'GaussianLaser', 'LaguerreGaussLaser', 'FlattenedGaussianLaser']

--- a/fbpic/lpa_utils/laser/__init__.py
+++ b/fbpic/lpa_utils/laser/__init__.py
@@ -3,7 +3,8 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It imports functions which are useful when initializing a laser pulse
 """
 from .laser import add_laser, add_laser_pulse
-from .laser_profiles import GaussianLaser, LaguerreGaussLaser
+from .laser_profiles import GaussianLaser, LaguerreGaussLaser, \
+                            FocusedFlattenedLaser
 
 __all__ = ['add_laser', 'add_laser_pulse',
-            'GaussianLaser', 'LaguerreGaussLaser']
+            'GaussianLaser', 'LaguerreGaussLaser', 'FocusedFlattenedLaser']

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -398,7 +398,7 @@ class LaguerreGaussLaser( LaserProfile ):
 class FlattenedGaussianLaser( LaserProfile ):
     """Class that calculates a focused flattened Gaussian"""
 
-    def __init__( self, a0, w0, tau, z0, N=10, zf=None, theta_pol=0.,
+    def __init__( self, a0, w0, tau, z0, N=6, zf=None, theta_pol=0.,
                     lambda0=0.8e-6, cep_phase=0. ):
         """
         Define a linearly-polarized laser such that the transverse intensity
@@ -419,8 +419,7 @@ class FlattenedGaussianLaser( LaserProfile ):
             \exp\\left(-\\frac{r^2}{(N+1)w_0^2}\\right)
             \sum_{n=0}^N c'_n L^0_n\\left(\\frac{2\,r^2}{(N+1)w_0^2}\\right)
 
-            \mathrm{with} \qquad c'_n = \sum_{m=n}^{N}\\frac{1}{2^m}
-            \\left( \\begin{array}{c}m \\ n\end{array} \\right)
+            \mathrm{with} \qquad c'_n = \sum_{m=n}^{N}\\frac{1}{2^m}\\binom{m}{n}
 
         - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\\left(-\\frac{r^2}{w_0^2}\\right)`.
 
@@ -445,9 +444,40 @@ class FlattenedGaussianLaser( LaserProfile ):
         a0: float (dimensionless)
             The peak normalized vector potential at the focal plane.
 
-        w0: float
+        w0: float (in meter)
+            Laser spot size in the focal plane, defined as :math:`w_0` in the
+            above formula.
 
+        tau: float (in second)
+            The duration of the laser (in the lab frame)
+
+        z0: float (in meter)
+            The initial position of the centroid of the laser
+            (in the lab frame)
+
+        N: int
+            Determines the "flatness" of the transverse profile, far from
+            focus (see the above formula).
+            Default: ``N=6`` ; somewhat close to an 8th order supergaussian.
+
+        zf: float (in meter), optional
+            The position of the focal plane (in the lab frame).
+            If ``zf`` is not provided, the code assumes that ``zf=z0``, i.e.
+            that the laser pulse is at the focal plane initially.
+
+        theta_pol: float (in radian), optional
+           The angle of polarization with respect to the x axis.
+
+        lambda0: float (in meter), optional
+            The wavelength of the laser (in the lab frame)
+            Default: 0.8 microns (Ti:Sapph laser).
+
+        cep_phase: float (in radian), optional
+            The Carrier Enveloppe Phase (CEP, i.e. the phase of the laser
+            oscillation, at the position where the laser enveloppe is maximum)
         """
+        # Ensure that N is an integer
+        N = int(round(N))
         # Calculate effective waist of the Laguerre-Gauss modes, at focus
         w_foc = w0*(N+1)**.5
 

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -433,7 +433,7 @@ class FlattenedGaussianLaser( LaserProfile ):
             \exp\\left(-\\frac{(N+1)r^2}{w(z)^2}\\right)
             \sum_{n=0}^N \\frac{1}{n!}\left(\\frac{(N+1)\,r^2}{w(z)^2}\\right)^n
 
-            \mathrm{with} \qquad w(z) = \\frac{\lambda_0}{\pi w_0^2}|z-z_{foc}|
+            \mathrm{with} \qquad w(z) = \\frac{\lambda_0}{\pi w_0}|z-z_{foc}|
 
         - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\\left(-\\frac{r^2}{w_(z)^2}\\right)`.
 

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -402,53 +402,52 @@ class FlattenedGaussianLaser( LaserProfile ):
                     lambda0=0.8e-6, cep_phase=0. ):
         """
         Define a linearly-polarized laser such that the transverse intensity
-        profile is a flattened Gaussian **far from focus**, and distribution
-        with rings **in the focal plane**.
+        profile is a flattened Gaussian **far from focus**, and a distribution
+        with rings **in the focal plane**. (See `Santarsiero et al., J.
+        Modern Optics, 1997 <http://doi.org/10.1080/09500349708232927>`_)
 
         Increasing the parameter ``N`` increases the
-        flatness of transverse profile **far from focus**, and increases the
-        number of rings **in the focal plane**.
+        flatness of the transverse profile **far from focus**,
+        and increases the number of rings **in the focal plane**.
 
         More precisely, the expression **in the focal plane** uses the
-        Laguerre polynomials :math:`L^0_n`:
+        Laguerre polynomials :math:`L^0_n`, and reads:
 
         .. math::
 
-            E(\\boldsymbol{x},t)\propto\exp\left(-\\frac{r^2}{(N+1)w_0^2}\right)
-            \sum_{n=0}^N c_n L^0_n\left(\\frac{2\,r^2}{(N+1)w_0^2}\right)
+            E(\\boldsymbol{x},t)\propto
+            \exp\\left(-\\frac{r^2}{(N+1)w_0^2}\\right)
+            \sum_{n=0}^N c'_n L^0_n\\left(\\frac{2\,r^2}{(N+1)w_0^2}\\right)
 
-            \mathrm{with} \qquad c_n = \sum_{m=n}^{N}\frac{1}{2^m}
+            \mathrm{with} \qquad c'_n = \sum_{m=n}^{N}\\frac{1}{2^m}
+            \\left( \\begin{array}{c}m \\ n\end{array} \\right)
 
-        For :math:`N=0`, this is a Gaussian profile:
-        :math:`E\propto\exp\left(-\\frac{r^2}{w_0^2}\right)`.
-        For :math:`N\rightarrow\infty`, this is a Jinc profile:
-        :math:`E\propto \\frac{J_1(r/w_0)}{r/w_0}`.
+        - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\\left(-\\frac{r^2}{w_0^2}\\right)`.
+
+        - For :math:`N\\rightarrow\infty`, this is a Jinc profile: :math:`E\propto \\frac{J_1(r/w_0)}{r/w_0}`.
 
         The expression **far from focus** is
 
         .. math::
 
-            E(\\boldsymbol{x},t)\propto\exp\left(-\\frac{(N+1)r^2}{w(z)^2}\right)
-            \sum_{n=0}^N \\frac{1}{n!}\left(\\frac{(N+1)\,r^2}{w(z)^2}\right)^n
+            E(\\boldsymbol{x},t)\propto
+            \exp\\left(-\\frac{(N+1)r^2}{w(z)^2}\\right)
+            \sum_{n=0}^N \\frac{1}{n!}\left(\\frac{(N+1)\,r^2}{w(z)^2}\\right)^n
 
-            \mathrm{with} \qquad w(z) = \\frac{\lambda_0}{\pi w_0^2}|z|
+            \mathrm{with} \qquad w(z) = \\frac{\lambda_0}{\pi w_0^2}|z-z_{foc}|
 
-        For :math:`N=0`, this is a Gaussian profile:
-        :math:`E\propto\exp\left(-\\frac{r^2}{w_(z)^2}\right)`.
-        For :math:`N\rightarrow\infty`, this is a flat profile:
-        :math:`E\propto \\Theta(w(z)-r)`, where :math:`\\Theta` is
-        the Heaviside function.
+        - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\\left(-\\frac{r^2}{w_(z)^2}\\right)`.
 
-        For more details, see
-        `Santarsiero et al., J. Modern Optics, 1997 <http://doi.org/10.1080/09500349708232927>`_.
+        - For :math:`N\\rightarrow\infty`, this is a flat profile: :math:`E\propto \\Theta(w(z)-r)`.
 
-        Parameters:
-        -----------
-        TODO
+        Parameters
+        ----------
+        a0: float (dimensionless)
+            The peak normalized vector potential at the focal plane.
+
+        w0: float
 
         """
-        # Set a number of parameters for the laser
-        k0 = 2*np.pi/lambda0
         # Calculate effective waist of the Laguerre-Gauss modes, at focus
         w_foc = w0*(N+1)**.5
 

--- a/tests/test_flattenedgauss_laser.py
+++ b/tests/test_flattenedgauss_laser.py
@@ -1,0 +1,112 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This test file is part of FB-PIC (Fourier-Bessel Particle-In-Cell).
+
+It tests the flattened Gaussian laser profile by initializing the laser
+in the focal plane, and letting it propagate for many Rayleigh lengths.
+This test then automatically checks that the transverse profile at this
+point corresponds to a flattened Gaussian.
+
+Usage :
+-------
+In order to show the transverse profile out of focus:
+$ python tests/test_flattenedgauss_laser.py
+(except when setting show to False in the parameters below)
+
+In order to let Python check the agreement between the curve without
+having to look at the plots
+$ py.test -q tests/test_flattenedgauss_laser.py
+or
+$ python setup.py test
+"""
+import numpy as np
+from scipy.special import factorial
+from scipy.constants import c
+from fbpic.main import Simulation
+from fbpic.lpa_utils.laser import add_laser_pulse, FlattenedGaussianLaser
+
+# Parameters
+# ----------
+
+show = True  # Whether to show the plots, and check them manually
+
+use_cuda = True
+
+# Simulation box
+Nz = 1600
+zmin = -40.e-6
+zmax = 40.e-6
+Nr = 600
+rmax = 300.e-6
+Nm = 2
+n_order = -1
+# Laser pulse
+w0 = 4.e-6
+N = 6
+ctau = 10.e-6
+k0 = 2*np.pi/0.8e-6
+a0 = 1.
+# Propagation
+Lprop = 2400.e-6 # Corresponds to many Rayleigh lengths
+
+# Checking the results
+rtol = 1.5e-2
+
+def flat_gauss(x, N):
+    """
+    Function that calculates the theoretical profile out of focus
+    """
+    u = np.zeros_like(x)
+    for n in range(N+1):
+        u += 1./factorial(n) * ((N+1)*x**2)**n
+    u *= np.exp(-(N+1)*x**2)
+    return u
+
+
+def test_laser_periodic(show=False):
+    """
+    Function that is run by py.test, when doing `python setup.py test`
+    Test the propagation of a laser in a periodic box.
+    """
+    # Propagate the pulse in a single step
+    dt = Lprop*1./c
+
+    # Initialize the simulation object
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
+                n_order=n_order, zmin=zmin, boundaries='periodic' )
+
+    # Initialize the laser fields
+    profile = FlattenedGaussianLaser(a0=a0, w0=w0, N=N, tau=ctau/c, z0=0, zf=0)
+    add_laser_pulse( sim, profile )
+
+    # Propagate the pulse
+    sim.step(1)
+
+    # Check the validity of the transverse field profile
+    # (Take the RMS field in order to suppress the laser oscillations)
+    trans_profile = np.sqrt( np.average(sim.fld.interp[1].Er.real**2, axis=0) )
+    # Calculate the theortical profile out-of-focus
+    Zr = k0*w0**2/2
+    w_th = w0*Lprop/Zr
+    r = sim.fld.interp[1].r
+    th_profile = trans_profile[0]*flat_gauss( r/w_th, N )
+    # Plot the profile, if requested by the user
+    if show:
+        import matplotlib.pyplot as plt
+        plt.plot( 1.e6*r, trans_profile, label='Simulated' )
+        plt.plot( 1.e6*r, th_profile, label='Theoretical' )
+        plt.legend(loc=0)
+        plt.xlabel('r (microns)')
+        plt.title('Transverse profile out-of-focus')
+        plt.tight_layout()
+        plt.show()
+    # Check the validity
+    assert np.allclose( th_profile, trans_profile, atol=rtol*th_profile[0] )
+
+
+if __name__ == '__main__' :
+
+    # Run the testing function
+    test_laser_periodic(show=show)

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -217,8 +217,7 @@ def propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
     """
 
     # Initialize the simulation object
-    sim = Simulation( Nz, zmax, Nr, Lr, Nm, dt, p_zmin=0, p_zmax=0,
-                    p_rmin=0, p_rmax=0, p_nz=2, p_nr=2, p_nt=2, n_e=0.,
+    sim = Simulation( Nz, zmax, Nr, Lr, Nm, dt,
                     n_order=n_order, zmin=zmin, use_cuda=use_cuda,
                     boundaries=boundaries, v_comoving=v_comoving,
                     exchange_period = 1, use_galilean=use_galilean )


### PR DESCRIPTION
This adds a laser profile which is flattened in the near-field and has rings in the far-field. The advantage of this profile is that it has a fully analytical expression for any `z` and `t` (contrary to an exact flat-top profile).

In addition, the documentation for laser profiles has been slightly modified, in order to list the different available laser profiles, and have one page per profile, as this makes it more readable ; here is a preview: http://www.normalesup.org/~lehe/html_fbpic/api_reference/lpa_utilities/laser.html#laser-profiles

TODO

- [x] Add automated test
