### PR TITLE
Enable restart for arbitrary modes

### DIFF
--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -197,12 +197,12 @@ def load_fields( grid, fieldtype, coord, ts, iteration ):
                                          m=m, iteration=iteration )
         # Select a half-plane and transpose it to conform to FBPIC format
         field_data = field_data[Nr:,:].T
-    elif m==1:
+    else:
         # Extract the real and imaginary part by selecting the angle
         field_data_real, info = ts.get_field( fieldtype, coord,
                             iteration=iteration, m=m, theta=0)
         field_data_imag, _ = ts.get_field( fieldtype, coord,
-                            iteration=iteration, m=m, theta=np.pi/2)
+                            iteration=iteration, m=m, theta=np.pi/(2*m))
         # Select a half-plane and transpose it to conform to FBPIC format
         field_data_real = field_data_real[Nr:,:].T
         field_data_imag = field_data_imag[Nr:,:].T


### PR DESCRIPTION
So far it was not possible to load checkpoints with more than 2 modes. This tiny PR changes that. As a quick test I simulated an off-axis beam with Nm = 4. The plot below shows the Ex field in mode 3 before and after restarting.
![restart](https://user-images.githubusercontent.com/10922951/41127415-2403976e-6aab-11e8-8440-ec1e0830574b.png)
