### PR TITLE
Copy rho arrays to device after exchange (not to host)

### DIFF
--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -368,10 +368,10 @@ class BufferHandler(object):
                 # copy the CPU receiving buffers to the GPU buffers
                 if not gpudirect:
                     if copy_left:
-                        self.d_recv_l[exchange_type].copy_to_host(
+                        self.d_recv_l[exchange_type].copy_to_device(
                             self.recv_l[exchange_type] )
                     if copy_right:
-                        self.d_recv_r[exchange_type].copy_to_host(
+                        self.d_recv_r[exchange_type].copy_to_device(
                             self.recv_r[exchange_type] )
                 if method == 'replace':
                     # Replace the guard cells of the domain with the buffers


### PR DESCRIPTION
PR #247 introduced a bug in the MPI exchange of `rho`, when running on GPU: after the MPI exchanges (on CPU), the MPI buffers were not properly copied to GPU.

For instance, here is the rho diagnostic for the `test_linear_wakefield.py` run with 2 MPI rank and the `dev` branch:
![png image 600 x 500 pixels](https://user-images.githubusercontent.com/6685781/40262561-3079ae32-5abd-11e8-913b-25f65753d0b2.png)


Here is the same diagnostic with the current PR:
![png image 600 x 500 pixels](https://user-images.githubusercontent.com/6685781/40262557-224c9cca-5abd-11e8-9a5b-c6f6c442c53b.png)
