### PR TITLE
Allow the user to specify the temperature, through `add_new_species`

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -640,7 +640,9 @@ class Simulation(object):
     def add_new_species( self, q, m, n=None, dens_func=None,
                             p_nz=None, p_nr=None, p_nt=None,
                             p_zmin=-np.inf, p_zmax=np.inf,
-                            p_rmin=0, p_rmax=np.inf, uz_m=0.,
+                            p_rmin=0, p_rmax=np.inf,
+                            uz_m=0., ux_m=0., uy_m=0.,
+                            uz_th=0., ux_th=0., uy_th=0.,
                             continuous_injection=True ):
         """
         Create a new species (i.e. an instance of `Particles`) with
@@ -703,9 +705,13 @@ class Simulation(object):
             The maximal r position below which the particles are initialized
             (in the lab frame). Default: upper edge of the simulation box.
 
-        uz_m: float (dimensionless), optional
-           Normalized momentum (in the lab frame)
-           of the injected particles in the z direction
+        uz_m, ux_m, uy_m: floats (dimensionless), optional
+           Normalized mean momenta (in the lab frame)
+           of the injected particles in each direction
+
+        uz_th, ux_th, uy_th: floats (dimensionless), optional
+           Normalized thermal momenta (in the lab frame)
+           in each direction
 
         continuous_injection : bool, optional
            Whether to continuously inject the particles,
@@ -765,6 +771,8 @@ class Simulation(object):
                         Nptheta=p_nt, dt=self.dt, uz_m=uz_m,
                         particle_shape=self.particle_shape,
                         use_cuda=self.use_cuda, grid_shape=self.grid_shape,
+                        ux_m=ux_m, uy_m=uy_m, uz_m=uz_m,
+                        ux_th=ux_th, uy_th=uy_th, uz_th=uz_th,
                         continuous_injection=continuous_injection,
                         dz_particles=dz_particles )
 

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -768,7 +768,7 @@ class Simulation(object):
         new_species = Particles( q=q, m=m, n=n, dens_func=dens_func,
                         Npz=Npz, zmin=p_zmin, zmax=p_zmax,
                         Npr=Npr, rmin=p_rmin, rmax=p_rmax,
-                        Nptheta=p_nt, dt=self.dt, uz_m=uz_m,
+                        Nptheta=p_nt, dt=self.dt,
                         particle_shape=self.particle_shape,
                         use_cuda=self.use_cuda, grid_shape=self.grid_shape,
                         ux_m=ux_m, uy_m=uy_m, uz_m=uz_m,

--- a/tests/test_continuous_injection.py
+++ b/tests/test_continuous_injection.py
@@ -68,7 +68,8 @@ def test_rest_continuous_injection(show=False):
         return( dens )
 
     # Run the test
-    run_continuous_injection( None, dens_func, p_zmin, p_zmax, show )
+    uth = 0.001
+    run_continuous_injection(None, dens_func, uth, p_zmin, p_zmax, show)
 
 def test_boosted_continuous_injection(show=False):
     "Function that is run by py.test, when doing `python setup.py test`"
@@ -92,10 +93,11 @@ def test_boosted_continuous_injection(show=False):
         return( dens )
 
     # Run the test
-    run_continuous_injection( gamma_boost, dens_func, p_zmin, p_zmax, show )
+    uth = 0.001
+    run_continuous_injection(gamma_boost, dens_func, uth, p_zmin, p_zmax, show)
 
 
-def run_continuous_injection( gamma_boost, dens_func,
+def run_continuous_injection( gamma_boost, dens_func, uth,
                               p_zmin, p_zmax, show, N_check=3 ):
     # Chose the time step
     dt = (zmax-zmin)/Nz/c
@@ -107,9 +109,11 @@ def run_continuous_injection( gamma_boost, dens_func,
         use_cuda=use_cuda, gamma_boost=gamma_boost, boundaries='open' )
 
     # Add another species with a different number of particles per cell
+    # and with a finite temperature
     sim.add_new_species( -e, m_e, 0.5*n, dens_func,
                             2*p_nz, 2*p_nr, 2*p_nt,
-                            p_zmin, p_zmax, 0, p_rmax )
+                            p_zmin, p_zmax, 0, p_rmax,
+                            ux_th=uth, uy_th=uth, uz_th=uth )
 
     # Set the moving window, which handles the continuous injection
     # The moving window has an arbitrary velocity (0.7*c) so as to check


### PR DESCRIPTION
While the `Particles` object takes the thermal velocities as argument, the `add_new_species` methods did not.

This PR fixes this. It adds the thermal velocities as arguments, and performs the corresponding boosted-frame transformations if needed (using an approximate formula). 

I also incorporated this change in on of the automated tests.