### PR TITLE
[WIP] Allow one electron species per ionization level

### DIFF
--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -31,7 +31,7 @@ def perform_cumsum( input_array ):
     element is 0 and its last element is the total sum of `input_array`)
     """
     cumulative_array = np.zeros( len(input_array)+1, dtype=np.int64 )
-    np.cumsum( input_array, out=cumulative_array[1:] )
+    np.cumsum( input_array, out=cumulative_array[1:], axis=-1 )
     return( cumulative_array )
 
 def reallocate_and_copy_old( species, use_cuda, old_Ntot, new_Ntot ):
@@ -56,7 +56,7 @@ def reallocate_and_copy_old( species, use_cuda, old_Ntot, new_Ntot ):
     """
     # Check if the data is on the GPU
     data_on_gpu = (type(species.w) is not np.ndarray)
-    
+
     # On GPU, use one thread per particle
     if data_on_gpu:
         ptcl_grid_1d, ptcl_block_1d = cuda_tpb_bpg_1d( old_Ntot )

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -13,15 +13,18 @@ from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
-def allocate_empty( N, use_cuda, dtype ):
+def allocate_empty( shape, use_cuda, dtype ):
     """
     Allocate and return an empty array, of size `N` and type `dtype`,
     either on GPU or CPU, depending on whether `use_cuda` is True or False
     """
+    if type(shape) is not tuple:
+        # Convert single scalar to tuple
+        shape = (shape,)
     if use_cuda:
-        return( cuda.device_array( (N,), dtype=dtype ) )
+        return( cuda.device_array( shape, dtype=dtype ) )
     else:
-        return( np.empty( N, dtype=dtype ) )
+        return( np.empty( shape, dtype=dtype ) )
 
 def perform_cumsum( input_array ):
     """

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -45,7 +45,7 @@ def perform_cumsum_2d( input_array ):
     """
     new_shape = (input_array.shape[0], input_array.shape[1]+1)
     cumulative_array = np.zeros( new_shape, dtype=np.int64 )
-    np.cumsum( input_array, out=cumulative_array[:,1:] )
+    np.cumsum( input_array, out=cumulative_array[:,1:], axis=-1 )
     return( cumulative_array )
 
 def reallocate_and_copy_old( species, use_cuda, old_Ntot, new_Ntot ):

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -31,7 +31,21 @@ def perform_cumsum( input_array ):
     element is 0 and its last element is the total sum of `input_array`)
     """
     cumulative_array = np.zeros( len(input_array)+1, dtype=np.int64 )
-    np.cumsum( input_array, out=cumulative_array[1:], axis=-1 )
+    np.cumsum( input_array, out=cumulative_array[1:] )
+    return( cumulative_array )
+
+def perform_cumsum_2d( input_array ):
+    """
+    Return an array containing the cumulative sum of the 2darray `input_array`,
+    where the cumsum is taken along the last axis.
+
+    (The returned array has one more element than `input_array` along the
+    last axis; its first element is 0 and its last element is the
+    total sum of `input_array`)
+    """
+    new_shape = (input_array.shape[0], input_array.shape[1]+1)
+    cumulative_array = np.zeros( new_shape, dtype=np.int64 )
+    np.cumsum( input_array, out=cumulative_array[:,1:] )
     return( cumulative_array )
 
 def reallocate_and_copy_old( species, use_cuda, old_Ntot, new_Ntot ):

--- a/fbpic/particles/elementary_process/ionization/cuda_methods.py
+++ b/fbpic/particles/elementary_process/ionization/cuda_methods.py
@@ -77,7 +77,8 @@ def ionize_ions_cuda( N_batch, batch_size, Ntot, level_max,
 @cuda.jit()
 def copy_ionized_electrons_cuda(
     N_batch, batch_size, elec_old_Ntot, ion_Ntot,
-    cumulative_n_ionized, is_ionized,
+    cumulative_n_ionized, ionized_from,
+    i_level, store_electrons_per_level,
     elec_x, elec_y, elec_z, elec_inv_gamma,
     elec_ux, elec_uy, elec_uz, elec_w,
     elec_Ex, elec_Ey, elec_Ez, elec_Bx, elec_By, elec_Bz,
@@ -93,7 +94,8 @@ def copy_ionized_electrons_cuda(
     if i_batch < N_batch:
         copy_ionized_electrons_batch(
             i_batch, batch_size, elec_old_Ntot, ion_Ntot,
-            cumulative_n_ionized, is_ionized,
+            cumulative_n_ionized, ionized_from,
+            i_level, store_electrons_per_level,
             elec_x, elec_y, elec_z, elec_inv_gamma,
             elec_ux, elec_uy, elec_uz, elec_w,
             elec_Ex, elec_Ey, elec_Ez, elec_Bx, elec_By, elec_Bz,

--- a/fbpic/particles/elementary_process/ionization/cuda_methods.py
+++ b/fbpic/particles/elementary_process/ionization/cuda_methods.py
@@ -21,29 +21,33 @@ copy_ionized_electrons_batch = cuda.jit( copy_ionized_electrons_batch,
                                             device=True, inline=True )
 
 @cuda.jit()
-def ionize_ions_cuda( N_batch, batch_size, Ntot, level_max,
-    n_ionized, is_ionized, ionization_level, random_draw,
+def ionize_ions_cuda( N_batch, batch_size, Ntot,
+    level_start, level_max, n_levels,
+    n_ionized, ionized_from, ionization_level, random_draw,
     adk_prefactor, adk_power, adk_exp_prefactor,
     ux, uy, uz, Ex, Ey, Ez, Bx, By, Bz, w, w_times_level ):
     """
     For each ion macroparticle, decide whether it is going to
     be further ionized during this timestep, based on the ADK rate.
 
-    Increment the elements in `ionization_level` accordingly, and update the
+    Increment the elements in `ionization_level` accordingly, and update
     `w_times_level` of the ions to take into account the change in level
     of the corresponding macroparticle.
 
     For the purpose of counting and creating the corresponding electrons,
-    `is_ionized` (one element per macroparticle) is set to 1 at the position
-    of the ionized ions, and `n_ionized` (one element per batch) counts
-    the total number of ionized particles in the current batch.
+    `ionized_from` (one element per macroparticle) is set to -1 at the position
+    of the unionized ions, and to the level (before ionization) otherwise
+    `n_ionized` (one element per batch, and per ionizable level that needs
+    to be distinguished) counts the total number of ionized particles
+    in the current batch.
     """
     # Loop over batches of particles
     i_batch = cuda.grid(1)
     if i_batch < N_batch:
 
         # Set the count of ionized particles in the batch to 0
-        n_ionized[i_batch] = 0
+        for i_level in range(n_levels):
+            n_ionized[i_level, i_batch] = 0
 
         # Loop through the batch
         N_max = min( (i_batch+1)*batch_size, Ntot )
@@ -53,7 +57,7 @@ def ionize_ions_cuda( N_batch, batch_size, Ntot, level_max,
             # has already been reached for this macroparticle
             level = ionization_level[ip]
             if level >= level_max:
-                is_ionized[ip] = 0
+                ionized_from[ip] = -1
                 continue
 
             # Calculate the amplitude of the electric field,
@@ -66,13 +70,18 @@ def ionize_ions_cuda( N_batch, batch_size, Ntot, level_max,
             # Ionize particles
             if random_draw[ip] < p:
                 # Set the corresponding flag and update particle count
-                is_ionized[ip] = 1
-                n_ionized[i_batch] += 1
+                ionized_from[ip] = level-level_start
+                if n_levels == 1:
+                    # No need to distinguish ionization levels
+                    n_ionized[0, i_batch] += 1
+                else:
+                    # Distinguish count for each ionizable level
+                    n_ionized[level-level_start, i_batch] += 1
                 # Update the ionization level and the corresponding weight
                 ionization_level[ip] += 1
                 w_times_level[ip] = w[ip] * ionization_level[ip]
             else:
-                is_ionized[ip] = 0
+                ionized_from[ip] = -1
 
 @cuda.jit()
 def copy_ionized_electrons_cuda(

--- a/fbpic/particles/elementary_process/ionization/inline_functions.py
+++ b/fbpic/particles/elementary_process/ionization/inline_functions.py
@@ -80,7 +80,17 @@ def copy_ionized_electrons_batch(
     N_max = min( (i_batch+1)*batch_size, ion_Ntot )
     for ion_index in range( i_batch*batch_size, N_max ):
 
-        if is_ionized[ion_index] == 1:
+        # Determine if a new electron should be created from this ion
+        create_electron = False
+        # If electrons are not distinguished by level, take all ionized ions
+        if (not store_electrons_per_level) and ionized_from[ion_index] >=0:
+            create_electron = True
+        # If electrons are to be distinguished by level, take only those
+        # of the corresponding i_level
+        if store_electrons_per_level and ionized_from[ion_index] == i_level:
+            create_electron = True
+
+        if create_electron:
             # Copy the ion data to the current electron_index
             elec_x[elec_index] = ion_x[ion_index]
             elec_y[elec_index] = ion_y[ion_index]

--- a/fbpic/particles/elementary_process/ionization/inline_functions.py
+++ b/fbpic/particles/elementary_process/ionization/inline_functions.py
@@ -52,7 +52,8 @@ def get_ionization_probability( E, gamma, prefactor, power, exp_prefactor ):
 
 def copy_ionized_electrons_batch(
     i_batch, batch_size, elec_old_Ntot, ion_Ntot,
-    cumulative_n_ionized, is_ionized,
+    cumulative_n_ionized, ionized_from,
+    i_level, store_electrons_per_level,
     elec_x, elec_y, elec_z, elec_inv_gamma,
     elec_ux, elec_uy, elec_uz, elec_w,
     elec_Ex, elec_Ey, elec_Ez, elec_Bx, elec_By, elec_Bz,
@@ -65,14 +66,16 @@ def copy_ionized_electrons_batch(
 
     Particles are handled by batch: this functions goes through one batch
     of ion macroparticles and checks which macroparticles have been ionized
-    during the present timestep (using the flag `is_ionized`).
+    during the present timestep (using the flag `ionized_from`, which
+    is -1 if the ion is not ionized, and has the value of the original level
+    otherwise).
     In order to know at which position, in the electron array, this data
     should be copied, the cumulated number of electrons `cumulative_n_ionized`
     (one element per batch) is used.
     """
     # Electron index: this is incremented each time
     # an ionized electron is identified
-    elec_index = elec_old_Ntot + cumulative_n_ionized[i_batch]
+    elec_index = elec_old_Ntot + cumulative_n_ionized[i_level, i_batch]
     # Loop through the ions in this batch
     N_max = min( (i_batch+1)*batch_size, ion_Ntot )
     for ion_index in range( i_batch*batch_size, N_max ):

--- a/fbpic/particles/elementary_process/ionization/ionizer.py
+++ b/fbpic/particles/elementary_process/ionization/ionizer.py
@@ -252,7 +252,7 @@ class Ionizer(object):
         # Reallocate electron species (on CPU or GPU depending on `use_cuda`),
         # to accomodate the electrons produced by ionization,
         # and copy the old electrons to the new arrays
-        assert len(self.target_species == n_levels)
+        assert len(self.target_species) == n_levels
         for i_level, elec in enumerate(self.target_species):
             old_Ntot = elec.Ntot
             new_Ntot = old_Ntot + cumulative_n_ionized[i_level,-1]

--- a/fbpic/particles/elementary_process/ionization/ionizer.py
+++ b/fbpic/particles/elementary_process/ionization/ionizer.py
@@ -210,7 +210,7 @@ class Ionizer(object):
                                     dtype=np.int64 )
         # Draw random numbers
         if self.use_cuda:
-            random_draw = allocate_empty(ion.Ntot, use_cuda, dtype=np.float32)
+            random_draw = allocate_empty( ion.Ntot, use_cuda, dtype=np.float32)
             self.prng.uniform( random_draw )
         else:
             random_draw = np.random.rand( ion.Ntot )
@@ -244,8 +244,9 @@ class Ionizer(object):
         if np.all( cumulative_n_ionized[:,-1] == 0 ):
             return
         # Copy the cumulated number of electrons back on GPU
+        # (Keep a copy on the CPU)
         if use_cuda:
-            cumulative_n_ionized = cuda.to_device( cumulative_n_ionized )
+            d_cumulative_n_ionized = cuda.to_device( cumulative_n_ionized )
 
         # Loop over the electron species associated to each level
         # (when store_electrons_per_level is False, there is a single species)
@@ -261,7 +262,7 @@ class Ionizer(object):
             if use_cuda:
                 copy_ionized_electrons_cuda[ batch_grid_1d, batch_block_1d ](
                     N_batch, self.batch_size, old_Ntot, ion.Ntot,
-                    cumulative_n_ionized, ionized_from,
+                    d_cumulative_n_ionized, ionized_from,
                     i_level, self.store_electrons_per_level,
                     elec.x, elec.y, elec.z, elec.inv_gamma,
                     elec.ux, elec.uy, elec.uz, elec.w,
@@ -274,7 +275,7 @@ class Ionizer(object):
             else:
                 copy_ionized_electrons_numba(
                     N_batch, self.batch_size, old_Ntot, ion.Ntot,
-                    cumulative_n_ionized, ionized_from,
+                    d_cumulative_n_ionized, ionized_from,
                     i_level, self.store_electrons_per_level,
                     elec.x, elec.y, elec.z, elec.inv_gamma,
                     elec.ux, elec.uy, elec.uz, elec.w,

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -411,7 +411,7 @@ class Particles(object) :
             ratio_w_electron_photon, boost )
 
 
-    def make_ionizable( self, element, target_species, level_start=0):
+    def make_ionizable(self, element, target_species, level_start=0):
         """
         Make this species ionizable.
 
@@ -433,9 +433,15 @@ class Particles(object) :
             The atomic symbol of the considered ionizable species
             (e.g. 'He', 'N' ;  do not use 'Helium' or 'Nitrogen')
 
-        target_species: an fbpic.Particles object
+        target_species: a `Particles` object or a list of `Particles` objects
             Stores the electron macroparticles that are created in
-            the ionization process.
+            the ionization process. If a single `Particles` object is
+            passed, than electrons from all ionization levels are stored
+            into this object. If a list is passed, then it needs to contain
+            as many `Particles` object as the number of ionizable levels
+            (starting from `level_start`). In this case, the electrons from
+            each distinct ionizable level will be stored into these
+            separate objects.
 
         level_start: int
             The ionization level at which the macroparticles are initially

--- a/tests/test_ionization.py
+++ b/tests/test_ionization.py
@@ -38,7 +38,7 @@ from opmd_viewer import OpenPMDTimeSeries
 # ----------
 use_cuda = True
 
-def run_simulation( gamma_boost ):
+def run_simulation( gamma_boost, use_separate_electron_species ):
     """
     Run a simulation with a laser pulse going through a gas jet of ionizable
     N5+ atoms, and check the fraction of atoms that are in the N5+ state.
@@ -47,6 +47,9 @@ def run_simulation( gamma_boost ):
     ----------
     gamma_boost: float
         The Lorentz factor of the frame in which the simulation is carried out.
+    use_separate_electron_species: bool
+        Whether to use separate electron species for each level, or
+        a single electron species for all levels.
     """
     # The simulation box
     zmax_lab = 20.e-6    # Length of the box along z (meters)
@@ -60,7 +63,7 @@ def run_simulation( gamma_boost ):
     p_zmax = 15.e-6
     p_rmin = 0.      # Minimal radial position of the plasma (meters)
     p_rmax = 100.e-6 # Maximal radial position of the plasma (meters)
-    n_e = 1.         # The plasma density is chosen very low,
+    n_atoms = 0.2    # The atomic density is chosen very low,
                      # to avoid collective effects
     p_nz = 2         # Number of particles per cell along z
     p_nr = 1         # Number of particles per cell along r
@@ -72,7 +75,7 @@ def run_simulation( gamma_boost ):
     beta_boost = np.sqrt( 1. - 1./gamma_boost**2 )
     zmin, zmax = boost.static_length( [zmin_lab, zmax_lab] )
     p_zmin, p_zmax = boost.static_length( [p_zmin, p_zmax] )
-    n_e, = boost.static_density( [n_e] )
+    n_atoms, = boost.static_density( [n_atoms] )
     # Increase the number of particles per cell in order to keep sufficient
     # statistics for the evaluation of the ionization fraction
     if gamma_boost > 1:
@@ -110,20 +113,40 @@ def run_simulation( gamma_boost ):
     # The diagnostics
     diag_period = N_step-1 # Period of the diagnostics in number of timesteps
 
-    # Initialize the simulation object, with the electrons
-    # No macroparticles created because we do not pass n, p_nz, p_nr, etc
-    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-        zmin=zmin, initialize_ions=False,
-        v_comoving=v_plasma, use_galilean=False,
-        boundaries='open', use_cuda=use_cuda )
-    elec = sim.ptcl[0]
-    # Add the N atoms
-    atoms = sim.add_new_species( q=0, m=14.*m_p, n=0.2*n_e,
+    # Initial ionization level of the Nitrogen atoms
+    level_start = 2
+    # Initialize the simulation object, with the neutralizing electrons
+    # No particles are created because we do not pass the density
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
+        initialize_ions=False, v_comoving=v_plasma,
+        use_galilean=False, boundaries='open', use_cuda=use_cuda )
+    sim.ptcl = []
+    # Add the charge-neutralizing electrons
+    elec = sim.add_new_species( q=-e, m=m_e, n=level_start*n_atoms,
                         p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
                         p_zmin=p_zmin, p_zmax=p_zmax,
                         p_rmin=p_rmin, p_rmax=p_rmax,
                         continuous_injection=False, uz_m=uz_m )
-    atoms.make_ionizable(element='N', level_start=0, target_species=elec)
+    # Add the N atoms
+    ions = sim.add_new_species( q=0, m=14.*m_p, n=n_atoms,
+                        p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
+                        p_zmin=p_zmin, p_zmax=p_zmax,
+                        p_rmin=p_rmin, p_rmax=p_rmax,
+                        continuous_injection=False, uz_m=uz_m )
+    # Add the target electrons
+    if use_separate_electron_species:
+        # Use a dictionary of electron species: one per ionizable level
+        elec_species_dict = {}
+        for i_level in range(level_start, 7): # N can go up to N7+
+            elec_species_dict[i_level] = sim.add_new_species( q=-e, m=m_e )
+        target_species = [ elec_species_dict[i_level] \
+                            for i_level in range(level_start, 7) ]
+    else:
+        # Use the pre-existing, charge-neutralizing electrons
+        target_species = elec
+    # Define ionization
+    ions.make_ionizable( element='N', level_start=level_start,
+                        target_species=target_species )
     # Set the moving window
     sim.set_moving_window( v=v_plasma )
 
@@ -132,24 +155,24 @@ def run_simulation( gamma_boost ):
         ExternalField( laser_func, 'Ex', E0, 0. ),
         ExternalField( laser_func, 'By', B0, 0. ) ]
 
-    # Add a field diagnostic
+    # Add a particle diagnostic
     sim.diags = [ ParticleDiagnostic( diag_period,
-        {"ions":sim.ptcl[1]}, write_dir='tests/diags', comm=sim.comm) ]
+        {"ions":ions}, write_dir='tests/diags', comm=sim.comm) ]
     if gamma_boost > 1:
         T_sim_lab = (2.*40.*lambda0_lab + zmax_lab-zmin_lab)/c
         sim.diags.append(
             BoostedParticleDiagnostic(zmin_lab, zmax_lab, v_lab=0.,
                 dt_snapshots_lab=T_sim_lab/2., Ntot_snapshots_lab=3,
                 gamma_boost=gamma_boost, period=diag_period,
-                fldobject=sim.fld, species={"ions": sim.ptcl[1]},
+                fldobject=sim.fld, species={"ions":ions},
                 comm=sim.comm, write_dir='tests/lab_diags') )
 
     # Run the simulation
     sim.step( N_step, use_true_rho=True )
 
     # Check the fraction of N5+ ions at the end of the simulation
-    w = sim.ptcl[1].w
-    ioniz_level = sim.ptcl[1].ionizer.ionization_level
+    w = ions.w
+    ioniz_level = ions.ionizer.ionization_level
     # Get the total number of N atoms/ions (all ionization levels together)
     ntot = w.sum()
     # Get the total number of N5+ ions
@@ -158,6 +181,13 @@ def run_simulation( gamma_boost ):
     N5_fraction = n_N5 / ntot
     print('N5+ fraction: %.4f' %N5_fraction)
     assert ((N5_fraction > 0.30) and (N5_fraction < 0.34))
+
+    # When different electron species are created, check the fraction of
+    # each electron species
+    if use_separate_electron_species:
+        for i_level in range(level_start, 7):
+            n_N = w[ioniz_level == i_level].sum()
+            assert np.allclose( elec_species_dict[i_level].w.sum(), n_N )
 
     # Check consistency in the regular openPMD diagnostics
     ts = OpenPMDTimeSeries('./tests/diags/hdf5/')
@@ -183,10 +213,10 @@ def run_simulation( gamma_boost ):
         shutil.rmtree('./tests/lab_diags/')
 
 def test_ionization_labframe():
-    run_simulation(1.)
+    run_simulation(1., use_separate_electron_species=True)
 
 def test_ionization_boostedframe():
-    run_simulation(2.)
+    run_simulation(2., use_separate_electron_species=False)
 
 # Run the tests
 if __name__ == '__main__':


### PR DESCRIPTION
Several users requested that the electrons coming from different ionization level be distinguishable.

In this PR, this is done by using a separate electron species for each ionization level. (The option to use a single electron species - the previous behavior - is still kept, since using separate electron species typically impact the performance.)

The current branch is working but I am not a fan of the API I came up with. It is very error-prone (i.e. the user has to setup the species in the right order, and it is easy to get confused about which species corresponds to which ionization level.) @MKirchen @soerenjalas @hightower8083 Any suggestion for a better API?