### PR TITLE
Switch complex convention for definition of laser profiles

### DIFF
--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -207,18 +207,18 @@ class GaussianLaser( LaserProfile ):
         # multiplying the Fourier transform of the laser at focus
         # E(k_x,k_y,\omega) = exp( -(\omega-\omega_0)^2(\tau^2/4 + \phi^(2)/2)
         # - (k_x^2 + k_y^2)w_0^2/4 ) by the paraxial propagator
-        # e^(i(\omega/c - (k_x^2 +k_y^2)/2k0)(z-z_foc))
+        # e^(-i(\omega/c - (k_x^2 +k_y^2)/2k0)(z-z_foc))
         # and then by taking the inverse Fourier transform in x, y, and t
 
         # Diffraction and stretch_factor
-        diffract_factor = 1. - 1j * ( z - self.zf ) * self.inv_zr
-        stretch_factor = 1 + 2j * self.phi2_chirp * c**2 * self.inv_ctau2
+        diffract_factor = 1. + 1j * ( z - self.zf ) * self.inv_zr
+        stretch_factor = 1 - 2j * self.phi2_chirp * c**2 * self.inv_ctau2
         # Calculate the argument of the complex exponential
-        exp_argument = 1j*self.cep_phase + 1j*self.k0*( c*t + self.z0 - z ) \
+        exp_argument = 1j*self.k0*( z - self.z0 - c*t ) - 1j*self.cep_phase \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - 1./stretch_factor * self.inv_ctau2 * ( c*t  + self.z0 - z )**2
+            - 1./stretch_factor * self.inv_ctau2 * ( z - self.z0 - c*t )**2
         # Get the transverse profile
-        profile = np.exp(exp_argument) / ( diffract_factor * stretch_factor**0.5 )
+        profile = np.exp(exp_argument) /(diffract_factor * stretch_factor**0.5)
 
         # Get the projection along x and y, with the correct polarization
         Ex = self.E0x * profile
@@ -371,17 +371,17 @@ class LaguerreGaussLaser( LaserProfile ):
             Arrays of the same shape as x, y, z, containing the fields
         """
         # Diffraction factor, waist and Gouy phase
-        diffract_factor = 1. - 1j * ( z - self.zf ) * self.inv_zr
+        diffract_factor = 1. + 1j * ( z - self.zf ) * self.inv_zr
         w = self.w0 * abs( diffract_factor )
-        psi = - np.angle( diffract_factor )
+        psi = np.angle( diffract_factor )
         # Calculate the scaled radius and azimuthal angle
         scaled_radius_squared = 2*( x**2 + y**2 ) / w**2
         scaled_radius = np.sqrt( scaled_radius_squared )
         theta = np.angle( x + 1.j*y )
         # Calculate the argument of the complex exponential
-        exp_argument = 1j*self.cep_phase + 1j*self.k0*( c*t + self.z0 - z ) \
+        exp_argument = 1j*self.k0*( z - self.z0 - c*t ) - 1j*self.cep_phase \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - self.inv_ctau2 * ( c*t  + self.z0 - z )**2 \
+            - self.inv_ctau2 * ( z - self.z0 - c*t )**2 \
             + 1.j*(2*self.p + self.m)*psi # *Additional* Gouy phase
         # Get the transverse profile
         profile = np.exp(exp_argument) / diffract_factor \


### PR DESCRIPTION
The laser profiles typically use complex numbers to simplify the math ; however the `E_field` function only returns the real part of that complex number.

Right now, the complex number that are used are of the form
```
complex_profile = exp( i k (ct - z) + Z )
```
where `Z` is a complex number which groups other terms (wave front curvature, etc.)

However, because we only use the real part of this, we could also use the complex conjugate
```
complex_profile = exp( i k (z - ct) + Z* )
```
and still get the same result.

In the end, using the first or the second expression is a matter of convention. However, the first expression is somewhat confusing because we use the convention  `exp( i k (z - ct) )` in the derivations of the FBPIC paper. 

Also, in the case of the laser envelope model, the initialization of the laser keeps the full complex expression, and so in this case it does matter which convention we use. (See upcoming PR...) The second expression above is consistent with the convention which is typically used for the envelope model in the literature.

Therefore, this PR switches from the first expression to the second expression in the laser profiles.