### PR TITLE
Close #253 Implement donut-like Laguerre-Gauss modes

### DIFF
--- a/docs/source/api_reference/lpa_utilities/laser.rst
+++ b/docs/source/api_reference/lpa_utilities/laser.rst
@@ -56,6 +56,7 @@ own custom laser profiles.
 
     laser_profiles/gaussian
     laser_profiles/laguerre
+    laser_profiles/donut_laguerre
     laser_profiles/flattened
 
 Combining (summing) laser profiles

--- a/docs/source/api_reference/lpa_utilities/laser_profiles/donut_laguerre.rst
+++ b/docs/source/api_reference/lpa_utilities/laser_profiles/donut_laguerre.rst
@@ -1,0 +1,4 @@
+Donut-like Laguerre-Gauss profile
+*********************************
+
+.. autoclass:: fbpic.lpa_utils.laser.DonutLikeLaguerreGaussLaser

--- a/fbpic/lpa_utils/laser/__init__.py
+++ b/fbpic/lpa_utils/laser/__init__.py
@@ -4,7 +4,8 @@ It imports functions which are useful when initializing a laser pulse
 """
 from .laser import add_laser, add_laser_pulse
 from .laser_profiles import GaussianLaser, LaguerreGaussLaser, \
-                            FlattenedGaussianLaser
+              DonutLikeLaguerreGaussLaser, FlattenedGaussianLaser
 
 __all__ = ['add_laser', 'add_laser_pulse',
-            'GaussianLaser', 'LaguerreGaussLaser', 'FlattenedGaussianLaser']
+            'GaussianLaser', 'LaguerreGaussLaser', 
+            'DonutLikeLaguerreGaussLaser', 'FlattenedGaussianLaser']

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -186,19 +186,7 @@ class GaussianLaser( LaserProfile ):
 
     def E_field( self, x, y, z, t ):
         """
-        Return the electric field of the laser
-
-        Parameters
-        ----------
-        x, y, z: ndarrays (meters)
-            The positions at which to calculate the profile (in the lab frame)
-        t: ndarray or float (seconds)
-            The time at which to calculate the profile (in the lab frame)
-
-        Returns
-        -------
-        Ex, Ey: ndarrays (V/m)
-            Arrays of the same shape as x, y, z, containing the fields
+        See the docstring of LaserProfile.E_field
         """
         # Note: this formula is expressed with complex numbers for compactness
         # and simplicity, but only the real part is used in the end
@@ -234,6 +222,11 @@ class LaguerreGaussLaser( LaserProfile ):
                     lambda0=0.8e-6, cep_phase=0., theta0=0. ):
         """
         Define a linearly-polarized Laguerre-Gauss laser profile.
+
+        Unlike the :any:`DonutLikeLaguerreGaussLaser` profile, this
+        profile has a phase which is independent of the azimuthal angle
+        :math:`theta`, and an intensity profile which does depend on
+        :math:`theta`.
 
         More precisely, the electric field **near the focal plane**
         is given by:
@@ -272,14 +265,18 @@ class LaguerreGaussLaser( LaserProfile ):
             requires the azimuthal modes from :math:`0` to :math:`m+1`.
             (i.e. the number of required azimuthal modes is ``Nm=m+2``)
 
+            The non-linear plasma response for this profile (e.g.
+            wakefield driven by the ponderomotive force) may require
+            even more azimuthal modes.
+
         Parameters
         ----------
 
-        p: int
+        p: int (positive)
             The order of the Laguerre polynomial. (Increasing ``p`` increases
             the number of "rings" in the radial intensity profile of the laser.)
 
-        m: int
+        m: int (positive)
             The azimuthal order of the pulse.
             (In the transverse plane, the field of the pulse varies as
             :math:`\cos[m(\\theta-\\theta_0)]`.)
@@ -340,6 +337,8 @@ class LaguerreGaussLaser( LaserProfile ):
             zf = z0
 
         # Store the parameters
+        if m < 0 or type(m) is not int:
+            raise ValueError("m should be an integer positive number.")
         self.p = p
         self.m = m
         self.laguerre_pm = genlaguerre(self.p, self.m) # Laguerre polynomial
@@ -356,19 +355,7 @@ class LaguerreGaussLaser( LaserProfile ):
 
     def E_field( self, x, y, z, t ):
         """
-        Return the electric field of the laser
-
-        Parameters
-        ----------
-        x, y, z: ndarrays (meters)
-            The positions at which to calculate the profile (in the lab frame)
-        t: ndarray or float (seconds)
-            The time at which to calculate the profile (in the lab frame)
-
-        Returns:
-        --------
-        Ex, Ey: ndarrays (V/m)
-            Arrays of the same shape as x, y, z, containing the fields
+        See the docstring of LaserProfile.E_field
         """
         # Diffraction factor, waist and Gouy phase
         diffract_factor = 1. + 1j * ( z - self.zf ) * self.inv_zr
@@ -387,6 +374,156 @@ class LaguerreGaussLaser( LaserProfile ):
         profile = np.exp(exp_argument) / diffract_factor \
             * scaled_radius**self.m * self.laguerre_pm(scaled_radius_squared) \
             * np.cos( self.m*(theta-self.theta0) )
+
+        # Get the projection along x and y, with the correct polarization
+        Ex = self.E0x * profile
+        Ey = self.E0y * profile
+
+        return( Ex.real, Ey.real )
+
+
+class DonutLikeLaguerreGaussLaser( LaserProfile ):
+    """Class that calculates a donut-like Laguerre-Gauss pulse."""
+
+    def __init__( self, p, m, a0, waist, tau, z0, zf=None, theta_pol=0.,
+                    lambda0=0.8e-6, cep_phase=0. ):
+        """
+        Define a linearly-polarized donut-like Laguerre-Gauss laser profile.
+
+        Unlike the :any:`LaguerreGaussLaser` profile, this
+        profile has a phase which depends on the azimuthal angle
+        :math:`\\theta` (cork-screw pattern), and an intensity profile which
+        is independent on :math:`\\theta` (donut-like).
+
+        More precisely, the electric field **near the focal plane**
+        is given by:
+
+        .. math::
+
+            E(\\boldsymbol{x},t) = a_0\\times E_0 \, f(r) \,
+            \exp\left( -\\frac{r^2}{w_0^2} - \\frac{(z-z_0-ct)^2}{c^2\\tau^2}
+            \\right) \cos[ k_0( z - z_0 - ct ) - m\\theta - \phi_{cep} ]
+
+            \mathrm{with} \qquad f(r) =
+            \sqrt{\\frac{p!}{(m+p)!}}
+            \\left( \\frac{\sqrt{2}r}{w_0} \\right)^m
+            L^m_p\\left( \\frac{2 r^2}{w_0^2} \\right)
+
+        where :math:`L^m_p` is a Laguerre polynomial,
+        :math:`k_0 = 2\pi/\\lambda_0` is the wavevector and where
+        :math:`E_0 = m_e c^2 k_0 / q_e`.
+
+        (For more info, see
+        `Siegman, Lasers (1986) <https://www.osapublishing.org/books/bookshelf/lasers.cfm>`_,
+        Chapter 16: Wave optics and Gaussian beams)
+
+        .. note::
+
+            The additional terms that arise **far from the focal plane**
+            (Gouy phase, wavefront curvature, ...) are not included in the above
+            formula for simplicity, but are of course taken into account by
+            the code, when initializing the laser pulse away from the focal plane.
+
+        .. warning::
+            The above formula depends on a parameter :math:`m`
+            (see documentation below). In order to be properly resolved by
+            the simulation, a Laguerre-Gauss profile with a given :math:`m`
+            requires the azimuthal modes from :math:`0` to :math:`m+1`.
+            (i.e. the number of required azimuthal modes is ``Nm=m+2``)
+
+        Parameters
+        ----------
+
+        p: int
+            The order of the Laguerre polynomial. (Increasing ``p`` increases
+            the number of "rings" in the radial intensity profile of the laser.)
+
+        m: int (positive or negative)
+            The azimuthal order of the pulse. The laser phase in a given
+            transverse plane varies as :math:`m \\theta`.
+
+        a0: float (dimensionless)
+            The amplitude of the pulse, defined so that the total
+            energy of the pulse is the same as that of a Gaussian pulse
+            with the same :math:`a_0`, :math:`w_0` and :math:`\\tau`.
+            (i.e. The energy of the pulse is independent of ``p`` and ``m``.)
+
+        waist: float (in meter)
+            Laser waist at the focal plane, defined as :math:`w_0` in the
+            above formula.
+
+        tau: float (in second)
+            The duration of the laser (in the lab frame),
+            defined as :math:`\\tau` in the above formula.
+
+        z0: float (in meter)
+            The initial position of the centroid of the laser
+            (in the lab frame), defined as :math:`z_0` in the above formula.
+
+        zf: float (in meter), optional
+            The position of the focal plane (in the lab frame).
+            If ``zf`` is not provided, the code assumes that ``zf=z0``, i.e.
+            that the laser pulse is at the focal plane initially.
+
+        theta_pol: float (in radian), optional
+           The angle of polarization with respect to the x axis.
+
+        lambda0: float (in meter), optional
+            The wavelength of the laser (in the lab frame), defined as
+            :math:`\\lambda_0` in the above formula.
+            Default: 0.8 microns (Ti:Sapph laser).
+
+        cep_phase: float (in radian), optional
+            The Carrier Enveloppe Phase (CEP), defined as :math:`\phi_{cep}`
+            in the above formula (i.e. the phase of the laser
+            oscillation, at the position where the laser enveloppe is maximum)
+        """
+        # Set a number of parameters for the laser
+        k0 = 2*np.pi/lambda0
+        zr = 0.5*k0*waist**2
+        # Scaling factor, so that the pulse energy is independent of p and m.
+        scaled_amplitude = np.sqrt( factorial(p)/factorial(m+p) )
+        E0 = scaled_amplitude * a0 * m_e*c**2 * k0/e
+
+        # If no focal plane position is given, use z0
+        if zf is None:
+            zf = z0
+
+        # Store the parameters
+        self.p = p
+        self.m = m
+        self.laguerre_pm = genlaguerre(self.p, self.m) # Laguerre polynomial
+        self.k0 = k0
+        self.inv_zr = 1./zr
+        self.zf = zf
+        self.z0 = z0
+        self.E0x = E0 * np.cos(theta_pol)
+        self.E0y = E0 * np.sin(theta_pol)
+        self.w0 = waist
+        self.cep_phase = cep_phase
+        self.inv_ctau2 = 1./(c*tau)**2
+
+    def E_field( self, x, y, z, t ):
+        """
+        See the docstring of LaserProfile.E_field
+        """
+        # Diffraction factor, waist and Gouy phase
+        diffract_factor = 1. + 1j * ( z - self.zf ) * self.inv_zr
+        w = self.w0 * abs( diffract_factor )
+        psi = np.angle( diffract_factor )
+        # Calculate the scaled radius and azimuthal angle
+        scaled_radius_squared = 2*( x**2 + y**2 ) / w**2
+        scaled_radius = np.sqrt( scaled_radius_squared )
+        theta = np.angle( x + 1.j*y )
+        # Calculate the argument of the complex exponential
+        exp_argument = 1j*self.k0*( z - self.z0 - c*t ) \
+            - 1j*self.cep_phase - 1.j*self.m*theta \
+            - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
+            - self.inv_ctau2 * ( z - self.z0 - c*t )**2 \
+            + 1.j*(2*self.p + self.m)*psi # *Additional* Gouy phase
+        # Get the transverse profile
+        profile = np.exp(exp_argument) / diffract_factor \
+            * scaled_radius**self.m * self.laguerre_pm(scaled_radius_squared)
 
         # Get the projection along x and y, with the correct polarization
         Ex = self.E0x * profile
@@ -502,18 +639,6 @@ class FlattenedGaussianLaser( LaserProfile ):
 
     def E_field( self, x, y, z, t ):
         """
-        Return the electric field of the laser
-
-        Parameters
-        ----------
-        x, y, z: ndarrays (meters)
-            The positions at which to calculate the profile (in the lab frame)
-        t: ndarray or float (seconds)
-            The time at which to calculate the profile (in the lab frame)
-
-        Returns:
-        --------
-        Ex, Ey: ndarrays (V/m)
-            Arrays of the same shape as x, y, z, containing the fields
+        See the docstring of LaserProfile.E_field
         """
         return self.summed_profile.E_field( x, y, z, t )

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -405,9 +405,9 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
             \\right) \cos[ k_0( z - z_0 - ct ) - m\\theta - \phi_{cep} ]
 
             \mathrm{with} \qquad f(r) =
-            \sqrt{\\frac{p!}{(m+p)!}}
-            \\left( \\frac{\sqrt{2}r}{w_0} \\right)^m
-            L^m_p\\left( \\frac{2 r^2}{w_0^2} \\right)
+            \sqrt{\\frac{p!}{(|m|+p)!}}
+            \\left( \\frac{\sqrt{2}r}{w_0} \\right)^{|m|}
+            L^{|m|}_p\\left( \\frac{2 r^2}{w_0^2} \\right)
 
         where :math:`L^m_p` is a Laguerre polynomial,
         :math:`k_0 = 2\pi/\\lambda_0` is the wavevector and where
@@ -428,8 +428,8 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
             The above formula depends on a parameter :math:`m`
             (see documentation below). In order to be properly resolved by
             the simulation, a Laguerre-Gauss profile with a given :math:`m`
-            requires the azimuthal modes from :math:`0` to :math:`m+1`.
-            (i.e. the number of required azimuthal modes is ``Nm=m+2``)
+            requires the azimuthal modes from :math:`0` to :math:`|m|+1`.
+            (i.e. the number of required azimuthal modes is ``Nm=|m|+2``)
 
         Parameters
         ----------
@@ -482,7 +482,7 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
         k0 = 2*np.pi/lambda0
         zr = 0.5*k0*waist**2
         # Scaling factor, so that the pulse energy is independent of p and m.
-        scaled_amplitude = np.sqrt( factorial(p)/factorial(m+p) )
+        scaled_amplitude = np.sqrt( factorial(p)/factorial(abs(m)+p) )
         E0 = scaled_amplitude * a0 * m_e*c**2 * k0/e
 
         # If no focal plane position is given, use z0
@@ -492,7 +492,7 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
         # Store the parameters
         self.p = p
         self.m = m
-        self.laguerre_pm = genlaguerre(self.p, self.m) # Laguerre polynomial
+        self.laguerre_pm = genlaguerre(self.p, abs(m)) # Laguerre polynomial
         self.k0 = k0
         self.inv_zr = 1./zr
         self.zf = zf
@@ -520,10 +520,11 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
             - 1j*self.cep_phase - 1.j*self.m*theta \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
             - self.inv_ctau2 * ( z - self.z0 - c*t )**2 \
-            + 1.j*(2*self.p + self.m)*psi # *Additional* Gouy phase
+            + 1.j*(2*self.p + abs(self.m))*psi # *Additional* Gouy phase
         # Get the transverse profile
         profile = np.exp(exp_argument) / diffract_factor \
-            * scaled_radius**self.m * self.laguerre_pm(scaled_radius_squared)
+            * scaled_radius**abs(self.m) \
+            * self.laguerre_pm(scaled_radius_squared)
 
         # Get the projection along x and y, with the correct polarization
         Ex = self.E0x * profile

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -39,7 +39,7 @@ from scipy.constants import c, m_e, e
 from scipy.optimize import curve_fit
 from fbpic.main import Simulation
 from fbpic.lpa_utils.laser import add_laser_pulse, \
-    GaussianLaser, LaguerreGaussLaser
+    GaussianLaser, LaguerreGaussLaser, DonutLikeLaguerreGaussLaser
 
 # Parameters
 # ----------
@@ -336,8 +336,8 @@ def init_fields( sim, w, ctau, k0, z0, zf, E0, m=1 ) :
         profile = GaussianLaser( a0=a0, waist=w, tau=tau,
                     lambda0=lambda0, z0=z0, zf=zf )
     elif m == 2:
-        profile = LaguerreGaussLaser( 0, 1, a0=a0, waist=w, tau=tau,
-                    lambda0=lambda0, z0=z0, zf=zf )
+        profile = DonutLikeLaguerreGaussLaser( 0, 1, a0=a0, 
+                   waist=w, tau=tau, lambda0=lambda0, z0=z0, zf=zf )
     # Add the profiles to the simulation
     add_laser_pulse( sim, profile )
 

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -336,7 +336,7 @@ def init_fields( sim, w, ctau, k0, z0, zf, E0, m=1 ) :
         profile = GaussianLaser( a0=a0, waist=w, tau=tau,
                     lambda0=lambda0, z0=z0, zf=zf )
     elif m == 2:
-        profile = DonutLikeLaguerreGaussLaser( 0, 1, a0=a0, 
+        profile = DonutLikeLaguerreGaussLaser( 0, -1, a0=a0, 
                    waist=w, tau=tau, lambda0=lambda0, z0=z0, zf=zf )
     # Add the profiles to the simulation
     add_laser_pulse( sim, profile )


### PR DESCRIPTION
This pull request adds a new type of laser profile: the donut-like Laguerre-Gauss modes.
These modes have a cork-screw phase pattern and a donut-like intensity pattern.

While these modes can in principle be constructed from the regular Laguerre-Gauss modes, it is somewhat error-prone (esp. for large m). And in practice, this is a common enough laser profile that several users might want to use it.

This PR also adds a few checks for the regular Laguerre-Gauss modes, so as to prevent users from using negative`m`.