### PR TITLE
Have only MPI rank 0 print information on laser/beam initialization

### DIFF
--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -422,7 +422,8 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
         Can be either "forward" or "backward".
         Propagation direction of the beam.
     """
-    print("Calculating initial space charge field...")
+    if sim.comm.rank == 0:
+        print("Calculating initial space charge field...")
 
     # Calculate the mean gamma by summing on each subdomain
     gamma_sum_local = (1./ptcl.inv_gamma).sum()
@@ -498,7 +499,8 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
             local_field = getattr( sim.fld.interp[m], field )
             local_field[ iz_in_array:iz_in_array+Nz_local, : ] += local_array
 
-    print("Done.\n")
+    if sim.comm.rank == 0:
+        print("Done.\n")
 
 
 def get_space_charge_spect( spect, gamma, direction='forward' ) :

--- a/fbpic/lpa_utils/laser/direct_injection.py
+++ b/fbpic/lpa_utils/laser/direct_injection.py
@@ -37,7 +37,8 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
     boost: a BoostConverter object or None
        Contains the information about the boost to be applied
     """
-    print("Initializing laser pulse on the mesh...")
+    if sim.comm.rank == 0:
+        print("Initializing laser pulse on the mesh...")
 
     # Get the local azimuthally-decomposed laser fields Er and Et on each proc
     laser_Er, laser_Et = get_laser_Er_Et( sim, laser_profile, boost )
@@ -98,7 +99,8 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
             local_field = getattr( sim.fld.interp[m], field )
             local_field[ iz_in_array:iz_in_array+Nz_local, : ] += local_array
 
-    print("Done.\n")
+    if sim.comm.rank == 0:
+        print("Done.\n")
 
 
 def get_laser_Er_Et( sim, laser_profile, boost ):


### PR DESCRIPTION
It sometimes annoying/confusing that each MPI rank print 
```
Initializing laser pulse on the mesh...
Done.
```

This PR fixes the issue.