### PR TITLE
Implement laser envelope model in vacuum

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy.constants import c
 from fbpic.utils.mpi import MPI, comm, mpi_type_dict, \
     mpi_installed, gpudirect_enabled
-from fbpic.fields.fields import InterpolationGrid
+from fbpic.fields.fields import FieldInterpolationGrid
 from fbpic.fields.utility_methods import get_stencil_reach
 from fbpic.particles.particles import Particles
 from .field_buffer_handling import BufferHandler
@@ -471,7 +471,7 @@ class BoundaryCommunicator(object):
         Parameters:
         ------------
         interp: list
-            A list of InterpolationGrid objects
+            A list of FieldInterpolationGrid objects
             (one element per azimuthal mode)
 
         fieldtype: str
@@ -710,7 +710,7 @@ class BoundaryCommunicator(object):
 
         Parameter:
         -----------
-        interp: list of InterpolationGrid objects (one per azimuthal mode)
+        interp: list of FieldInterpolationGrid objects (one per azimuthal mode)
             Objects that contain the fields to be damped.
         """
         # Do not damp the fields for 0 n_damp cells (periodic)
@@ -803,7 +803,7 @@ class BoundaryCommunicator(object):
 
         Parameter:
         -----------
-        grid: Grid object (InterpolationGrid)
+        grid: Grid object (FieldInterpolationGrid)
             A grid object that is gathered on the root process
 
         root: int, optional
@@ -811,7 +811,7 @@ class BoundaryCommunicator(object):
 
         Returns:
         ---------
-        gathered_grid: Grid object (InterpolationGrid)
+        gathered_grid: Grid object (FieldInterpolationGrid)
             A gathered grid that contains the global simulation data
         """
         # Calculate global edges of the simulation box on root process
@@ -820,12 +820,12 @@ class BoundaryCommunicator(object):
                 local=False, with_guard=False, with_damp=False )
             zmin_global, zmax_global = self.get_zmin_zmax(
                 local=False, with_guard=False, with_damp=False )
-            # Initialize new InterpolationGrid object that
+            # Initialize new FieldInterpolationGrid object that
             # is used to gather the global grid data
-            gathered_grid = InterpolationGrid( Nz_global, grid.Nr, grid.m,
+            gathered_grid = FieldInterpolationGrid( Nz_global, grid.Nr, grid.m,
                                     zmin_global, zmax_global, grid.rmax )
         else:
-            # Other processes do not need to initialize new InterpolationGrid
+            # Other processes do not need to initialize new FieldInterpolationGrid
             gathered_grid = None
         # Loop over fields that need to be gathered
         for field in ['Er', 'Et', 'Ez',

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -292,7 +292,7 @@ class Fields(object) :
         ---------
         fieldtype :
             A string which represents the kind of field to transform
-            (either 'E', 'B', 'J', 'rho_next', 'rho_prev')
+            (either 'E', 'B', 'J', 'rho_next', 'rho_prev’, ‘A’)
         """
         # Use the appropriate transformation depending on the fieldtype.
         if fieldtype == 'E' :
@@ -325,6 +325,11 @@ class Fields(object) :
                 spectral_rho = getattr( self.spect[m], fieldtype )
                 self.trans[m].interp2spect_scal(
                     self.interp[m].rho, spectral_rho )
+        elif fieldtype == 'A':
+            # Transform each azimuthal grid individually
+            for m in range(self.Nm) :
+                self.trans[m].interp2spect_scal(
+                    self.interp[m].A, self.spect[m].A )
         else:
             raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
 
@@ -337,7 +342,7 @@ class Fields(object) :
         ---------
         fieldtype :
             A string which represents the kind of field to transform
-            (either 'E', 'B', 'J', 'rho_next', 'rho_prev')
+            (either 'E', 'B', 'J', 'rho_next', 'rho_prev’, ‘A’)
         """
         # Use the appropriate transformation depending on the fieldtype.
         if fieldtype == 'E' :
@@ -374,6 +379,11 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.trans[m].spect2interp_scal(
                     self.spect[m].rho_prev, self.interp[m].rho )
+        elif fieldtype == 'A' :
+            # Transform each azimuthal grid individually
+            for m in range(self.Nm) :
+                self.trans[m].spect2interp_scal(
+                    self.spect[m].A, self.interp[m].A )
         else :
             raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
 
@@ -394,7 +404,7 @@ class Fields(object) :
         ---------
         fieldtype :
             A string which represents the kind of field to transform
-            (either 'E', 'B', 'J', 'rho_next', 'rho_prev')
+            (either 'E', 'B', 'J', 'rho_next', 'rho_prev’, ‘A’)
         """
         # Use the appropriate transformation depending on the fieldtype.
         if fieldtype == 'E' :
@@ -429,6 +439,10 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.trans[m].fft.inverse_transform(
                     self.spect[m].rho_prev, self.interp[m].rho )
+        elif fieldtype == 'A' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].A, self.interp[m].A )
         else :
             raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
 
@@ -446,7 +460,7 @@ class Fields(object) :
         ---------
         fieldtype :
             A string which represents the kind of field to transform
-            (either 'E', 'B', 'J', 'rho_next', 'rho_prev')
+            (either 'E', 'B', 'J', 'rho_next', 'rho_prev’, ‘A’)
         """
         # Use the appropriate transformation depending on the fieldtype.
         if fieldtype == 'E' :
@@ -481,6 +495,10 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.trans[m].fft.transform(
                     self.interp[m].rho, self.spect[m].rho_prev )
+        elif fieldtype == 'A' :
+            for m in range(self.Nm) :
+                self.trans[m].fft.transform(
+                    self.interp[m].A, self.spect[m].A )
         else :
             raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
 
@@ -496,7 +514,7 @@ class Fields(object) :
         ---------
         fieldtype : string
             A string which represents the kind of field to be erased
-            (either 'E', 'B', 'J', 'rho')
+            (either 'E', 'B', 'J', 'rho' or ‘A’)
         """
         # Erase the fields in the interpolation grid
         for m in range(self.Nm):
@@ -549,7 +567,7 @@ class Fields(object) :
         ---------
         fieldtype : string
             A string which represents the kind of field to be filtered
-            (either 'E', 'B', 'J', 'rho_next' or 'rho_prev')
+            (either 'E', 'B', 'J', 'rho_next’, ‘rho_prev' or ‘A’)
         """
         for m in range(self.Nm) :
             self.spect[m].filter( fieldtype )

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -646,7 +646,7 @@ class Fields(object) :
         
         """
         if m >= self.Nm :
-            mode = m - 2*Nm + 1
+            mode = m - 2*self.Nm + 1
         else:
             mode = m
         return mode

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -246,6 +246,13 @@ class Fields(object) :
         # corresponding psatd coefficients
         for m in range(self.Nm) :
             self.spect[m].push_eb_with( self.psatd[m], use_true_rho )
+
+            # Placeholder for determining if one should use the envelope model
+            use_envelope_model_bool = True
+            if (use_envelope_model_bool):
+                self.spect[m].push_envelope_with(self.psatd[m])
+
+
             self.spect[m].push_rho()
 
     def correct_currents(self, check_exchanges=False) :
@@ -330,6 +337,8 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.trans[m].interp2spect_scal(
                     self.interp[m].A, self.spect[m].A )
+                self.trans[m].interp2spect_scal(
+                    self.interp[m].dtA, self.spect[m].dtA )
         else:
             raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
 
@@ -384,6 +393,8 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.trans[m].spect2interp_scal(
                     self.spect[m].A, self.interp[m].A )
+                self.trans[m].spect2interp_scal(
+                    self.spect[m].dtA, self.interp[m].dtA )
         else :
             raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
 
@@ -443,6 +454,8 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.trans[m].fft.inverse_transform(
                     self.spect[m].A, self.interp[m].A )
+                self.trans[m].fft.inverse_transform(
+                    self.spect[m].dtA, self.interp[m].dtA )
         else :
             raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
 
@@ -499,6 +512,8 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.trans[m].fft.transform(
                     self.interp[m].A, self.spect[m].A )
+                self.trans[m].fft.transform(
+                    self.interp[m].dtA, self.spect[m].dtA )
         else :
             raise ValueError( 'Invalid string for fieldtype: %s' %fieldtype )
 

--- a/fbpic/fields/interpolation_grid.py
+++ b/fbpic/fields/interpolation_grid.py
@@ -70,18 +70,6 @@ class InterpolationGrid(object) :
         # Note: No Verboncoeur-type correction required
         self.invvol = 1./vol
 
-        # Allocate the fields arrays
-        self.Er = np.zeros( (Nz, Nr), dtype='complex' )
-        self.Et = np.zeros( (Nz, Nr), dtype='complex' )
-        self.Ez = np.zeros( (Nz, Nr), dtype='complex' )
-        self.Br = np.zeros( (Nz, Nr), dtype='complex' )
-        self.Bt = np.zeros( (Nz, Nr), dtype='complex' )
-        self.Bz = np.zeros( (Nz, Nr), dtype='complex' )
-        self.Jr = np.zeros( (Nz, Nr), dtype='complex' )
-        self.Jt = np.zeros( (Nz, Nr), dtype='complex' )
-        self.Jz = np.zeros( (Nz, Nr), dtype='complex' )
-        self.rho = np.zeros( (Nz, Nr), dtype='complex' )
-
         # Check whether the GPU should be used
         self.use_cuda = use_cuda
 
@@ -99,6 +87,29 @@ class InterpolationGrid(object) :
         """Returns the 1d array of r, when the user queries self.r"""
         return( self.rmin + (0.5+np.arange(self.Nr))*self.dr )
 
+   
+                
+                
+                
+class FieldInterpolationGrid(InterpolationGrid):
+    
+    
+    def __init__(self, Nz, Nr, m, zmin, zmax, rmax, use_cuda=False ) :
+        
+        InterpolationGrid.__init__(self, Nz, Nr, m, zmin, zmax, rmax, use_cuda=False)
+        
+        # Allocate the fields arrays
+        self.Er = np.zeros( (Nz, Nr), dtype='complex' )
+        self.Et = np.zeros( (Nz, Nr), dtype='complex' )
+        self.Ez = np.zeros( (Nz, Nr), dtype='complex' )
+        self.Br = np.zeros( (Nz, Nr), dtype='complex' )
+        self.Bt = np.zeros( (Nz, Nr), dtype='complex' )
+        self.Bz = np.zeros( (Nz, Nr), dtype='complex' )
+        self.Jr = np.zeros( (Nz, Nr), dtype='complex' )
+        self.Jt = np.zeros( (Nz, Nr), dtype='complex' )
+        self.Jz = np.zeros( (Nz, Nr), dtype='complex' )
+        self.rho = np.zeros( (Nz, Nr), dtype='complex' )
+        
     def send_fields_to_gpu( self ):
         """
         Copy the fields to the GPU.
@@ -218,3 +229,24 @@ class InterpolationGrid(object) :
                 self.Jz *= self.invvol[np.newaxis,:]
             else:
                 raise ValueError('Invalid string for fieldtype: %s'%fieldtype)
+    
+    
+    
+class EnvelopeInterpolationGrid(InterpolationGrid):
+    
+    def __init__(self, Nz, Nr, m, zmin, zmax, rmax, use_cuda=False ) :
+        
+        InterpolationGrid.__init__(self, Nz, Nr, m, zmin, zmax, rmax, use_cuda=False)
+        
+        # Allocate the fields arrays
+        self.A = np.zeros( (Nz, Nr), dtype='complex' )
+        self.dtA = np.zeros( (Nz, Nr), dtype='complex' )
+    
+    def erase(self):
+        """
+        Sets the envelope fields A and dtA to zero on the interpolation grid
+
+        """
+        
+        self.A[:,:] = 0.
+        self.dtA[:,:] = 0.

--- a/fbpic/fields/numba_methods.py
+++ b/fbpic/fields/numba_methods.py
@@ -74,7 +74,7 @@ def numba_correct_currents_crossdeposition_standard( rho_prev, rho_next,
 
 @njit_parallel
 def numba_push_eb_standard( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
-                       rho_prev, rho_next,
+                       rho_prev, rho_next, A, dtA,
                        rho_prev_coef, rho_next_coef, j_coef,
                        C, S_w, kr, kz, dt,
                        use_true_rho, Nz, Nr) :
@@ -138,6 +138,27 @@ def numba_push_eb_standard( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                             + 1.j*kr[iz, ir]*Em_old ) \
                 + j_coef[iz, ir]*( 1.j*kr[iz, ir]*Jp[iz, ir] \
                             + 1.j*kr[iz, ir]*Jm[iz, ir] )
+
+            w1 = 2*c*np.pi/ (0.8e-6) 
+            w2 = c*np.sqrt(kr[iz, ir]**2 + kz[iz, ir]**2)
+            w3 = np.sqrt(w1**2 + w2**2)
+            invw3 = np.where(w3 == 0, 1, 1./w3)
+            SA, CA= np.sin(w3*dt), np.cos(w3*dt)
+            S2 = 1j * w1 * invw3 * SA
+            Exp = np.exp(1j * w1 * dt) 
+            
+            oldA = A[iz, ir]
+            A[iz, ir] = (invw3 * SA * dtA[iz,ir] \
+                   + (CA - S2) * A[iz, ir]) * Exp
+     
+            dtA[iz, ir] = Exp *( (CA + S2)*dtA[iz, ir]\
+                       + c * w2**2 * invw3 * SA * oldA ) 
+
+
+
+
+
+
 
     return
 

--- a/fbpic/fields/numba_methods.py
+++ b/fbpic/fields/numba_methods.py
@@ -146,8 +146,7 @@ def numba_push_eb_standard( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
 def numba_push_envelope_standard(A, dtA, w2_square, invw_tot, S_env, C_env,
                             sinc_env, A_coef, Nz, Nr):
                     
-    #print(Nz, Nr, A_coef, S_env[Nz//2, Nr//2], C_env[Nz//2, Nr//2], sinc_env[Nz//2, Nr//2], invw_tot[Nz//2, Nr//2])        
-    #print(w2_square[Nz//2, Nr//2])
+                    
     for iz in prange(Nz):
         for ir in range(Nr):
             A_old = A[iz, ir]
@@ -157,12 +156,6 @@ def numba_push_envelope_standard(A, dtA, w2_square, invw_tot, S_env, C_env,
             dtA[iz, ir] = A_coef * ( (C_env[iz, ir] + sinc_env[iz, ir]) * dtA[iz, ir] \
                         - w2_square[iz, ir] * invw_tot[iz, ir] * S_env[iz, ir] * A_old )
                         
-            #if (iz == Nz//2 and ir == Nr//2):
-                #print(A_old, A[iz, ir], A_coef * (invw_tot[iz, ir] * S_env[iz, ir] * dtA_old ), A_coef * (C_env[iz, ir] - sinc_env[iz, ir]) * A_old)
-                #print('')
-                #print(dtA_old, dtA[iz,ir], A_coef * (C_env[iz, ir] + sinc_env[iz, ir]) * dtA_old,
-                         #w2_square[iz, ir] * invw_tot[iz, ir] * S_env[iz, ir] * A_old * A_coef )
-                #print('')
     return
 
 

--- a/fbpic/fields/numba_methods.py
+++ b/fbpic/fields/numba_methods.py
@@ -154,7 +154,7 @@ def numba_push_envelope_standard(A, dtA, w2_square, invw_tot, S_env, C_env,
                     + (C_env[iz, ir] - sinc_env[iz, ir]) * A[iz, ir])
             dtA[iz, ir] = A_coef * ( (C_env[iz, ir] + sinc_env[iz, ir]) * dtA[iz, ir] \
                         - w2_square[iz, ir] * invw_tot[iz, ir] * S_env[iz, ir] * A_old )
-            print(A[iz, ir], dtA[iz, ir], dtA_old)
+            
                         
     return
 

--- a/fbpic/fields/numba_methods.py
+++ b/fbpic/fields/numba_methods.py
@@ -155,6 +155,7 @@ def numba_push_envelope_standard(A, dtA, w2_square, invw_tot, S_env, C_env,
                     + (C_env[iz, ir] - sinc_env[iz, ir]) * A[iz, ir])
             dtA[iz, ir] = A_coef * ( (C_env[iz, ir] + sinc_env[iz, ir]) * dtA[iz, ir] \
                         - w2_square[iz, ir] * invw_tot[iz, ir] * S_env[iz, ir] * A_old )
+            print(A[iz, ir], dtA[iz, ir], dtA_old)
                         
     return
 

--- a/fbpic/fields/psatd_coefs.py
+++ b/fbpic/fields/psatd_coefs.py
@@ -159,6 +159,15 @@ class PsatdCoeffs(object) :
             self.rho_next_coef = c**2/epsilon_0*(xi_2)
         # Enforce the right value for w==0
         self.rho_next_coef[ w==0 ] = c**2/epsilon_0*(1./6*dt**2)
+        
+        # Calculate all necessary coefficients for propagation of A field
+        w_laser = 2*c*np.pi/ (0.8e-6)
+        self.w2_square = c**2*(kr**2 + kz**2 + 2 * kz * w_laser/c)
+        w_tot = np.sqrt(w_laser**2 + self.w2_square)
+        self.invw_tot = np.where(w_tot == 0, 1, 1./w_tot)
+        self.S_env, self.C_env = np.sin(w_tot*dt), np.cos(w_tot*dt)
+        self.sinc_env = 1j * w_laser * self.invw_tot * self.S_env
+        self.A_coef = np.exp(-1j * w_laser * dt)
 
         # Replace these array by arrays on the GPU, when using cuda
         if use_cuda:

--- a/fbpic/fields/spectral_grid.py
+++ b/fbpic/fields/spectral_grid.py
@@ -466,7 +466,8 @@ class EnvelopeSpectralGrid(SpectralGrid):
         
             numba_push_envelope_standard(self.A, self.dtA, ps.w2_square, ps.invw_tot, ps.S_env,
                 ps.C_env, ps.sinc_env, ps.A_coef, self.Nz, self.Nr)
-                
+
+
     def filter(self) :
         """
         Filter the envelope field

--- a/fbpic/lpa_utils/laser/direct_envelope_injection.py
+++ b/fbpic/lpa_utils/laser/direct_envelope_injection.py
@@ -1,0 +1,139 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines methods to directly inject the laser in the Simulation box
+"""
+import numpy as np
+from scipy.constants import c
+from fbpic.fields import Fields
+
+def add_laser_direct_envelope( sim, laser_profile, boost ):
+    """
+    Add a laser pulse envelope in the simulation, by directly replacing any other A field.
+
+    Note:
+    -----
+    Currently only Gaussian profile can be used
+    (which must provide the *transverse electric field*)
+
+    Parameters:
+    -----------
+    sim: a Simulation object
+        The structure that contains the simulation.
+
+    laser_profile: a valid gaussian laser profile object
+        Laser profiles can be imported from fbpic.lpa_utils.laser
+
+    boost: a BoostConverter object or None
+       Contains the information about the boost to be applied
+    """
+    print("Initializing laser pulse envelope on the mesh...")
+
+    # Get the local azimuthally-decomposed laser fields A and dtA on each proc
+    laser_A, laser_dtA = get_laser_A_dtA( sim, laser_profile, boost )
+    for m in range(sim.fld.Nm):
+        sim.fld.interp[m].A[:,:] = laser_A[:,:,m]
+        sim.fld.interp[m].dtA[:,:] = laser_dtA[:,:,m]
+
+    # Create a global field object across all subdomains, and copy the fields
+    # (Calculating the self-consistent Ez and B is a global operation)
+    global_Nz, _ = sim.comm.get_Nz_and_iz(
+                    local=False, with_damp=True, with_guard=False )
+    global_zmin, global_zmax = sim.comm.get_zmin_zmax(
+                    local=False, with_damp=True, with_guard=False )
+    global_fld = Fields( global_Nz, global_zmax,
+            sim.fld.Nr, sim.fld.rmax, sim.fld.Nm, sim.fld.dt,
+            zmin=global_zmin, n_order=sim.fld.n_order, use_cuda=False)
+    # Gather the fields of the interpolation grid
+    for m in range(sim.fld.Nm):
+        for field in ['A', 'dtA']:
+            local_array = getattr( sim.fld.interp[m], field )
+            gathered_array = sim.comm.gather_grid_array(
+                                local_array, with_damp=True)
+            setattr( global_fld.interp[m], field, gathered_array )
+
+
+    # Communicate the results from proc 0 to the other procs
+    # and add it to the interpolation grid of sim.fld.
+    # - First find the indices at which the fields should be added
+    Nz_local, iz_start_local_domain = sim.comm.get_Nz_and_iz(
+        local=True, with_damp=True, with_guard=False, rank=sim.comm.rank )
+    _, iz_start_local_array = sim.comm.get_Nz_and_iz(
+        local=True, with_damp=True, with_guard=True, rank=sim.comm.rank )
+    iz_in_array = iz_start_local_domain - iz_start_local_array
+    # - Then loop over modes and fields
+    for m in range(sim.fld.Nm):
+        for field in ['A', 'dtA']:
+            # Get the local result from proc 0
+            global_array = getattr( global_fld.interp[m], field )
+            local_array = sim.comm.scatter_grid_array(
+                                    global_array, with_damp=True)
+            # Add it to the fields of sim.fld
+            local_field = getattr( sim.fld.interp[m], field )
+            local_field[ iz_in_array:iz_in_array+Nz_local, : ] += local_array
+
+    print("Done.\n")
+
+
+def get_laser_A_dtA( sim, laser_profile, boost ):
+    """
+    Calculate the laser A and dtA envelope fields on the points of the interpolation
+    grid of sim, and decompose into azimuthal modes.
+
+    Parameters:
+    -----------
+    sim: a Simulation object
+        The structure that contains the simulation.
+
+    boost: a BoostConverter object or None
+       Contains the information about the boost to be applied
+
+    Returns:
+    --------
+    A_m, dtA_m: 3d_arrays of complexs
+        Arrays of size (Nz, Nr, 2*Nm), that represent the
+        azimuthally-decomposed envelope fields of the laser. The first Nm points
+        along the last axis correspond to the values in the modes m>= 0.
+    """
+    # Initialize a grid on which the laser amplitude should be calculated
+    # - Get the 1d arrays of the grid
+    z = sim.fld.interp[0].z
+    r = sim.fld.interp[0].r
+    # - Sample the field at 2*Nm values of theta, in order to
+    #   perform the azimuthal decomposition of the fields
+    ntheta = 2*sim.fld.Nm
+    theta = (2*np.pi/ntheta) * np.arange( ntheta )
+    # - Get corresponding 3d arrays
+    z_3d, r_3d, theta_3d = np.meshgrid( z, r, theta, indexing='ij' )
+    cos_theta_3d = np.cos(theta_3d)
+    sin_theta_3d = np.sin(theta_3d)
+    x_3d = r_3d * cos_theta_3d
+    y_3d = r_3d * sin_theta_3d
+    
+
+    # For boosted-frame: convert time and position to the lab-frame
+    if boost is not None:
+        zlab_3d = boost.gamma0*( z_3d + boost.beta0 * c * sim.time )
+        tlab = boost.gamma0*( sim.time + (boost.beta0 * 1./c) * z_3d )
+    else:
+        zlab_3d = z_3d
+        tlab = sim.time
+
+    # Evaluate the scalar A and dtA fields in these positions
+    A_3d, dtA_3d = laser_profile.A_field( x_3d, y_3d, zlab_3d, tlab )
+
+    # For boosted-frame: scale the lab-frame value of the fields to
+    # the corresponding boosted-frame value
+    if boost is not None:
+        scale_factor = 1./( boost.gamma0*(1+boost.beta0) )
+        A_3d *= scale_factor
+        dtA_3d *= scale_factor
+
+    # Perform the azimuthal decomposition of the Er and Et fields
+    # and add them to the mesh
+    A_m_3d = np.fft.ifft(A_3d, axis=-1)
+    dtA_m_3d = np.fft.ifft(dtA_3d, axis=-1)
+
+    return( A_m_3d, dtA_m_3d )

--- a/fbpic/lpa_utils/laser/direct_envelope_injection.py
+++ b/fbpic/lpa_utils/laser/direct_envelope_injection.py
@@ -30,6 +30,11 @@ def add_laser_direct_envelope( sim, laser_profile, boost ):
        Contains the information about the boost to be applied
     """
     print("Initializing laser pulse envelope on the mesh...")
+    
+    # Check that no other laser simulation has been already added
+    if sim.fld.use_envelope:
+        raise ValueError("Another laser profile has already been added")
+    sim.fld.activate_envelope_model(laser_profile.k0)
 
     # Get the local azimuthally-decomposed laser fields A and dtA on each proc
     laser_A, laser_dtA = get_laser_A_dtA( sim, laser_profile, boost )
@@ -46,6 +51,7 @@ def add_laser_direct_envelope( sim, laser_profile, boost ):
     global_fld = Fields( global_Nz, global_zmax,
             sim.fld.Nr, sim.fld.rmax, sim.fld.Nm, sim.fld.dt,
             zmin=global_zmin, n_order=sim.fld.n_order, use_cuda=False)
+    global_fld.activate_envelope_model(laser_profile.k0)
     # Gather the fields of the interpolation grid
     for m in range(2*sim.fld.Nm-1):
         for field in ['A', 'dtA']:

--- a/fbpic/lpa_utils/laser/laser.py
+++ b/fbpic/lpa_utils/laser/laser.py
@@ -10,6 +10,7 @@ from fbpic.lpa_utils.boosted_frame import BoostConverter
 from .laser_profiles import GaussianLaser
 from .direct_injection import add_laser_direct
 from .antenna_injection import LaserAntenna
+from .direct_envelope_injection import add_laser_direct_envelope
 
 def add_laser_pulse( sim, laser_profile, gamma_boost=None,
                     method='direct', z0_antenna=None, fw_propagating=True ):
@@ -18,7 +19,8 @@ def add_laser_pulse( sim, laser_profile, gamma_boost=None,
 
     The laser is either added directly to the interpolation grid initially
     (method= ``direct``) or it is progressively emitted by an antenna
-    (method= ``antenna``).
+    (method= ``antenna``) or its envelope is added to the interpolation grid
+    A fields (method= ''direct_envelope'')
 
     Parameters
     ----------
@@ -83,6 +85,10 @@ def add_laser_pulse( sim, laser_profile, gamma_boost=None,
         Nm = sim.fld.Nm
         sim.laser_antennas.append(
             LaserAntenna( laser_profile, z0_antenna, dr, Nr, Nm, boost ))
+            
+    elif method == 'direct_envelope':
+        
+        add_laser_direct_envelope(sim, laser_profile, boost)
 
     else:
         raise ValueError('Unknown laser method: %s' %method)

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -248,12 +248,12 @@ class GaussianLaser( LaserProfile ):
         # Calculate the argument of the complex exponential
         exp_argument = -1j*self.cep_phase  \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - 1./stretch_factor * self.inv_ctau2 * ( c*t  + self.z0 - z )**2
+            - 1./stretch_factor * self.inv_ctau2 * ( z - self.z0 - c*t)**2
         # Get the transverse profile
         profile = np.exp(exp_argument) / ( diffract_factor * stretch_factor**0.5 )
         
         A = self.a0 * profile
-        dtA = - self.a0 * 1./stretch_factor * self.inv_ctau2 * c * ( c*t + self.z0 - z) * profile
+        dtA = self.a0 * 1./stretch_factor * self.inv_ctau2 * c * ( z - self.z0 - c*t)) * profile
         
         return A, dtA 
         

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -337,6 +337,7 @@ class Simulation(object):
         self.comm.damp_EB_open_boundary( fld.interp )
         fld.interp2spect('E')
         fld.interp2spect('B')
+        fld.interp2spect('A')
 
         # Beginning of the N iterations
         # -----------------------------
@@ -466,14 +467,17 @@ class Simulation(object):
             # are updated by doing an iFFT/FFT instead of a full transform)
             fld.spect2partial_interp('E')
             fld.spect2partial_interp('B')
+            fld.spect2partial_interp('A')
             self.comm.exchange_fields(fld.interp, 'E', 'replace')
             self.comm.exchange_fields(fld.interp, 'B', 'replace')
             self.comm.damp_EB_open_boundary( fld.interp )
             fld.partial_interp2spect('E')
             fld.partial_interp2spect('B')
+            fld.partial_interp2spect('A')
             # Get the corresponding fields in interpolation space
             fld.spect2interp('E')
             fld.spect2interp('B')
+            fld.spect2interp('A')
 
             # Increment the global time and iteration
             self.time += dt

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -337,7 +337,8 @@ class Simulation(object):
         self.comm.damp_EB_open_boundary( fld.interp )
         fld.interp2spect('E')
         fld.interp2spect('B')
-        fld.interp2spect('A')
+        if (fld.use_envelope):
+            fld.interp2spect('A')
 
         # Beginning of the N iterations
         # -----------------------------
@@ -465,19 +466,20 @@ class Simulation(object):
             # spectral space and interpolation space
             # (Since exchange/damp operation is purely along z, spectral fields
             # are updated by doing an iFFT/FFT instead of a full transform)
+
             fld.spect2partial_interp('E')
             fld.spect2partial_interp('B')
-            fld.spect2partial_interp('A')
             self.comm.exchange_fields(fld.interp, 'E', 'replace')
             self.comm.exchange_fields(fld.interp, 'B', 'replace')
             self.comm.damp_EB_open_boundary( fld.interp )
             fld.partial_interp2spect('E')
             fld.partial_interp2spect('B')
-            fld.partial_interp2spect('A')
+
             # Get the corresponding fields in interpolation space
             fld.spect2interp('E')
             fld.spect2interp('B')
-            fld.spect2interp('A')
+            if (fld.use_envelope):
+                fld.spect2interp('A')
 
             # Increment the global time and iteration
             self.time += dt

--- a/tests/unautomated/test_laser_envelope.py
+++ b/tests/unautomated/test_laser_envelope.py
@@ -1,0 +1,457 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This test file is part of FB-PIC (Fourier-Bessel Particle-In-Cell).
+
+It tests the structures implemented in fields.py,
+by studying the propagation of a laser in vacuum:
+- The mode 0 is tested by using an annular, radial beam,
+   which propagates to the right.
+- The mode 1 is tested by using a linearly polarized beam,
+   which propagates to the right
+
+In both cases, the evolution of the a0 and w0 are compared
+with theoretical results from diffraction theory.
+
+These tests are performed in 3 cases:
+- Periodic box : in this case, a very large timestep is taken,
+  so as to test the absence of a Courant condition
+- Moving window : in this case, the timestep has to be reduced,
+  in order to leave time for the moving window to shift/damp the fields
+- In a galilean frame : in this case again, large timestep can be taken
+
+Usage :
+-------
+In order to show the images of the laser, and manually check the
+agreement between the simulation and the theory:
+$ python tests/test_laser.py
+(except when setting show to False in the parameters below)
+
+In order to let Python check the agreement between the curve without
+having to look at the plots
+$ py.test -q tests/test_fields.py
+or
+$ python setup.py test
+"""
+import numpy as np
+from scipy.constants import c, m_e, e
+from scipy.optimize import curve_fit
+from fbpic.main import Simulation
+from fbpic.lpa_utils.laser import add_laser_pulse, \
+    GaussianLaser, LaguerreGaussLaser
+
+# Parameters
+# ----------
+# (See the documentation of the function propagate_pulse
+# below for their definition)
+show = True  # Whether to show the plots, and check them manually
+
+use_cuda = False
+
+# Simulation box
+Nz = 400
+zmin = -10.e-6
+zmax = 10.e-6
+Nr = 25
+Lr = 40.e-6
+Nm = 2
+n_order = -1
+# Laser pulse
+w0 = 4.e-6
+ctau = 5.e-6
+k0 = 2*np.pi/0.8e-6
+E0 = 1.
+# Propagation
+L_prop = 30.e-6
+zf = 25.e-6
+N_diag = 10   # Number of diagnostic points along the propagation
+# Checking the results
+N_show = 2
+rtol = 1.e-4
+
+def test_laser_periodic(show=False):
+    """
+    Function that is run by py.test, when doing `python setup.py test`
+    Test the propagation of a laser in a periodic box.
+    """
+    # Choose a very long timestep to check the absence of Courant limit
+    dt = L_prop*1./c/N_diag
+    print('dt = %d', dt)
+    # Test modes up to m=2
+    for m in range(1):
+
+        print('')
+        print('Testing mode m=%d' %m)
+        propagate_pulse( Nz, Nr, m+1, zmin, zmax, Lr, L_prop, zf, dt,
+                          N_diag, w0, ctau, k0, E0, m, N_show, n_order,
+                          rtol, boundaries='periodic', v_window=0, show=show )
+
+    print('')
+
+def test_laser_moving_window(show=False):
+    """
+    Function that is run by py.test, when doing `python setup.py test`
+    Test the propagation of a laser in a moving window
+    """
+    # Choose the regular timestep (required by moving window)
+    dt = (zmax-zmin)*1./c/Nz
+
+    # Test modes up to m=2
+    for m in range(3):
+
+        print('')
+        print('Testing mode m=%d' %m)
+        propagate_pulse( Nz, Nr, m+1, zmin, zmax, Lr, L_prop, zf, dt,
+                          N_diag, w0, ctau, k0, E0, m, N_show, n_order,
+                          rtol, boundaries='open', v_window=c, show=show )
+
+    print('')
+
+def test_laser_galilean(show=False):
+    """
+    Function that is run by py.test, when doing `python setup.py test`
+    Test the propagation of a laser with a galilean change of frame
+    """
+    # Choose the regular timestep (required by moving window)
+    dt = L_prop*1./c/N_diag
+
+    # Test modes up to m=2
+    for m in range(3):
+
+        print('')
+        print('Testing mode m=%d' %m)
+        propagate_pulse( Nz, Nr, m+1, zmin, zmax, Lr, L_prop, zf, dt,
+                      N_diag, w0, ctau, k0, E0, m, N_show, n_order,
+                      rtol, boundaries='open',
+                      use_galilean=True, v_comoving=0.999*c, show=show )
+
+    print('')
+
+def propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
+        N_diag, w0, ctau, k0, E0, m, N_show, n_order, rtol,
+        boundaries, v_window=0, use_galilean=False, v_comoving=0, show=False ):
+    """
+    Propagate the beam over a distance L_prop in Nt steps,
+    and extracts the waist and a0 at each step.
+
+    Parameters
+    ----------
+    show : bool
+       Wether to show the fields, so that the user can manually check
+       the agreement with the theory.
+       If True, this will periodically show the map of the fields (with
+       a period N_show), as well as (eventually) the evoluation of a0 and w0.
+       If False, this
+
+    N_diag : int
+       Number of diagnostic points (i.e. measure of waist and a0)
+       along the propagation
+
+    Nz, Nr : int
+       The number of points on the grid in z and r respectively
+
+    Nm : int
+        The number of modes in the azimuthal direction
+
+    zmin, zmax : float
+        The limits of the box in z
+
+    Lr : float
+       The size of the box in the r direction
+       (In the case of Lr, this is the distance from the *axis*
+       to the outer boundary)
+
+    L_prop : float
+       The total propagation distance (in meters)
+
+    zf : float
+       The position of the focal plane of the laser (only works for m=1)
+
+    dt : float
+       The timestep of the simulation
+
+    w0 : float
+       The initial waist of the laser (in meters)
+
+    ctau : float
+       The initial temporal waist of the laser (in meters)
+
+    k0 : flat
+       The central wavevector of the laser (in meters^-1)
+
+    E0 : float
+       The initial E0 of the pulse
+
+    m : int
+       Index of the mode to be tested
+       For m = 1 : test with a gaussian, linearly polarized beam
+       For m = 0 : test with an annular beam, polarized in E_theta
+
+    n_order : int
+       Order of the stencil
+
+    rtol : float
+       Relative precision with which the results are tested
+
+    boundaries : string
+        Type of boundary condition
+        Either 'open' or 'periodic'
+
+    v_window : float
+        Speed of the moving window
+
+    v_comoving : float
+        Velocity at which the currents are assumed to move
+
+    use_galilean: bool
+        Whether to use a galilean frame that moves at the speed v_comoving
+
+    Returns
+    -------
+    A dictionary containing :
+    - 'E' : 1d array containing the values of the amplitude
+    - 'w' : 1d array containing the values of waist
+    - 'fld' : the Fields object at the end of the simulation.
+    """
+
+    # Initialize the simulation object
+    sim = Simulation( Nz, zmax, Nr, Lr, Nm, dt, p_zmin=0, p_zmax=0,
+                    p_rmin=0, p_rmax=0, p_nz=2, p_nr=2, p_nt=2, n_e=0.,
+                    n_order=n_order, zmin=zmin, use_cuda=use_cuda,
+                    boundaries=boundaries, v_comoving=v_comoving,
+                    exchange_period = 1, use_galilean=use_galilean )
+    # Remove the particles
+    sim.ptcl = []
+    # Set the moving window object
+    if v_window !=0:
+        sim.set_moving_window( v=v_window )
+
+    # Initialize the laser fields
+    z0 = (zmax+zmin)/2
+    init_fields( sim, w0, ctau, k0, z0, zf, E0, m )
+
+    # Create the arrays to get the waist and amplitude
+    w = np.zeros(N_diag)
+    A = np.zeros(N_diag)
+
+    # Calculate the number of steps to run between each diagnostic
+    Ntot_step = int( round( L_prop/(c*dt) ) )
+    N_step = int( round( Ntot_step/N_diag ) )
+
+    # Loop over the iterations
+    print('Running the simulation...')
+    for it in range(N_diag) :
+        print( 'Diagnostic point %d/%d' %(it, N_diag) )
+        # Fit the fields to find the waist and a0
+        w[it], A[it] = fit_fields( sim.fld, m )
+        # Plot the fields during the simulation
+        if show==True and it%N_show == 0 :
+            import matplotlib.pyplot as plt
+            plt.clf()
+            plt.plot(sim.fld.interp[m].r,  (abs( sim.fld.interp[m].A )**2).sum(axis=0))
+            plt.show()
+        # Advance the Maxwell equations
+        sim.step( N_step, show_progress= False )
+
+    # Get the analytical solution
+    z_prop = c*dt*N_step*np.arange(N_diag)
+    ZR = 0.5*k0*w0**2
+    w_analytic = w0*np.sqrt( 1 + (z_prop-zf)**2/ZR**2 )
+    A_analytic = E0*e/(m_e*c**2*k0)/( 1 + (z_prop-zf)**2/ZR**2 )**(1./2)
+
+    # Either plot the results and check them manually
+    if show is True:
+        import matplotlib.pyplot as plt
+        plt.suptitle('Diffraction of a pulse in the mode %d' %m)
+        plt.subplot(121)
+        plt.plot( 1.e6*z_prop, 1.e6*w, 'o', label='Simulation' )
+        plt.plot( 1.e6*z_prop, 1.e6*w_analytic, '--', label='Theory' )
+        plt.xlabel('z (microns)')
+        plt.ylabel('w (microns)')
+        plt.title('Waist')
+        plt.legend(loc=0)
+        plt.subplot(122)
+        plt.plot( 1.e6*z_prop, A, 'o', label='Simulation' )
+        plt.plot( 1.e6*z_prop, A_analytic, '--', label='Theory' )
+        plt.xlabel('z (microns)')
+        plt.ylabel('E')
+        plt.legend(loc=0)
+        plt.title('Amplitude')
+        plt.show()
+    # or automatically check that the theoretical and simulated curves
+    # of w and E are close
+    else:
+        assert np.allclose( w, w_analytic, rtol=rtol )
+        assert np.allclose( A, A_analytic, rtol=5.e-3 )
+        print('The simulation results agree with the theory to %e.' %rtol)
+
+    # Return a dictionary of the results
+    return( { 'A' : A, 'w' : w, 'fld' : sim.fld } )
+
+
+def init_fields( sim, w, ctau, k0, z0, zf, E0, m=1 ) :
+    """
+    Imprints the appropriate profile on the fields of the simulation.
+
+    Parameters
+    ----------
+    sim: Simulation object from fbpic
+
+    w : float
+       The initial waist of the laser (in microns)
+
+    ctau : float
+       The initial temporal waist of the laser (in microns)
+
+    k0 : flat
+       The central wavevector of the laser (in microns^-1)
+
+    z0 : float
+       The position of the centroid on the z axis
+
+    zf : float
+       The position of the focal plane
+
+    E0 : float
+       The initial E0 of the pulse
+
+    m: int, optional
+        The mode on which to imprint the profile
+        For m = 1 : gaussian profile, linearly polarized beam
+        For m = 0 : annular profile, polarized in E_theta
+    """
+    # Initialize the fields
+    a0 = E0*e/(m_e*c**2*k0)
+    tau = ctau/c
+    lambda0 = 2*np.pi/k0
+    # Create the relevant laser profile
+
+    if m == 0:
+        profile = GaussianLaser( a0=a0, waist=w, tau=tau,
+                    lambda0=lambda0, z0=z0, zf=zf )
+   
+    # Add the profiles to the simulation
+    add_laser_pulse( sim, profile, method = 'direct_envelope' )
+
+def gaussian_transverse_profile( r, w, E ) :
+    """
+    Calculte the Gaussian transverse profile.
+
+    This is used for the fit of the fields
+
+    Parameters
+    ----------
+    r: 1darray
+       Represents the positions of the grid in r
+
+    w : float
+       The initial waist of the laser (in microns)
+
+    E : float
+       The a0 of the pulse
+    """
+    return( E*np.exp( -r**2/w**2 ) )
+
+def annular_transverse_profile( r, w, E ) :
+    """
+    Calculte the annular transverse profile.
+
+    This is used both for the initialization and
+    for the fit of the fields
+
+    Parameters
+    ----------
+    r: 1darray
+       Represents the positions of the grid in r
+
+    w : float
+       The initial waist of the laser (in microns)
+
+    E : float
+       The E0 of the pulse
+    """
+    return( E*(r/w)*np.exp( -r**2/w**2 ) )
+
+def annular_pulse( z, r, w0, ctau, k0, z0, E0 ) :
+    """
+    Calculate the profile of an annular beam.
+    This is used to initialize the beam
+
+    Parameters
+    ----------
+    z: 1darray
+       Represents the positions of the grid in z
+
+    r: 1darray
+       Represents the positions of the grid in r
+
+    w0 : float
+       The initial waist of the laser (in microns)
+
+    ctau : float
+       The initial temporal waist of the laser (in microns)
+
+    k0 : flat
+       The central wavevector of the laser (in microns^-1)
+
+    z0 : float
+       The position of the centroid on the z axis
+
+    E0 : float
+       The initial E0 of the pulse
+
+    Return
+    ------
+       A 2d array with z as the first axis and r as the second axis,
+       which contains the values of the
+
+    """
+    longitudinal = np.exp( -(z-z0)**2/ctau**2 )*np.cos(k0*(z-z0))
+    transverse = annular_transverse_profile( r, w0, E0 )
+    profile = longitudinal[:,np.newaxis]*transverse[np.newaxis,:]
+
+    return(profile)
+
+
+def fit_fields( fld, m ) :
+    """
+    Extracts the waist and a0 of the pulse through a transverse Gaussian fit.
+
+    The laser oscillations are first averaged longitudinally.
+
+    Parameters
+    ----------
+    fld : Fields object from fbpic
+
+    m : int, optional
+       The index of the mode to be fitted
+    """
+    # Integrate the laser oscillations longitudinally
+    dz = fld.interp[0].dz
+    laser_profile = np.sqrt(dz*(abs( fld.interp[m].A )**2).sum(axis=0)) 
+    # Renormalize so that this gives the peak of the Gaussian
+    laser_profile *= 2.**(-3./4)/( np.pi**(1./4) * ctau**(1./2) )
+
+    # Do the fit
+    r = fld.interp[m].r
+    if m==0 :  # Gaussian profile
+        fit_result = curve_fit(gaussian_transverse_profile, r,
+                            laser_profile, p0=np.array([w0,E0]) )
+    else: # Annular profile, or Laguerre-Gaussian profile
+        fit_result = curve_fit(annular_transverse_profile, r,
+                            laser_profile, p0=np.array([w0,E0]) )
+    if m > 0:
+        # Factor 2 on the amplitude, related to the factor 2
+        # in the particle gather for the modes m > 0
+        fit_result[0][1] = 2*fit_result[0][1]
+    return( fit_result[0] )
+
+if __name__ == '__main__' :
+
+    # Run the testing function
+    test_laser_periodic(show=show)
+
+    #test_laser_moving_window(show=show)
+
+    #test_laser_galilean(show=show)

--- a/tests/unautomated/test_laser_envelope.py
+++ b/tests/unautomated/test_laser_envelope.py
@@ -6,10 +6,9 @@ This test file is part of FB-PIC (Fourier-Bessel Particle-In-Cell).
 
 It tests the structures implemented in fields.py,
 by studying the propagation of a laser in vacuum:
-- The mode 0 is tested by using an annular, radial beam,
+- The mode 0 is tested by using a linearly polarized gaussian beam,
    which propagates to the right.
-- The mode 1 is tested by using a linearly polarized beam,
-   which propagates to the right
+- The mode 1 is tested by ????
 
 In both cases, the evolution of the a0 and w0 are compared
 with theoretical results from diffraction theory.
@@ -21,6 +20,8 @@ These tests are performed in 3 cases:
   in order to leave time for the moving window to shift/damp the fields
 - In a galilean frame : in this case again, large timestep can be taken
 
+WARNING: Only Periodic box for mode 0 test is implemented for now
+
 Usage :
 -------
 In order to show the images of the laser, and manually check the
@@ -28,11 +29,6 @@ agreement between the simulation and the theory:
 $ python tests/test_laser.py
 (except when setting show to False in the parameters below)
 
-In order to let Python check the agreement between the curve without
-having to look at the plots
-$ py.test -q tests/test_fields.py
-or
-$ python setup.py test
 """
 import numpy as np
 from scipy.constants import c, m_e, e
@@ -210,7 +206,7 @@ def propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
     Returns
     -------
     A dictionary containing :
-    - 'E' : 1d array containing the values of the amplitude
+    - 'A' : 1d array containing the values of the amplitude
     - 'w' : 1d array containing the values of waist
     - 'fld' : the Fields object at the end of the simulation.
     """
@@ -349,7 +345,7 @@ def gaussian_transverse_profile( r, w, E ) :
        The initial waist of the laser (in microns)
 
     E : float
-       The a0 of the pulse
+       The E0 of the pulse
     """
     return( E*np.exp( -r**2/w**2 ) )
 

--- a/tests/unautomated/test_laser_envelope.py
+++ b/tests/unautomated/test_laser_envelope.py
@@ -41,7 +41,7 @@ from fbpic.lpa_utils.laser import add_laser_pulse, \
 # ----------
 # (See the documentation of the function propagate_pulse
 # below for their definition)
-show = True  # Whether to show the plots, and check them manually
+show = False  # Whether to show the plots, and check them manually
 
 use_cuda = False
 
@@ -245,7 +245,7 @@ def propagate_pulse( Nz, Nr, Nm, zmin, zmax, Lr, L_prop, zf, dt,
         if show==True and it%N_show == 0 :
             import matplotlib.pyplot as plt
             plt.clf()
-            plt.plot(sim.fld.interp[m].r,  (abs( sim.fld.interp[m].A )**2).sum(axis=0))
+            plt.plot(sim.fld.envelope_interp[m].r,  (abs( sim.fld.envelope_interp[m].A )**2).sum(axis=0))
             plt.show()
         # Advance the Maxwell equations
         sim.step( N_step, show_progress= False )
@@ -425,7 +425,7 @@ def fit_fields( fld, m ) :
     """
     # Integrate the laser oscillations longitudinally
     dz = fld.interp[0].dz
-    laser_profile = np.sqrt(dz*(abs( fld.interp[m].A )**2).sum(axis=0)) 
+    laser_profile = np.sqrt(dz*(abs( fld.envelope_interp[m].A )**2).sum(axis=0)) 
     # Renormalize so that this gives the peak of the Gaussian
     laser_profile *= 2.**(-3./4)/( np.pi**(1./4) * ctau**(1./2) )
 

--- a/tests/unautomated/test_laser_envelope.py
+++ b/tests/unautomated/test_laser_envelope.py
@@ -35,13 +35,13 @@ from scipy.constants import c, m_e, e
 from scipy.optimize import curve_fit
 from fbpic.main import Simulation
 from fbpic.lpa_utils.laser import add_laser_pulse, \
-    GaussianLaser
+    GaussianLaser, LaguerreGaussLaser
 
 # Parameters
 # ----------
 # (See the documentation of the function propagate_pulse
 # below for their definition)
-show = True  # Whether to show the plots, and check them manually
+show = False # Whether to show the plots, and check them manually
 
 use_cuda = False
 
@@ -75,7 +75,7 @@ def test_laser_periodic(show=False):
     dt = L_prop*1./c/N_diag
     print('dt = %d', dt)
     # Test modes up to m=2
-    for m in range(1, 2):
+    for m in range( 2):
 
         print('')
         print('Testing mode m=%d' %m)
@@ -353,47 +353,6 @@ def annular_transverse_profile( r, w, E ) :
     """
     return( E*(r/w)*np.exp( -r**2/w**2 ) )
 
-def annular_pulse( z, r, w0, ctau, k0, z0, E0 ) :
-    """
-    Calculate the profile of an annular beam.
-    This is used to initialize the beam
-
-    Parameters
-    ----------
-    z: 1darray
-       Represents the positions of the grid in z
-
-    r: 1darray
-       Represents the positions of the grid in r
-
-    w0 : float
-       The initial waist of the laser (in microns)
-
-    ctau : float
-       The initial temporal waist of the laser (in microns)
-
-    k0 : flat
-       The central wavevector of the laser (in microns^-1)
-
-    z0 : float
-       The position of the centroid on the z axis
-
-    E0 : float
-       The initial E0 of the pulse
-
-    Return
-    ------
-       A 2d array with z as the first axis and r as the second axis,
-       which contains the values of the
-
-    """
-    longitudinal = np.exp( -(z-z0)**2/ctau**2 )*np.cos(k0*(z-z0))
-    transverse = annular_transverse_profile( r, w0, E0 )
-    profile = longitudinal[:,np.newaxis]*transverse[np.newaxis,:]
-
-    return(profile)
-
-
 def fit_fields( fld, m ) :
     """
     Extracts the waist and a0 of the pulse through a transverse Gaussian fit.
@@ -411,7 +370,6 @@ def fit_fields( fld, m ) :
     dz = fld.interp[0].dz
     laser_profile = np.sqrt(dz*(abs( fld.envelope_interp[m].A )**2).sum(axis=0)) 
     # Renormalize so that this gives the peak of the Gaussian
-    print(laser_profile)
     laser_profile *= 2.**(-3./4)/( np.pi**(1./4) * ctau**(1./2) )
 
     # Do the fit
@@ -425,7 +383,7 @@ def fit_fields( fld, m ) :
     if m > 0:
         # Factor 2 on the amplitude, related to the factor 2
         # in the particle gather for the modes m > 0
-        fit_result[0][1] = 2*fit_result[0][1]
+        fit_result[0][1] = fit_result[0][1]
     return( fit_result[0] )
 
 if __name__ == '__main__' :


### PR DESCRIPTION
This is a first draft for implementing an envelope model for the laser, which would allow for a lower resolution along the z axis.
In this PR we modified heavily fields.py and its dependencies to allow for the handling of the envelope of the laser. We thus store the A envelope field, as well as the dtA field (derivative in time) and we are able to push them forward in time. For this, as the envelope is inherently complex, we also need to compute the negative azimuthal modes and so we store 2Nm - 1 modes in total. In order to do this, the InterpolationGrid and SpectralGrid objects have each been separated in two variations, Envelope and Field which contains everything the old grids used to hold.

The simulation is for now capable of simulating the propagation of the A envelope field in a vacuum. New methods have also been created to initialize the field created by a Gaussian laser as an envelope A field rather than a standard E field. There is also a test file added allowing to test the propagation of the envelope in a vacuum, currently only for m = 0.

The following has not yet been implemented:
-Any interactions with the plasma
-MPI or GPU use 
-Comoving approach (Note: the envelope model as of now is not valid for high boosts)
-Handling moving windows
-Boundary conditions
-Any further tests