### PR TITLE
Simplify the API of the InterpolationGrid

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -992,12 +992,10 @@ class BoundaryCommunicator(object):
                 local=False, with_guard=False, with_damp=False )
             zmin_global, zmax_global = self.get_zmin_zmax(
                 local=False, with_guard=False, with_damp=False )
-            # Create new grid array that contains cell positions in z
-            z = zmin_global + \
-                self.dz*( 0.5 + iz_start_global + np.arange(Nz_global) )
             # Initialize new InterpolationGrid object that
             # is used to gather the global grid data
-            gathered_grid = InterpolationGrid(z=z, r=grid.r, m=grid.m)
+            gathered_grid = InterpolationGrid( Nz_global, grid.Nr, grid.m,
+                                    zmin_global, zmax_global, grid.rmax )
         else:
             # Other processes do not need to initialize new InterpolationGrid
             gathered_grid = None

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -670,10 +670,18 @@ class InterpolationGrid(object) :
 
         Parameters
         ----------
-        TODO
+        Nz, Nr : int
+            The number of gridpoints in z and r
 
         m : int
             The index of the mode
+
+        zmin, zmax : float (zmin, optional)
+            The initial position of the left and right
+            edge of the box along z
+
+        rmax : float
+            The position of the edge of the box along r
 
         use_cuda : bool, optional
             Wether to use the GPU or not


### PR DESCRIPTION
In the `dev` branch, the `InterpolationGrid` requires the array `z` to be passed, but this array is in fact only used in order to calculate `dz` and `zmin`,`zmax`.

Therefore it is a bit weird/ugly to pass the full `z` array. This PR modifies the API of `InterpolationGrid` to fix this.