### PR TITLE
Reduce duplication for the Vay pusher on CPU and GPU

### DIFF
--- a/fbpic/particles/push/inline_functions.py
+++ b/fbpic/particles/push/inline_functions.py
@@ -1,0 +1,48 @@
+# Copyright 2018, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines inline functions that are compiled for both GPU and CPU, and
+used in the functions for the particle pusher
+"""
+import math
+
+def push_p_vay( ux_i, uy_i, uz_i, inv_gamma_i,
+    Ex, Ey, Ez, Bx, By, Bz, econst, bconst ):
+    """
+    Push at single macroparticle, using the Vay pusher
+    """
+    # Get the magnetic rotation vector
+    taux = bconst*Bx
+    tauy = bconst*By
+    tauz = bconst*Bz
+    tau2 = taux**2 + tauy**2 + tauz**2
+
+    # Get the momenta at the half timestep
+    uxp = ux_i + econst*Ex \
+    + inv_gamma_i*( uy_i*tauz - uz_i*tauy )
+    uyp = uy_i + econst*Ey \
+    + inv_gamma_i*( uz_i*taux - ux_i*tauz )
+    uzp = uz_i + econst*Ez \
+    + inv_gamma_i*( ux_i*tauy - uy_i*taux )
+    sigma = 1 + uxp**2 + uyp**2 + uzp**2 - tau2
+    utau = uxp*taux + uyp*tauy + uzp*tauz
+
+    # Get the new 1./gamma
+    inv_gamma_f = math.sqrt(
+        2./( sigma + math.sqrt( sigma**2 + 4*(tau2 + utau**2 ) ) ) )
+
+    # Reuse the tau and utau arrays to save memory
+    tx = inv_gamma_f*taux
+    ty = inv_gamma_f*tauy
+    tz = inv_gamma_f*tauz
+    ut = inv_gamma_f*utau
+    s = 1./( 1 + tau2*inv_gamma_f**2 )
+
+    # Get the new u
+    ux_f = s*( uxp + tx*ut + uyp*tz - uzp*ty )
+    uy_f = s*( uyp + ty*ut + uzp*tx - uxp*tz )
+    uz_f = s*( uzp + tz*ut + uxp*ty - uyp*tx )
+
+    return( ux_f, uy_f, uz_f, inv_gamma_f )

--- a/fbpic/particles/push/numba_methods.py
+++ b/fbpic/particles/push/numba_methods.py
@@ -5,10 +5,13 @@
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the particle push methods on the CPU with numba.
 """
-import math
 import numba
 from fbpic.utils.threading import njit_parallel, prange
 from scipy.constants import c, e
+# Import inline functions
+from .inline_functions import push_p_vay
+# Compile the inline functions for CPU
+push_p_vay = numba.njit(push_p_vay)
 
 @njit_parallel
 def push_x_numba( x, y, z, ux, uy, uz, inv_gamma, Ntot, dt,
@@ -51,7 +54,7 @@ def push_p_after_plane_numba( z, z_plane, ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz, q, m, Ntot, dt ) :
     """
     Advance the particles' momenta, using numba.
-    Only the particles that are located beyond the plane z=z_plane 
+    Only the particles that are located beyond the plane z=z_plane
     have their momentum modified ; the others particles move ballistically.
     """
     # Set a few constants
@@ -93,43 +96,3 @@ def push_p_ioniz_numba( ux, uy, uz, inv_gamma,
             econst, bconst )
 
     return ux, uy, uz, inv_gamma
-
-@numba.njit
-def push_p_vay( ux_i, uy_i, uz_i, inv_gamma_i,
-                Ex, Ey, Ez, Bx, By, Bz, econst, bconst ):
-    """
-    Push at single macroparticle, using the Vay pusher
-    """
-    # Get the magnetic rotation vector
-    taux = bconst*Bx
-    tauy = bconst*By
-    tauz = bconst*Bz
-    tau2 = taux**2 + tauy**2 + tauz**2
-
-    # Get the momenta at the half timestep
-    uxp = ux_i + econst*Ex \
-    + inv_gamma_i*( uy_i*tauz - uz_i*tauy )
-    uyp = uy_i + econst*Ey \
-    + inv_gamma_i*( uz_i*taux - ux_i*tauz )
-    uzp = uz_i + econst*Ez \
-    + inv_gamma_i*( ux_i*tauy - uy_i*taux )
-    sigma = 1 + uxp**2 + uyp**2 + uzp**2 - tau2
-    utau = uxp*taux + uyp*tauy + uzp*tauz
-
-    # Get the new 1./gamma
-    inv_gamma_f = math.sqrt(
-        2./( sigma + math.sqrt( sigma**2 + 4*(tau2 + utau**2 ) ) ) )
-
-    # Reuse the tau and utau variables to save memory
-    tx = inv_gamma_f*taux
-    ty = inv_gamma_f*tauy
-    tz = inv_gamma_f*tauz
-    ut = inv_gamma_f*utau
-    s = 1./( 1 + tau2*inv_gamma_f**2 )
-
-    # Get the new u
-    ux_f = s*( uxp + tx*ut + uyp*tz - uzp*ty )
-    uy_f = s*( uyp + ty*ut + uzp*tx - uxp*tz )
-    uz_f = s*( uzp + tz*ut + uxp*ty - uyp*tx )
-
-    return( ux_f, uy_f, uz_f, inv_gamma_f )


### PR DESCRIPTION
@PierrePelletier recently noticed that the function defining the vay pusher was duplicated for CPU and GPU, whereas we could use the same "inline function" trick that is used for ionization and gathering.
(i.e. defining the Python function only once, and then compiling it for CPU or GPU when importing it.)

This PR implements the corresponding change.

@PierrePelletier: Thanks again for pointing this out :)