### PR TITLE
Implement moving antenna

### DIFF
--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -254,7 +254,7 @@ class LaserAntenna( object ):
         # (This prevents out-of-bounds errors, and prevents 2 neighboring
         # processors from simultaneously depositing the laser antenna)
         zmin_local, zmax_local = comm.get_zmin_zmax(
-            local=True, with_damp=False, with_guard=False, rank=comm.rank )
+            local=True, with_damp=True, with_guard=False, rank=comm.rank )
         # Interrupt this function if the antenna is not in the local domain
         z_antenna = self.baseline_z[0]
         if (z_antenna < zmin_local) or (z_antenna >= zmax_local):

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -48,8 +48,8 @@ class LaserAntenna( object ):
     Note that the antenna always uses linear shape factors (even when the
     rest of the simulation uses cubic shape factors.)
     """
-    def __init__( self, laser_profile, z0_antenna, dr_grid, Nr_grid,
-        Nm, boost, npr=2, epsilon=0.01 ):
+    def __init__( self, laser_profile, z0_antenna, v_antenna,
+                    dr_grid, Nr_grid, Nm, boost, npr=2, epsilon=0.01 ):
         """
         Initialize a LaserAntenna object (see class docstring for more info)
 
@@ -60,6 +60,10 @@ class LaserAntenna( object ):
 
         z0_antenna: float (m)
             Initial position of the antenna *in the lab frame*
+
+        v_antenna: float (m/s)
+            Only used for the ``antenna`` method: velocity of the antenna
+            (in the lab frame)
 
         dr_grid: float (m)
            Resolution of the grid which contains the fields
@@ -90,6 +94,12 @@ class LaserAntenna( object ):
         self.laser_profile = laser_profile
         self.boost = boost
 
+        # For now, boost and non-zero velocity are incompatible
+        if (v_antenna != 0) and (boost is not None):
+            if boost.gamma0 != 1.:
+                raise ValueError("For now, the boosted frame is incompatible "
+                    "with non-zero v_antenna.")
+
         # Initialize virtual particle with 2*Nm values of angle
         nptheta = 2*Nm
 
@@ -103,8 +113,13 @@ class LaserAntenna( object ):
         # velocity of the particles and the electric field to be emitted
         self.mobility_coef = 2*np.pi * \
           dr_grid**2 / ( nptheta*npr*alpha_weights ) * epsilon_0 * c
+        # Tune the mobility for the boosted-frame
         if boost is not None:
             self.mobility_coef = self.mobility_coef / boost.gamma0
+        # Tune the mobility for a moving antenna
+        elif v_antenna is not None:
+            self.mobility_coef *= \
+                (1. - laser_profile.propag_direction*v_antenna/c)
 
         # Get total number of virtual particles
         Npr = Nr_grid * npr
@@ -137,6 +152,9 @@ class LaserAntenna( object ):
         if boost is not None:
             self.baseline_z, = boost.static_length( [ self.baseline_z ] )
             self.vz, = boost.velocity( [ self.vz ] )
+        # If there is a moving antenna, assign velocity
+        elif v_antenna != 0:
+            self.vz += v_antenna
 
         # Initialize small-size buffers where the particles charge and currents
         # will be deposited before being added to the regular, large-size array

--- a/fbpic/lpa_utils/laser/laser.py
+++ b/fbpic/lpa_utils/laser/laser.py
@@ -12,7 +12,7 @@ from .direct_injection import add_laser_direct
 from .antenna_injection import LaserAntenna
 
 def add_laser_pulse( sim, laser_profile, gamma_boost=None,
-                    method='direct', z0_antenna=None ):
+                method='direct', z0_antenna=None, v_antenna=0.):
     """
     Introduce a laser pulse in the simulation.
 
@@ -44,6 +44,10 @@ def add_laser_pulse( sim, laser_profile, gamma_boost=None,
     z0_antenna: float, optional (meters)
        Required for the ``antenna`` method: initial position
        (in the lab frame) of the antenna.
+
+    v_antenna: float, optional (meters per second)
+       Only used for the ``antenna`` method: velocity of the antenna
+       (in the lab frame)
 
     Example
     -------
@@ -82,7 +86,8 @@ def add_laser_pulse( sim, laser_profile, gamma_boost=None,
         Nr = sim.fld.interp[0].Nr
         Nm = sim.fld.Nm
         sim.laser_antennas.append(
-            LaserAntenna( laser_profile, z0_antenna, dr, Nr, Nm, boost ))
+            LaserAntenna( laser_profile, z0_antenna, v_antenna,
+                            dr, Nr, Nm, boost ) )
 
     else:
         raise ValueError('Unknown laser method: %s' %method)
@@ -93,7 +98,8 @@ def add_laser_pulse( sim, laser_profile, gamma_boost=None,
 def add_laser( sim, a0, w0, ctau, z0, zf=None, lambda0=0.8e-6,
                cep_phase=0., phi2_chirp=0., theta_pol=0.,
                gamma_boost=None, method='direct',
-               fw_propagating=True, update_spectral=True, z0_antenna=None ):
+               fw_propagating=True, update_spectral=True,
+               z0_antenna=None, v_antenna=0. ):
     """
     Introduce a linearly-polarized, Gaussian laser in the simulation.
 
@@ -186,6 +192,10 @@ def add_laser( sim, a0, w0, ctau, z0, zf=None, lambda0=0.8e-6,
     z0_antenna: float, optional (meters)
        Only for the `antenna` method: initial position (in the lab frame)
        of the antenna. If not provided, then the z0_antenna is set to zf.
+
+    v_antenna: float, optional (meters per second)
+       Only used for the ``antenna`` method: velocity of the antenna
+       (in the lab frame)
     """
     # Pick the propagation direction
     if fw_propagating:
@@ -201,4 +211,4 @@ def add_laser( sim, a0, w0, ctau, z0, zf=None, lambda0=0.8e-6,
 
     # Add it to the simulation
     add_laser_pulse( sim, laser_profile, gamma_boost=gamma_boost,
-        method=method, z0_antenna=z0_antenna )
+        method=method, z0_antenna=z0_antenna, v_antenna=v_antenna )

--- a/tests/test_laser_antenna.py
+++ b/tests/test_laser_antenna.py
@@ -35,9 +35,8 @@ from fbpic.lpa_utils.boosted_frame import BoostConverter
 
 # Parameters
 # ----------
-show = True
+show = True # Whether to show the plots, and check them manually
 write_files = True
-# Whether to show the plots, and check them manually
 use_cuda = True
 
 # Simulation box
@@ -58,7 +57,7 @@ z0 = -5.e-6
 # Propagation
 Lprop = 10.5e-6
 Ntot_step = int(Lprop/(c*dt))
-N_show = 3 # Number of instants in which to show the plots (during propagation)
+N_show = 5 # Number of instants in which to show the plots (during propagation)
 
 # The boost in the case of the boosted frame run
 gamma_boost = 10.
@@ -70,6 +69,13 @@ def test_antenna_labframe(show=False, write_files=False):
     """
     run_and_check_laser_antenna(None, show, write_files)
 
+def test_antenna_labframe_moving( show=False, write_files=False ):
+    """
+    Function that is run by py.test, when doing `python setup.py test`
+    Test the emission of a laser by a moving antenna, in the lab frame
+    """
+    run_and_check_laser_antenna( None, show, write_files, v=-c )
+
 def test_antenna_boostedframe(show=False, write_files=False):
     """
     Function that is run by py.test, when doing `python setup.py test`
@@ -77,7 +83,7 @@ def test_antenna_boostedframe(show=False, write_files=False):
     """
     run_and_check_laser_antenna(gamma_boost, show, write_files)
 
-def run_and_check_laser_antenna(gamma_b, show, write_files):
+def run_and_check_laser_antenna(gamma_b, show, write_files, v=0):
     """
     Generic function, which runs and check the laser antenna for
     both boosted frame and lab frame
@@ -92,6 +98,9 @@ def run_and_check_laser_antenna(gamma_b, show, write_files):
 
     write_files: bool
         Whether to output openPMD data of the laser
+
+    v: float (m/s)
+        Speed of the laser antenna
     """
     # Initialize the simulation object
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, p_zmin=0, p_zmax=0,
@@ -103,8 +112,8 @@ def run_and_check_laser_antenna(gamma_b, show, write_files):
     sim.ptcl = []
 
     # Add the laser
-    add_laser( sim, a0, w0, ctau, z0, zf=zf,
-        method='antenna', z0_antenna=z0_antenna, gamma_boost=gamma_b)
+    add_laser( sim, a0, w0, ctau, z0, zf=zf, method='antenna',
+        z0_antenna=z0_antenna, v_antenna=v, gamma_boost=gamma_b)
 
     for antenna in sim.laser_antennas:
         print(antenna.laser_profile.propag_direction)
@@ -272,4 +281,5 @@ if __name__ == '__main__' :
 
     # Run the testing functions
     test_antenna_labframe(show, write_files)
+    test_antenna_labframe_moving(show, write_files)
     test_antenna_boostedframe(show, write_files)

--- a/tests/test_laser_antenna.py
+++ b/tests/test_laser_antenna.py
@@ -51,9 +51,8 @@ dt = (zmax-zmin)/Nz/c
 w0 = 128.e-6
 ctau = 5.e-6
 a0 = 1.
-z0_antenna = 0.e-6
 zf = 0.e-6
-z0 = -5.e-6
+z0_antenna = 0.e-6
 # Propagation
 Lprop = 10.5e-6
 Ntot_step = int(Lprop/(c*dt))
@@ -67,23 +66,26 @@ def test_antenna_labframe(show=False, write_files=False):
     Function that is run by py.test, when doing `python setup.py test`
     Test the emission of a laser by an antenna, in the lab frame
     """
-    run_and_check_laser_antenna(None, show, write_files)
+    run_and_check_laser_antenna(None, show, write_files, z0=z0_antenna-ctau)
 
 def test_antenna_labframe_moving( show=False, write_files=False ):
     """
     Function that is run by py.test, when doing `python setup.py test`
     Test the emission of a laser by a moving antenna, in the lab frame
     """
-    run_and_check_laser_antenna( None, show, write_files, v=-c )
+    run_and_check_laser_antenna( None, show, write_files, z0=z0_antenna+ctau,
+                                    v=c, forward_propagating=False )
 
 def test_antenna_boostedframe(show=False, write_files=False):
     """
     Function that is run by py.test, when doing `python setup.py test`
     Test the emission of a laser by an antenna, in the boosted frame
     """
-    run_and_check_laser_antenna(gamma_boost, show, write_files)
+    run_and_check_laser_antenna(gamma_boost, show, write_files,
+                                z0=z0_antenna-ctau)
 
-def run_and_check_laser_antenna(gamma_b, show, write_files, v=0):
+def run_and_check_laser_antenna(gamma_b, show, write_files,
+                            z0, v=0, forward_propagating=True ):
     """
     Generic function, which runs and check the laser antenna for
     both boosted frame and lab frame
@@ -113,7 +115,8 @@ def run_and_check_laser_antenna(gamma_b, show, write_files, v=0):
 
     # Add the laser
     add_laser( sim, a0, w0, ctau, z0, zf=zf, method='antenna',
-        z0_antenna=z0_antenna, v_antenna=v, gamma_boost=gamma_b)
+        z0_antenna=z0_antenna, v_antenna=v, gamma_boost=gamma_b,
+        fw_propagating=forward_propagating )
 
     for antenna in sim.laser_antennas:
         print(antenna.laser_profile.propag_direction)
@@ -153,11 +156,12 @@ def run_and_check_laser_antenna(gamma_b, show, write_files, v=0):
         field = getattr(sim.fld.interp[1], fieldtype)\
                             [Nz_half:-(sim.comm.n_guard+sim.comm.n_damp)]
         print( 'Checking %s' %fieldtype )
-        check_fields( factor*field, z, r, info_in_real_part, gamma_b )
+        check_fields( factor*field, z, r, info_in_real_part,
+                        z0, gamma_b, forward_propagating )
         print( 'OK' )
 
-def check_fields( interp1_complex, z, r, info_in_real_part, gamma_b,
-                    show_difference=False ):
+def check_fields( interp1_complex, z, r, info_in_real_part, z0, gamma_b,
+                    forward_propagating, show_difference=False ):
     """
     Check the real and imaginary part of the interpolation grid agree
     with the theory by:
@@ -186,6 +190,9 @@ def check_fields( interp1_complex, z, r, info_in_real_part, gamma_b,
         boost = BoostConverter(gamma_b)
     ctau_b, lambda0_b, Lprop_b, z0_b = \
         boost.copropag_length([ctau, 0.8e-6, Lprop, z0])
+    # Take into account whether the pulse is propagating forward or backward
+    if not forward_propagating:
+        Lprop_b = - Lprop_b
 
     # Fit the on-axis profile to extract a0
     def fit_function(z, a0, z0_phase):

--- a/tests/test_laser_antenna.py
+++ b/tests/test_laser_antenna.py
@@ -118,9 +118,6 @@ def run_and_check_laser_antenna(gamma_b, show, write_files,
         z0_antenna=z0_antenna, v_antenna=v, gamma_boost=gamma_b,
         fw_propagating=forward_propagating )
 
-    for antenna in sim.laser_antennas:
-        print(antenna.laser_profile.propag_direction)
-
     # Calculate the number of steps between each output
     N_step = int( round( Ntot_step/N_show ) )
 


### PR DESCRIPTION
Having a moving antenna can be useful in cases where e.g. a counterpropagating laser needs to be emitted in a moving window.

This PR implements the moving antenna ; for the moment this is incompatible with the boosted frame. (The boosted frame formulas used for the antenna assume that the antenna does not move in the lab frame.)

Note that I allowed the antenna to deposit charge/current in the damp cells. This is because users will typically put the antenna at `zmax` and with the same velocity as the moving window. However, because the moving window moves only once per timestep, and the antenna moves at every half timestep, this means that the antenna typically gets out of the physical box (on a length scale of half a cell).