### PR TITLE
Fix bug in space charge initialization

### DIFF
--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -438,6 +438,8 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
     sim.fld.erase('J')
     ptcl.deposit( sim.fld, 'rho' )
     ptcl.deposit( sim.fld, 'J' )
+    sim.fld.sum_reduce_deposition_array('rho')
+    sim.fld.sum_reduce_deposition_array('J')
     sim.fld.divide_by_volume('rho')
     sim.fld.divide_by_volume('J')
     # Exchange guard cells


### PR DESCRIPTION
Pull request #234 introduced a bug in the initial space-charge calculation: the initial space-charge field is in practice 0 (because the `sum_reduce` is not performed anymore after depositing the charge from the electron bunch).

This PR fixes this issue (by adding the `sum_reduce` in the space charge calculation routines).
In addition, it adds a more specific tests, so that a similar error will be caught in the future.

(The previous tests only compared the fields between serial and parallel simulation, but did not compare it to the theory.)