### PR TITLE
Close #267 Per-species density diagnostic

### DIFF
--- a/docs/source/api_reference/diagnostics.rst
+++ b/docs/source/api_reference/diagnostics.rst
@@ -1,7 +1,7 @@
 The openPMD diagnostics
 =======================
 
-During a simulation, FBPIC outputs diagnostics of fields and 
+During a simulation, FBPIC outputs diagnostics of fields and
 particles in the form of `openPMD files <https://github.com/openPMD>`__.
 
 A diagnostic can be directly added to simulation (or removed) by
@@ -24,6 +24,11 @@ Particle diagnostic
 ~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: fbpic.openpmd_diag.ParticleDiagnostic
+
+Particle density diagnostic
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: fbpic.openpmd_diag.ParticleDensityDiagnostic
 
 Back-transformed diagnostics (boosted-frame simulations)
 --------------------------------------------------------

--- a/docs/source/example_input/ionization_script.py
+++ b/docs/source/example_input/ionization_script.py
@@ -26,8 +26,9 @@ from scipy.constants import c, e, m_e, m_p
 # Import the relevant structures from fbpic
 from fbpic.main import Simulation
 from fbpic.lpa_utils.laser import add_laser
-from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic, \
-     set_periodic_checkpoint, restart_from_checkpoint
+from fbpic.openpmd_diag import FieldDiagnostic, \
+    ParticleDiagnostic, ParticleDensityDiagnostic, \
+    set_periodic_checkpoint, restart_from_checkpoint
 
 # ----------
 # Parameters
@@ -147,12 +148,17 @@ if __name__ == '__main__':
     # Configure the moving window
     sim.set_moving_window( v=v_window )
 
-    # Add a diagnostics
+    # Add diagnostics
     sim.diags = [
                 FieldDiagnostic( diag_period, sim.fld, comm=sim.comm ),
                 ParticleDiagnostic( diag_period,
                     {"electrons from N": elec_from_N, "electrons": elec},
-                    comm=sim.comm )
+                    comm=sim.comm ),
+                # Since rho from `FieldDiagnostic` is 0 almost everywhere
+                # (neutral plasma), it is useful to see the charge density
+                # of individual particles
+                ParticleDensityDiagnostic( diag_period, sim,
+                    {"electrons": elec} )
                 ]
     # Add checkpoints
     if save_checkpoints:

--- a/docs/source/example_input/ionization_script.py
+++ b/docs/source/example_input/ionization_script.py
@@ -27,7 +27,7 @@ from scipy.constants import c, e, m_e, m_p
 from fbpic.main import Simulation
 from fbpic.lpa_utils.laser import add_laser
 from fbpic.openpmd_diag import FieldDiagnostic, \
-    ParticleDiagnostic, ParticleDensityDiagnostic, \
+    ParticleDiagnostic, ParticleChargeDensityDiagnostic, \
     set_periodic_checkpoint, restart_from_checkpoint
 
 # ----------
@@ -157,7 +157,7 @@ if __name__ == '__main__':
                 # Since rho from `FieldDiagnostic` is 0 almost everywhere
                 # (neutral plasma), it is useful to see the charge density
                 # of individual particles
-                ParticleDensityDiagnostic( diag_period, sim,
+                ParticleChargeDensityDiagnostic( diag_period, sim,
                     {"electrons": elec} )
                 ]
     # Add checkpoints

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -435,17 +435,10 @@ def get_space_charge_fields( sim, ptcl, direction='forward') :
         gamma = gamma_sum/Ntot
 
     # Project the charge and currents onto the local subdomain
-    sim.fld.erase('rho')
-    sim.fld.erase('J')
-    ptcl.deposit( sim.fld, 'rho' )
-    ptcl.deposit( sim.fld, 'J' )
-    sim.fld.sum_reduce_deposition_array('rho')
-    sim.fld.sum_reduce_deposition_array('J')
-    sim.fld.divide_by_volume('rho')
-    sim.fld.divide_by_volume('J')
-    # Exchange guard cells
-    sim.comm.exchange_fields( sim.fld.interp, 'rho', 'add' )
-    sim.comm.exchange_fields( sim.fld.interp, 'J', 'add')
+    sim.deposit( 'rho', exchange=True, species_list=[ptcl],
+                    update_spectral=False )
+    sim.deposit( 'J', exchange=True, species_list=[ptcl],
+                    update_spectral=False )
 
     # Create a global field object across all subdomains, and copy the sources
     # (Space-charge calculation is a global operation)

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -523,7 +523,13 @@ class Simulation(object):
             the fields to the spectral grid. (The corresponding flag in
             fld.exchanged_source is set accordingly.)
 
-        TODO
+        update_spectral: bool
+            Whether to update the value of the deposited field in
+            spectral space.
+
+        species_list: list of `Particles` objects, or None
+            The species which that should deposit their charge/current.
+            If this is None, all species (and antennas) deposit.
         """
         # Shortcut
         fld = self.fld

--- a/fbpic/openpmd_diag/__init__.py
+++ b/fbpic/openpmd_diag/__init__.py
@@ -5,7 +5,7 @@ It imports the objects that allow to produce output in openPMD format.
 
 from .field_diag import FieldDiagnostic
 from .particle_diag import ParticleDiagnostic
-from .particledensity_diag import ParticleDensityDiagnostic
+from .particle_density_diag import ParticleDensityDiagnostic
 from .boosted_field_diag import BoostedFieldDiagnostic
 from .boosted_particle_diag import BoostedParticleDiagnostic
 from .checkpoint_restart import set_periodic_checkpoint, \

--- a/fbpic/openpmd_diag/__init__.py
+++ b/fbpic/openpmd_diag/__init__.py
@@ -13,4 +13,5 @@ from .checkpoint_restart import set_periodic_checkpoint, \
 
 __all__ = ['FieldDiagnostic', 'ParticleDiagnostic',
 	'BoostedFieldDiagnostic', 'BoostedParticleDiagnostic',
-    'set_periodic_checkpoint', 'restart_from_checkpoint']
+        'ParticleDensityDiagnostic',
+        'set_periodic_checkpoint', 'restart_from_checkpoint']

--- a/fbpic/openpmd_diag/__init__.py
+++ b/fbpic/openpmd_diag/__init__.py
@@ -5,7 +5,7 @@ It imports the objects that allow to produce output in openPMD format.
 
 from .field_diag import FieldDiagnostic
 from .particle_diag import ParticleDiagnostic
-from .particle_density_diag import ParticleDensityDiagnostic
+from .particle_density_diag import ParticleChargeDensityDiagnostic
 from .boosted_field_diag import BoostedFieldDiagnostic
 from .boosted_particle_diag import BoostedParticleDiagnostic
 from .checkpoint_restart import set_periodic_checkpoint, \
@@ -13,5 +13,5 @@ from .checkpoint_restart import set_periodic_checkpoint, \
 
 __all__ = ['FieldDiagnostic', 'ParticleDiagnostic',
 	'BoostedFieldDiagnostic', 'BoostedParticleDiagnostic',
-        'ParticleDensityDiagnostic',
+        'ParticleChargeDensityDiagnostic',
         'set_periodic_checkpoint', 'restart_from_checkpoint']

--- a/fbpic/openpmd_diag/__init__.py
+++ b/fbpic/openpmd_diag/__init__.py
@@ -1,23 +1,11 @@
 """
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It imports the objects that allow to produce output in openPMD format.
-
-Usage
------
-In the Warp main script, initialize a
-FieldDiagnostic and a ParticleDiagnostic :
-    from openpmd_diag import FieldDiagnostic, ParticleDiagnostic
-    diag1 = FieldDiagnostic( period=50, top=top, w3d=w3d, em=em )
-    diag2 = ParticleDiagnostic( period=50, top=top, w3d=w3d,
-                     species={"electrons":elec} )
-
-Then pass the method diag.write to installafterstep :
-    installafterstep( diag1.write )
-    installafterstep( diag2.write )
 """
 
 from .field_diag import FieldDiagnostic
 from .particle_diag import ParticleDiagnostic
+from .particledensity_diag import ParticleDensityDiagnostic
 from .boosted_field_diag import BoostedFieldDiagnostic
 from .boosted_particle_diag import BoostedParticleDiagnostic
 from .checkpoint_restart import set_periodic_checkpoint, \

--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -262,7 +262,7 @@ class FieldDiagnostic(OpenPMDDiagnostic):
                 if fieldtype.startswith("rho"):
                     # Setup the dataset
                     dset = field_grp.require_dataset(
-                        "rho", data_shape, dtype='f8')
+                        fieldtype, data_shape, dtype='f8')
                     self.setup_openpmd_mesh_component( dset, fieldtype )
                     # Setup the record to which it belongs
                     self.setup_openpmd_mesh_record( dset, fieldtype, dz, zmin )

--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -257,13 +257,15 @@ class FieldDiagnostic(OpenPMDDiagnostic):
             for fieldtype in self.fieldtypes:
 
                 # Scalar field
-                if fieldtype == "rho":
+                # e.g. 'rho', but also 'rho_electron' in the case of
+                # the sub-class ParticleDensityDiagnostic
+                if fieldtype.startswith("rho"):
                     # Setup the dataset
                     dset = field_grp.require_dataset(
                         "rho", data_shape, dtype='f8')
-                    self.setup_openpmd_mesh_component( dset, "rho" )
+                    self.setup_openpmd_mesh_component( dset, fieldtype )
                     # Setup the record to which it belongs
-                    self.setup_openpmd_mesh_record( dset, "rho", dz, zmin )
+                    self.setup_openpmd_mesh_record( dset, fieldtype, dz, zmin )
 
                 # Vector field
                 elif fieldtype in ["E", "B", "J"]:

--- a/fbpic/openpmd_diag/generic_diag.py
+++ b/fbpic/openpmd_diag/generic_diag.py
@@ -188,6 +188,9 @@ class OpenPMDDiagnostic(object) :
         quantity : string
            The name of the record considered
         """
+        if quantity.startswith('rho'): # particle density such as rho_electrons
+            quantity = 'rho'
+
         dset.attrs["unitDimension"] = unit_dimension_dict[quantity]
         # No time offset (approximation)
         dset.attrs["timeOffset"] = 0.

--- a/fbpic/openpmd_diag/particle_density_diag.py
+++ b/fbpic/openpmd_diag/particle_density_diag.py
@@ -1,0 +1,112 @@
+# Copyright 2018, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file defines the class ParticleDensityDiagnostic.
+"""
+import os
+import numpy as np
+from .field_diag import FieldDiagnostic
+
+class ParticleDensityDiagnostic(FieldDiagnostic):
+    """
+    Class that defines a diagnostic for particle density
+    """
+
+    def __init__(self, period, sim, species={}, write_dir=None,
+                 iteration_min=0, iteration_max=np.inf ) :
+        """
+        Initialize the field diagnostic.
+
+        Parameters
+        ----------
+        period : int
+            The period of the diagnostics, in number of timesteps.
+            (i.e. the diagnostics are written whenever the number
+            of iterations is divisible by `period`)
+
+        TODO
+
+        write_dir : string, optional
+            The POSIX path to the directory where the results are
+            to be written. If none is provided, this will be the path
+            of the current working directory.
+
+        iteration_min, iteration_max: ints
+            The iterations between which data should be written
+            (`iteration_min` is inclusive, `iteration_max` is exclusive)
+        """
+        # Build the list of fieldtypes
+        fieldtypes = []
+        for species_name in species.keys():
+            fieldtypes.append( 'rho_%s' %species_name )
+
+        # General setup
+        FieldDiagnostic.__init__(self, period, fldobject=sim.fld,
+                    comm=sim.comm, fieldtypes=fieldtypes, write_dir=write_dir,
+                    iteration_min=iteration_min, iteration_max=iteration_max )
+
+        # Register the arguments
+        self.sim = sim
+        self.species = species
+
+    def write_hdf5( self, iteration ) :
+        """
+        Write an HDF5 file that complies with the OpenPMD standard
+
+        Parameter
+        ---------
+        iteration : int
+             The current iteration number of the simulation.
+        """
+        sim = self.sim
+
+        # Loop over the requested species
+        for species_name in self.species.keys():
+
+            # Deposit the charge density for this species ; this does not
+            # affect the spectral space, and therefore it does not affect
+            # the simulation
+            species_object = self.species[species_name]
+            sim.deposit( 'rho', species_list=[species_object],
+                        update_spectral=False, exchange=True )
+
+            # If needed: Receive data from the GPU
+            if self.fld.use_cuda :
+                self.fld.receive_fields_from_gpu()
+
+            # Extract information needed for the openPMD attributes
+            dt = self.fld.dt
+            time = iteration * dt
+            dz = self.fld.interp[0].dz
+            zmin, _ = self.comm.get_zmin_zmax(
+                    local=False, with_damp=False, with_guard=False )
+            Nz, _ = self.comm.get_Nz_and_iz(
+                    local=False, with_damp=False, with_guard=False )
+
+            # Create the file with these attributes
+            filename = "data%08d.h5" %iteration
+            fullpath = os.path.join( self.write_dir, "hdf5", filename )
+            self.create_file_empty_meshes(
+                fullpath, iteration, time, Nz, zmin, dz, dt )
+
+            # Open the file again, and get the field path
+            f = self.open_file( fullpath )
+            # (f is None if this processor does not participate in writing data)
+            if f is not None:
+                field_path = "/data/%d/fields/" %iteration
+                field_grp = f[field_path]
+            else:
+                field_grp = None
+
+            # Loop over the different quantities that should be written
+            fieldtype = "rho_%s" %species_name
+            self.write_dataset( field_grp, "rho", fieldtype )
+
+            # Close the file (only the first proc does this)
+            if f is not None:
+                f.close()
+
+            # Send data to the GPU if needed
+            if self.fld.use_cuda :
+                self.fld.send_fields_to_gpu()

--- a/fbpic/openpmd_diag/particle_density_diag.py
+++ b/fbpic/openpmd_diag/particle_density_diag.py
@@ -8,7 +8,7 @@ import os
 import numpy as np
 from .field_diag import FieldDiagnostic
 
-class ParticleDensityDiagnostic(FieldDiagnostic):
+class ParticleChargeDensityDiagnostic(FieldDiagnostic):
     """
     Class that defines a diagnostic for particle density
     """


### PR DESCRIPTION
This PR implements a new type of diagnostic: `ParticleDensityDiagnostic`. This outputs the density of one given species, and can be useful e.g. in the case where the plasma is neutral (so as to still see the plasma profile in the output).

Regarding the API: I included this diagnostics in the example script for ionization. I also added the diagnostics in the documentation. Please let me know if you have any suggestion regarding the API.

Regarding the implementation: in order to avoid having to add a new array, the density of the requested species is deposited directly to the array `rho` in interpolation space. However, this will not perturb the on-going simulation, because the deposition does not update the spectral space in this case. (And the simulation only cares about the spectral components `rho_next` and `rho_prev`). In practice, this was done by generalizing `sim.deposit` so as to be able to pass a list of species, and to indicate whether or not the spectral space should be updated.

The new `sim.deposit` is now also used for the space charge calculation, as it saves a few lines.

The implementation was, in the end, quite simple, but has a few limitations:
- This writes the *charge density* ; for neutral particles, it will not produce anything.
- The produced density is not smoothed (because we do not go through spectral space)