### PR TITLE
Simplify MPI code, and use separate buffers for E and B exchange

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -501,13 +501,13 @@ class BoundaryCommunicator(object):
             grid_t = [ getattr(interp[m], fieldtype+'t') for m in range(Nm) ]
             grid_z = [ getattr(interp[m], fieldtype+'z') for m in range(Nm) ]
             self.mpi_buffers.handle_vec_buffer(
-                    grid_r, grid_t, grid_z, method, use_cuda,
+                    grid_r, grid_t, grid_z, method, exchange_type, use_cuda,
                     before_sending=True, gpudirect=gpudirect_enabled )
         else:
             # Scalar field
             grid = [ getattr(interp[m], fieldtype) for m in range(Nm) ]
             self.mpi_buffers.handle_scal_buffer(
-                    grid, method, use_cuda,
+                    grid, method, exchange_type, use_cuda,
                     before_sending=True, gpudirect=gpudirect_enabled )
         if gpudirect_enabled:
             # Synchronize GPU execution (break asynchroneous kernel
@@ -540,12 +540,12 @@ class BoundaryCommunicator(object):
         if fieldtype in ('E', 'B', 'J'):
             # Vector field
             self.mpi_buffers.handle_vec_buffer(
-                    grid_r, grid_t, grid_z, method, use_cuda,
+                    grid_r, grid_t, grid_z, method, exchange_type, use_cuda,
                     after_receiving=True, gpudirect=gpudirect_enabled )
         else:
             # Scalar field
             self.mpi_buffers.handle_scal_buffer(
-                    grid, method, use_cuda,
+                    grid, method, exchange_type, use_cuda,
                     after_receiving=True, gpudirect=gpudirect_enabled )
 
 

--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -109,8 +109,6 @@ class BufferHandler(object):
         -- or --
         2) Replaces or adds MPI sending buffers to the field grids
 
-        TODO: Update the docstring
-
         For method 'replace':
 
         Either copy the inner part of the domain to the sending buffer
@@ -136,6 +134,10 @@ class BufferHandler(object):
         method: str
             Can either be 'replace' or 'add' depending on the type
             of field exchange that is needed
+
+        exchange_type: str
+            Can either be 'E:replace', 'B:replace', 'J:add' or 'rho:add'
+            Determines which buffer array is used.
 
         use_cuda: bool
             Whether the simulation runs on GPUs. If True,

--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -201,10 +201,10 @@ class BufferHandler(object):
                 # copy the CPU receiving buffers to the GPU buffers
                 if not gpudirect:
                     if copy_left:
-                        self.d_recv_l[exchange_type].copy_to_host(
+                        self.d_recv_l[exchange_type].copy_to_device(
                             self.recv_l[exchange_type] )
                     if copy_right:
-                        self.d_recv_r[exchange_type].copy_to_host(
+                        self.d_recv_r[exchange_type].copy_to_device(
                             self.recv_r[exchange_type] )
                 if method == 'replace':
                     # Replace the guard cells of the domain with the buffers


### PR DESCRIPTION
This PR is more of a suggestion ; feel free to reject it.

The aim is to reduce duplication in the code for the MPI exchanges. This is done (mainly) by using dictionaries that point to the different types of MPI buffers, instead of using `if` conditions which explicitly refer to the buffer in each case.

Also, there is now a separate buffer for each of the exchanges that are done (replace B, replace E, add J, add rho). In the future, this could be useful in order to make these exchanges asynchronous, and overlap them. There is no buffer anymore for the exchanges that are not done in the code (replacing a scalar).

I successfully tested this with 2 MPI, using the `test_linear_wakefield.py` with `n_order=32` in the following configurations:
- on CPU
- on GPU without GPU-direct
- on GPU with GPU-direct