### PR TITLE
Avoid recompilation when threading is disabled

### DIFF
--- a/fbpic/utils/threading.py
+++ b/fbpic/utils/threading.py
@@ -42,7 +42,8 @@ if threading_enabled:
 # Set the function njit_parallel and prange to the correct object
 if not threading_enabled:
     # Use regular serial compilation function
-    njit_parallel = njit
+    # Uses `cache=True` to avoid re-compilation (not available with threading)
+    njit_parallel = njit( cache=True )
     prange = range
     nthreads = 1
 else:


### PR DESCRIPTION
For rapid testing/debugging of new features, it is often annoying to have to wait for the JIT compilation (especially if the test itself takes very little compute time).

It turns out that Numba has a [caching option](https://numba.pydata.org/numba-doc/dev/user/jit.html#cache), but this can only be used on CPU, and without threading. 

Therefore, this PR enables the caching flag in the case where the user disables threading.
In other words, when performing quick tests/debugging, it is recommended to use `export FBPIC_DISABLE_THREADING=1`, so that caching is activated and compilation time can be saved.