### PR TITLE
Thread the function that erase charge/current buffers

### DIFF
--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -8,7 +8,7 @@ It defines the high-level Fields class.
 import warnings
 import numpy as np
 from fbpic.utils.threading import nthreads
-from .numba_methods import sum_reduce_2d_array
+from .numba_methods import sum_reduce_2d_array, numba_erase_threading_buffer
 from .utility_methods import get_modified_k
 from .spectral_transform import SpectralTransformer
 from .interpolation_grid import InterpolationGrid
@@ -505,11 +505,12 @@ class Fields(object) :
         # Erase the duplicated deposition buffer
         if not self.use_cuda:
             if fieldtype == 'rho':
-                self.rho_global[:,:,:,:] = 0.
+                numba_erase_threading_buffer( self.rho_global )
             elif fieldtype == 'J':
-                self.Jr_global[:,:,:,:] = 0.
-                self.Jt_global[:,:,:,:] = 0.
-                self.Jz_global[:,:,:,:] = 0.
+                numba_erase_threading_buffer( self.Jr_global )
+                numba_erase_threading_buffer( self.Jt_global )
+                numba_erase_threading_buffer( self.Jz_global )
+
 
     def sum_reduce_deposition_array(self, fieldtype):
         """

--- a/fbpic/fields/numba_methods.py
+++ b/fbpic/fields/numba_methods.py
@@ -10,6 +10,7 @@ c2 = c**2
 import numba
 from fbpic.utils.threading import njit_parallel, prange
 
+
 @njit_parallel
 def numba_correct_currents_curlfree_standard( rho_prev, rho_next, Jp, Jm, Jz,
                             kz, kr, inv_k2, inv_dt, Nz, Nr ):
@@ -293,6 +294,26 @@ def numba_push_eb_comoving( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
 # -----------------------------------------------------------------------
 # Parallel reduction of the global arrays for threads into a single array
 # -----------------------------------------------------------------------
+
+@njit_parallel
+def numba_erase_threading_buffer( global_array ):
+    """
+    Set the threading buffer `global_array` to 0
+
+    Parameter:
+    ----------
+    global_array: 4darray of complexs
+        An array that contains the duplicated charge/current for each thread
+    """
+    nthreads, Nm, Nz, Nr = global_array.shape
+    # Loop in parallel along nthreads
+    for i_thread in prange(nthreads):
+        # Loop through the modes and the grid
+        for m in range(Nm):
+            for iz in range(Nz):
+                for ir in range(Nr):
+                    # Erase values
+                    global_array[i_thread, m, iz, ir] = 0.
 
 @njit_parallel
 def sum_reduce_2d_array( global_array, reduced_array, m ):


### PR DESCRIPTION
I recently observed that, when using a high number of threads on CPU (e.g. 16 in the case I looked at), the part of the code that erases the duplicated buffers for charge/current can take a significant amount of time.

This is certainly due to the fact that this part is written in numpy, and is not threaded. This PR solves this problem by threading this particular operation, using the usual numba synthax.