### PR TITLE
Allow laser profiles to propagate forward or backward

### DIFF
--- a/fbpic/lpa_utils/laser/direct_injection.py
+++ b/fbpic/lpa_utils/laser/direct_injection.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy.constants import c
 from fbpic.fields import Fields
 
-def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
+def add_laser_direct( sim, laser_profile, boost ):
     """
     Add a laser pulse in the simulation, by directly adding it to the mesh
 
@@ -30,9 +30,6 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
 
     laser_profile: a valid laser profile object
         Laser profiles can be imported from fbpic.lpa_utils.laser
-
-    fw_propagating: bool, optional
-       Whether the laser is propagating in the forward or backward direction.
 
     boost: a BoostConverter object or None
        Contains the information about the boost to be applied
@@ -78,7 +75,7 @@ def add_laser_direct( sim, laser_profile, fw_propagating, boost ):
     # Calculate the Ez and B fields on the global grid
     # (For a multi-proc simulation: only performed by the first proc)
     if sim.comm.rank == 0:
-        calculate_laser_fields( global_fld, fw_propagating )
+        calculate_laser_fields( global_fld, laser_profile.propag_direction )
 
     # Communicate the results from proc 0 to the other procs
     # and add it to the interpolation grid of sim.fld.
@@ -112,9 +109,6 @@ def get_laser_Er_Et( sim, laser_profile, boost ):
     -----------
     sim: a Simulation object
         The structure that contains the simulation.
-
-    fw_propagating: bool
-       Whether the laser is propagating in the forward or backward direction.
 
     boost: a BoostConverter object or None
        Contains the information about the boost to be applied
@@ -169,7 +163,7 @@ def get_laser_Er_Et( sim, laser_profile, boost ):
     return( Er_m_3d, Et_m_3d )
 
 
-def calculate_laser_fields( fld, fw_propagating ):
+def calculate_laser_fields( fld, propag_direction ):
     """
     Given the fields Er and Et of the laser (in `fld`),
     calculate the fields Ez and B in a self-consistent manner,
@@ -181,7 +175,7 @@ def calculate_laser_fields( fld, fw_propagating ):
         Contains the fields of the global domain
         (with the correct Er and Et of the laser on the interpolation grid)
 
-    fw_propagating: bool
+    propag_direction: float (either +1. or -1.)
         Whether the laser is propagating in the forward or backward direction.
     """
     # Get the (filtered) E field in spectral space
@@ -205,13 +199,11 @@ def calculate_laser_fields( fld, fw_propagating ):
 
     # Calculate the B field by ensuring that d_t B = - curl(E)
     # i.e. -i w B = - curl(E), where the sign of w is chosen so that
-    # the direction of propagation is given by the flag `fw_propagating`
+    # the direction of propagation is given by `propag_direction`
     for m in range(fld.Nm):
         # Calculate w with the right sign
         w = c*np.sqrt( spect[m].kz**2 + spect[m].kr**2 )
-        w *= np.sign( spect[m].kz )
-        if not fw_propagating:
-            w *= -1.
+        w *= np.sign( spect[m].kz ) * propag_direction
         inv_w = np.where( w==0, 0., 1./np.where( w==0, 1., w ) ) # Avoid nan
         # Calculate the components of the curl in spectral cylindrical
         spect[m].Bp[:,:] = -1.j*inv_w*( spect[m].kz * spect[m].Ep \

--- a/fbpic/lpa_utils/laser/laser.py
+++ b/fbpic/lpa_utils/laser/laser.py
@@ -12,7 +12,7 @@ from .direct_injection import add_laser_direct
 from .antenna_injection import LaserAntenna
 
 def add_laser_pulse( sim, laser_profile, gamma_boost=None,
-                    method='direct', z0_antenna=None, fw_propagating=True ):
+                    method='direct', z0_antenna=None ):
     """
     Introduce a laser pulse in the simulation.
 
@@ -41,10 +41,6 @@ def add_laser_pulse( sim, laser_profile, gamma_boost=None,
         (method= ``direct``) or through a laser antenna (method= ``antenna``).
         Default: ``direct``
 
-    fw_propagating: bool, optional
-       Only for the ``direct`` method: Whether the laser is propagating
-       in the forward or backward direction.
-
     z0_antenna: float, optional (meters)
        Required for the ``antenna`` method: initial position
        (in the lab frame) of the antenna.
@@ -64,15 +60,19 @@ def add_laser_pulse( sim, laser_profile, gamma_boost=None,
         add_laser_pulse( sim, profile )
     """
     # Prepare the boosted frame converter
-    if (gamma_boost is not None) and (fw_propagating==True):
-        boost = BoostConverter( gamma_boost )
+    if (gamma_boost is not None) and (gamma_boost != 1.):
+        if laser_profile.forward_propagating:
+            boost = BoostConverter( gamma_boost )
+        else:
+            raise ValueError('For now, backward-propagating lasers '
+                         'cannot be used in the boosted-frame.')
     else:
         boost = None
 
     # Handle the introduction method of the laser
     if method == 'direct':
         # Directly add the laser to the interpolation object
-        add_laser_direct( sim, laser_profile, fw_propagating, boost )
+        add_laser_direct( sim, laser_profile, boost )
 
     elif method == 'antenna':
         # Add a laser antenna to the simulation object
@@ -177,8 +177,7 @@ def add_laser( sim, a0, w0, ctau, z0, zf=None, lambda0=0.8e-6,
         or through a laser antenna (method=`antenna`)
 
     fw_propagating: bool, optional
-       Only for the `direct` method: Wether the laser is propagating in the
-       forward or backward direction.
+       Whether the laser is propagating in the forward or backward direction.
 
     update_spectral: bool, optional
        Only for the `direct` method: Wether to update the fields in spectral
@@ -191,8 +190,9 @@ def add_laser( sim, a0, w0, ctau, z0, zf=None, lambda0=0.8e-6,
     # Create a Gaussian laser profile
     laser_profile = GaussianLaser( a0, waist=w0, tau=ctau/c, z0=z0,
         zf=zf, theta_pol=theta_pol, lambda0=lambda0,
-        cep_phase=cep_phase, phi2_chirp=phi2_chirp )
+        cep_phase=cep_phase, phi2_chirp=phi2_chirp,
+        forward_propagating=fw_propagating )
 
     # Add it to the simulation
     add_laser_pulse( sim, laser_profile, gamma_boost=gamma_boost,
-        method=method, z0_antenna=z0_antenna, fw_propagating=fw_propagating )
+        method=method, z0_antenna=z0_antenna )

--- a/fbpic/lpa_utils/laser/laser.py
+++ b/fbpic/lpa_utils/laser/laser.py
@@ -187,11 +187,17 @@ def add_laser( sim, a0, w0, ctau, z0, zf=None, lambda0=0.8e-6,
        Only for the `antenna` method: initial position (in the lab frame)
        of the antenna. If not provided, then the z0_antenna is set to zf.
     """
+    # Pick the propagation direction
+    if fw_propagating:
+        propagation_direction = 1
+    else:
+        propagation_direction = -1
+
     # Create a Gaussian laser profile
     laser_profile = GaussianLaser( a0, waist=w0, tau=ctau/c, z0=z0,
         zf=zf, theta_pol=theta_pol, lambda0=lambda0,
         cep_phase=cep_phase, phi2_chirp=phi2_chirp,
-        forward_propagating=fw_propagating )
+        propagation_direction=propagation_direction )
 
     # Add it to the simulation
     add_laser_pulse( sim, laser_profile, gamma_boost=gamma_boost,

--- a/fbpic/lpa_utils/laser/laser.py
+++ b/fbpic/lpa_utils/laser/laser.py
@@ -61,7 +61,7 @@ def add_laser_pulse( sim, laser_profile, gamma_boost=None,
     """
     # Prepare the boosted frame converter
     if (gamma_boost is not None) and (gamma_boost != 1.):
-        if laser_profile.forward_propagating:
+        if laser_profile.propag_direction == 1:
             boost = BoostConverter( gamma_boost )
         else:
             raise ValueError('For now, backward-propagating lasers '

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -22,22 +22,20 @@ class LaserProfile( object ):
     Profiles that inherit from this base class can be summed,
     using the overloaded + operator.
     """
-    def __init__( self, forward_propagating ):
+    def __init__( self, propagation_direction ):
         """
         Initialize the propagation direction of the laser.
         (Each subclass should call this method at initialization.)
 
         Parameter
         ---------
-        forward_propagating: bool, optional
-            Whether this laser is propagating towards positive z.
-            (If False, this laser is propagating towards negative z.)
+        propagation_direction: int
+            Indicates in which direction the laser propagates.
+            This should be either 1 (laser propagates towards positive z)
+            or -1 (laser propagates towards negative z).
         """
-        self.forward_propagating = forward_propagating
-        if forward_propagating:
-            self.propag_direction = 1.
-        else:
-            self.propag_direction = -1.
+        assert propagation_direction in [-1, 1]
+        self.propag_direction = float(propagation_direction)
 
     def E_field( self, x, y, z, t ):
         """
@@ -79,8 +77,8 @@ class SummedLaserProfile( LaserProfile ):
         profile1, profile2: instances of LaserProfile
         """
         # Check that both profiles propagate in the same direction
-        assert profile1.forward_propagating == profile2.forward_propagating
-        LaserProfile.__init__(self, profile1.forward_propagating)
+        assert profile1.propag_direction == profile2.propag_direction
+        LaserProfile.__init__(self, profile1.propag_direction)
 
         # Register the profiles from which the sum should be calculated
         self.profile1 = profile1
@@ -103,7 +101,7 @@ class GaussianLaser( LaserProfile ):
 
     def __init__( self, a0, waist, tau, z0, zf=None, theta_pol=0.,
                     lambda0=0.8e-6, cep_phase=0., phi2_chirp=0.,
-                    forward_propagating=True ):
+                    propagation_direction=1 ):
         """
         Define a linearly-polarized Gaussian laser profile.
 
@@ -172,12 +170,13 @@ class GaussianLaser( LaserProfile ):
             i.e. red part of the spectrum in the front of the pulse and blue
             part of the spectrum in the back.
 
-        forward_propagating: bool, optional
-            Whether this laser is propagating towards positive z.
-            (If False, this laser is propagating towards negative z.)
+        propagation_direction: int, optional
+            Indicates in which direction the laser propagates.
+            This should be either 1 (laser propagates towards positive z)
+            or -1 (laser propagates towards negative z).
         """
         # Initialize propagation direction
-        LaserProfile.__init__(self, forward_propagating)
+        LaserProfile.__init__(self, propagation_direction)
 
         # Set a number of parameters for the laser
         k0 = 2*np.pi/lambda0
@@ -239,7 +238,7 @@ class LaguerreGaussLaser( LaserProfile ):
 
     def __init__( self, p, m, a0, waist, tau, z0, zf=None, theta_pol=0.,
                     lambda0=0.8e-6, cep_phase=0., theta0=0.,
-                    forward_propagating=True ):
+                    propagation_direction=1 ):
         """
         Define a linearly-polarized Laguerre-Gauss laser profile.
 
@@ -343,12 +342,13 @@ class LaguerreGaussLaser( LaserProfile ):
             (In the transverse plane, the field of the pulse varies as
             :math:`\cos[m(\\theta-\\theta_0)]`.)
 
-        forward_propagating: bool, optional
-            Whether this laser is propagating towards positive z.
-            (If False, this laser is propagating towards negative z.)
+        propagation_direction: int, optional
+            Indicates in which direction the laser propagates.
+            This should be either 1 (laser propagates towards positive z)
+            or -1 (laser propagates towards negative z).
         """
         # Initialize propagation direction
-        LaserProfile.__init__(self, forward_propagating)
+        LaserProfile.__init__(self, propagation_direction)
 
         # Set a number of parameters for the laser
         k0 = 2*np.pi/lambda0
@@ -415,7 +415,7 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
     """Class that calculates a donut-like Laguerre-Gauss pulse."""
 
     def __init__( self, p, m, a0, waist, tau, z0, zf=None, theta_pol=0.,
-                    lambda0=0.8e-6, cep_phase=0., forward_propagating=True ):
+                    lambda0=0.8e-6, cep_phase=0., propagation_direction=1 ):
         """
         Define a linearly-polarized donut-like Laguerre-Gauss laser profile.
 
@@ -507,12 +507,13 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
             in the above formula (i.e. the phase of the laser
             oscillation, at the position where the laser enveloppe is maximum)
 
-        forward_propagating: bool, optional
-            Whether this laser is propagating towards positive z.
-            (If False, this laser is propagating towards negative z.)
+        propagation_direction: int, optional
+            Indicates in which direction the laser propagates.
+            This should be either 1 (laser propagates towards positive z)
+            or -1 (laser propagates towards negative z).
         """
         # Initialize propagation direction
-        LaserProfile.__init__(self, forward_propagating)
+        LaserProfile.__init__(self, propagation_direction)
 
         # Set a number of parameters for the laser
         k0 = 2*np.pi/lambda0
@@ -574,7 +575,7 @@ class FlattenedGaussianLaser( LaserProfile ):
     """Class that calculates a focused flattened Gaussian"""
 
     def __init__( self, a0, w0, tau, z0, N=6, zf=None, theta_pol=0.,
-                    lambda0=0.8e-6, cep_phase=0., forward_propagating=True ):
+                    lambda0=0.8e-6, cep_phase=0., propagation_direction=1 ):
         """
         Define a linearly-polarized laser such that the transverse intensity
         profile is a flattened Gaussian **far from focus**, and a distribution
@@ -651,12 +652,13 @@ class FlattenedGaussianLaser( LaserProfile ):
             The Carrier Enveloppe Phase (CEP, i.e. the phase of the laser
             oscillation, at the position where the laser enveloppe is maximum)
 
-        forward_propagating: bool, optional
-            Whether this laser is propagating towards positive z.
-            (If False, this laser is propagating towards negative z.)
+        propagation_direction: int, optional
+            Indicates in which direction the laser propagates.
+            This should be either 1 (laser propagates towards positive z)
+            or -1 (laser propagates towards negative z).
         """
         # Initialize propagation direction
-        LaserProfile.__init__(self, forward_propagating)
+        LaserProfile.__init__(self, propagation_direction)
 
         # Ensure that N is an integer
         N = int(round(N))
@@ -673,7 +675,7 @@ class FlattenedGaussianLaser( LaserProfile ):
                             cep_phase=cep_phase_n, waist=w_foc,
                             tau=tau, z0=z0, zf=zf, theta_pol=theta_pol,
                             lambda0=lambda0, theta0=0.,
-                            forward_propagating=forward_propagating )
+                            propagation_direction=propagation_direction )
             if n==0:
                 summed_profile = profile
             else:

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -22,6 +22,22 @@ class LaserProfile( object ):
     Profiles that inherit from this base class can be summed,
     using the overloaded + operator.
     """
+    def __init__( self, forward_propagating ):
+        """
+        Initialize the propagation direction of the laser.
+        (Each subclass should call this method at initialization.)
+
+        Parameter
+        ---------
+        forward_propagating: bool, optional
+            Whether this laser is propagating towards positive z.
+            (If False, this laser is propagating towards negative z.)
+        """
+        self.forward_propagating = forward_propagating
+        if forward_propagating:
+            self.propag_direction = 1.
+        else:
+            self.propag_direction = -1.
 
     def E_field( self, x, y, z, t ):
         """
@@ -62,25 +78,17 @@ class SummedLaserProfile( LaserProfile ):
         -----------
         profile1, profile2: instances of LaserProfile
         """
+        # Check that both profiles propagate in the same direction
+        assert profile1.forward_propagating == profile2.forward_propagating
+        LaserProfile.__init__(self, profile1.forward_propagating)
+
         # Register the profiles from which the sum should be calculated
         self.profile1 = profile1
         self.profile2 = profile2
 
     def E_field( self, x, y, z, t ):
         """
-        Return the electric field of the laser
-
-        Parameters
-        -----------
-        x, y, z: ndarrays (meters)
-            The positions at which to calculate the profile (in the lab frame)
-        t: ndarray or float (seconds)
-            The time at which to calculate the profile (in the lab frame)
-
-        Returns:
-        --------
-        Ex, Ey: ndarrays (V/m)
-            Arrays of the same shape as x, y, z, containing the fields
+        See the docstring of LaserProfile.E_field
         """
         Ex1, Ey1 = self.profile1.E_field( x, y, z, t )
         Ex2, Ey2 = self.profile2.E_field( x, y, z, t )
@@ -94,7 +102,8 @@ class GaussianLaser( LaserProfile ):
     """Class that calculates a Gaussian laser pulse."""
 
     def __init__( self, a0, waist, tau, z0, zf=None, theta_pol=0.,
-                    lambda0=0.8e-6, cep_phase=0., phi2_chirp=0. ):
+                    lambda0=0.8e-6, cep_phase=0., phi2_chirp=0.,
+                    forward_propagating=True ):
         """
         Define a linearly-polarized Gaussian laser profile.
 
@@ -162,7 +171,14 @@ class GaussianLaser( LaserProfile ):
             Thus, a positive :math:`\phi^{(2)}` corresponds to positive chirp,
             i.e. red part of the spectrum in the front of the pulse and blue
             part of the spectrum in the back.
+
+        forward_propagating: bool, optional
+            Whether this laser is propagating towards positive z.
+            (If False, this laser is propagating towards negative z.)
         """
+        # Initialize propagation direction
+        LaserProfile.__init__(self, forward_propagating)
+
         # Set a number of parameters for the laser
         k0 = 2*np.pi/lambda0
         E0 = a0*m_e*c**2*k0/e
@@ -199,12 +215,15 @@ class GaussianLaser( LaserProfile ):
         # and then by taking the inverse Fourier transform in x, y, and t
 
         # Diffraction and stretch_factor
-        diffract_factor = 1. + 1j * ( z - self.zf ) * self.inv_zr
+        prop_dir = self.propag_direction
+        diffract_factor = 1. + 1j * prop_dir*(z - self.zf) * self.inv_zr
         stretch_factor = 1 - 2j * self.phi2_chirp * c**2 * self.inv_ctau2
         # Calculate the argument of the complex exponential
-        exp_argument = 1j*self.k0*( z - self.z0 - c*t ) - 1j*self.cep_phase \
+        exp_argument = - 1j*self.cep_phase \
+            + 1j*self.k0*( prop_dir*(z - self.z0) - c*t ) \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - 1./stretch_factor * self.inv_ctau2 * ( z - self.z0 - c*t )**2
+            - 1./stretch_factor*self.inv_ctau2 * \
+                                    ( prop_dir*(z - self.z0) - c*t )**2
         # Get the transverse profile
         profile = np.exp(exp_argument) /(diffract_factor * stretch_factor**0.5)
 
@@ -219,7 +238,8 @@ class LaguerreGaussLaser( LaserProfile ):
     """Class that calculates a Laguerre-Gauss pulse."""
 
     def __init__( self, p, m, a0, waist, tau, z0, zf=None, theta_pol=0.,
-                    lambda0=0.8e-6, cep_phase=0., theta0=0. ):
+                    lambda0=0.8e-6, cep_phase=0., theta0=0.,
+                    forward_propagating=True ):
         """
         Define a linearly-polarized Laguerre-Gauss laser profile.
 
@@ -322,7 +342,14 @@ class LaguerreGaussLaser( LaserProfile ):
             transverse plane.
             (In the transverse plane, the field of the pulse varies as
             :math:`\cos[m(\\theta-\\theta_0)]`.)
+
+        forward_propagating: bool, optional
+            Whether this laser is propagating towards positive z.
+            (If False, this laser is propagating towards negative z.)
         """
+        # Initialize propagation direction
+        LaserProfile.__init__(self, forward_propagating)
+
         # Set a number of parameters for the laser
         k0 = 2*np.pi/lambda0
         zr = 0.5*k0*waist**2
@@ -358,7 +385,8 @@ class LaguerreGaussLaser( LaserProfile ):
         See the docstring of LaserProfile.E_field
         """
         # Diffraction factor, waist and Gouy phase
-        diffract_factor = 1. + 1j * ( z - self.zf ) * self.inv_zr
+        prop_dir = self.propag_direction
+        diffract_factor = 1. + 1j * prop_dir * (z - self.zf) * self.inv_zr
         w = self.w0 * abs( diffract_factor )
         psi = np.angle( diffract_factor )
         # Calculate the scaled radius and azimuthal angle
@@ -366,9 +394,10 @@ class LaguerreGaussLaser( LaserProfile ):
         scaled_radius = np.sqrt( scaled_radius_squared )
         theta = np.angle( x + 1.j*y )
         # Calculate the argument of the complex exponential
-        exp_argument = 1j*self.k0*( z - self.z0 - c*t ) - 1j*self.cep_phase \
+        exp_argument = - 1j*self.cep_phase \
+            + 1j*self.k0*( prop_dir*(z - self.z0) - c*t ) \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - self.inv_ctau2 * ( z - self.z0 - c*t )**2 \
+            - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t )**2 \
             + 1.j*(2*self.p + self.m)*psi # *Additional* Gouy phase
         # Get the transverse profile
         profile = np.exp(exp_argument) / diffract_factor \
@@ -386,7 +415,7 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
     """Class that calculates a donut-like Laguerre-Gauss pulse."""
 
     def __init__( self, p, m, a0, waist, tau, z0, zf=None, theta_pol=0.,
-                    lambda0=0.8e-6, cep_phase=0. ):
+                    lambda0=0.8e-6, cep_phase=0., forward_propagating=True ):
         """
         Define a linearly-polarized donut-like Laguerre-Gauss laser profile.
 
@@ -477,7 +506,14 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
             The Carrier Enveloppe Phase (CEP), defined as :math:`\phi_{cep}`
             in the above formula (i.e. the phase of the laser
             oscillation, at the position where the laser enveloppe is maximum)
+
+        forward_propagating: bool, optional
+            Whether this laser is propagating towards positive z.
+            (If False, this laser is propagating towards negative z.)
         """
+        # Initialize propagation direction
+        LaserProfile.__init__(self, forward_propagating)
+
         # Set a number of parameters for the laser
         k0 = 2*np.pi/lambda0
         zr = 0.5*k0*waist**2
@@ -508,7 +544,8 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
         See the docstring of LaserProfile.E_field
         """
         # Diffraction factor, waist and Gouy phase
-        diffract_factor = 1. + 1j * ( z - self.zf ) * self.inv_zr
+        prop_dir = self.propag_direction
+        diffract_factor = 1. + 1j * prop_dir * ( z - self.zf ) * self.inv_zr
         w = self.w0 * abs( diffract_factor )
         psi = np.angle( diffract_factor )
         # Calculate the scaled radius and azimuthal angle
@@ -516,10 +553,10 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
         scaled_radius = np.sqrt( scaled_radius_squared )
         theta = np.angle( x + 1.j*y )
         # Calculate the argument of the complex exponential
-        exp_argument = 1j*self.k0*( z - self.z0 - c*t ) \
+        exp_argument = 1j*self.k0*( prop_dir*(z - self.z0) - c*t ) \
             - 1j*self.cep_phase - 1.j*self.m*theta \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - self.inv_ctau2 * ( z - self.z0 - c*t )**2 \
+            - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t )**2 \
             + 1.j*(2*self.p + abs(self.m))*psi # *Additional* Gouy phase
         # Get the transverse profile
         profile = np.exp(exp_argument) / diffract_factor \
@@ -537,7 +574,7 @@ class FlattenedGaussianLaser( LaserProfile ):
     """Class that calculates a focused flattened Gaussian"""
 
     def __init__( self, a0, w0, tau, z0, N=6, zf=None, theta_pol=0.,
-                    lambda0=0.8e-6, cep_phase=0. ):
+                    lambda0=0.8e-6, cep_phase=0., forward_propagating=True ):
         """
         Define a linearly-polarized laser such that the transverse intensity
         profile is a flattened Gaussian **far from focus**, and a distribution
@@ -613,7 +650,14 @@ class FlattenedGaussianLaser( LaserProfile ):
         cep_phase: float (in radian), optional
             The Carrier Enveloppe Phase (CEP, i.e. the phase of the laser
             oscillation, at the position where the laser enveloppe is maximum)
+
+        forward_propagating: bool, optional
+            Whether this laser is propagating towards positive z.
+            (If False, this laser is propagating towards negative z.)
         """
+        # Initialize propagation direction
+        LaserProfile.__init__(self, forward_propagating)
+
         # Ensure that N is an integer
         N = int(round(N))
         # Calculate effective waist of the Laguerre-Gauss modes, at focus
@@ -627,8 +671,9 @@ class FlattenedGaussianLaser( LaserProfile ):
             cn = (-1)**n * np.sum( 1./2**m_values * binom(m_values,n) ) /(N+1)
             profile = LaguerreGaussLaser( p=n, m=0, a0=cn*a0,
                             cep_phase=cep_phase_n, waist=w_foc,
-                            tau=tau, z0=z0, zf=zf,
-                            theta_pol=theta_pol, lambda0=lambda0, theta0=0. )
+                            tau=tau, z0=z0, zf=zf, theta_pol=theta_pol,
+                            lambda0=lambda0, theta0=0.,
+                            forward_propagating=forward_propagating )
             if n==0:
                 summed_profile = profile
             else:

--- a/tests/test_laser_antenna.py
+++ b/tests/test_laser_antenna.py
@@ -106,6 +106,9 @@ def run_and_check_laser_antenna(gamma_b, show, write_files):
     add_laser( sim, a0, w0, ctau, z0, zf=zf,
         method='antenna', z0_antenna=z0_antenna, gamma_boost=gamma_b)
 
+    for antenna in sim.laser_antennas:
+        print(antenna.laser_profile.propag_direction)
+
     # Calculate the number of steps between each output
     N_step = int( round( Ntot_step/N_show ) )
 


### PR DESCRIPTION
This PR depends on PR #259.

It allows each laser profile to propagate in the forward or backward direction.
For the backward direction, the formulas are obtained by basically applying the transformation `z => -z` in the existing formulas.

In addition, all laser profiles now need to have the attributes `forward_propagating` and `propag_direction`. The parent class `LaserProfile` has an `__init__` method that initializes these variables. 

Then these attributes are used in the `add_laser_pulse` method. Therefore the argument `fw_propagating` is not needed anymore, and was removed. Technically, this breaks backward compatibility ; however, I doubt that anyone was using `fw_propagating=False` with this (relatively new) function, and thus I think it's fine. @MKirchen Any opinion on this?