### PR TITLE
Enable user to set a maximum ionisation level

### DIFF
--- a/fbpic/particles/elementary_process/ionization/ionizer.py
+++ b/fbpic/particles/elementary_process/ionization/ionizer.py
@@ -100,7 +100,7 @@ class Ionizer(object):
             (e.g. 0 for initially neutral atoms)
 
         level_max: int, optional
-            If not None, defines the maxumum ionization level that
+            If not None, defines the maximum ionization level that
             macroparticles can reach. Should not exceed the physical
             limit for the chosen element.
         """

--- a/fbpic/particles/elementary_process/ionization/ionizer.py
+++ b/fbpic/particles/elementary_process/ionization/ionizer.py
@@ -99,13 +99,12 @@ class Ionizer(object):
             The ionization level at which the macroparticles are initially
             (e.g. 0 for initially neutral atoms)
 
-        level_max: int (optional)
+        level_max: int, optional
             If not None, defines the maxumum ionization level that
             macroparticles can reach. Should not exceed the physical
             limit for the chosen element.
         """
         # Register a few parameters
-
         self.level_start = level_start
         self.level_max = level_max
         self.use_cuda = ionizable_species.use_cuda
@@ -186,7 +185,7 @@ class Ionizer(object):
             self.level_max = len(Uion)
         else:
             assert type(self.level_max) is int, "level_max must be integer"
-            if self.level_max>=len(Uion):
+            if self.level_max>len(Uion):
                 raise ValueError("Chosen level_max for {}".format(element) + \
                                  " cannot exceed {}".format(len(Uion)))
 

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -453,7 +453,7 @@ class Particles(object) :
             (e.g. 0 for initially neutral atoms)
 
         level_max: int, optional
-            If not None, defines the maxumum ionization level that
+            If not None, defines the maximum ionization level that
             macroparticles can reach. Should not exceed the physical
             limit for the chosen element.
         """

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -411,7 +411,8 @@ class Particles(object) :
             ratio_w_electron_photon, boost )
 
 
-    def make_ionizable(self, element, target_species, level_start=0):
+    def make_ionizable(self, element, target_species,
+                       level_start=0, level_max=None):
         """
         Make this species ionizable.
 
@@ -450,9 +451,15 @@ class Particles(object) :
         level_start: int
             The ionization level at which the macroparticles are initially
             (e.g. 0 for initially neutral atoms)
+
+        level_max: int, optional
+            If not None, defines the maxumum ionization level that
+            macroparticles can reach. Should not exceed the physical
+            limit for the chosen element.
         """
         # Initialize the ionizer module
-        self.ionizer = Ionizer( element, self, target_species, level_start )
+        self.ionizer = Ionizer( element, self, target_species,
+                                level_start, level_max=level_max )
         # Set charge to the elementary charge e (assumed by deposition kernel,
         # when using self.ionizer.w_times_level as the effective weight)
         self.q = e

--- a/tests/test_ionization.py
+++ b/tests/test_ionization.py
@@ -137,14 +137,16 @@ def run_simulation( gamma_boost, use_separate_electron_species ):
     if use_separate_electron_species:
         # Use a dictionary of electron species: one per ionizable level
         target_species = {}
-        for i_level in range(level_start, 7): # N can go up to N7+
+        level_max = 6 # N can go up to N7+, but here we stop at N6+
+        for i_level in range(level_start, level_max): 
             target_species[i_level] = sim.add_new_species( q=-e, m=m_e )
     else:
         # Use the pre-existing, charge-neutralizing electrons
         target_species = elec
+        level_max = None # Default is going up to N6+
     # Define ionization
     ions.make_ionizable( element='N', level_start=level_start,
-                        target_species=target_species )
+                         level_max=level_max, target_species=target_species )
     # Set the moving window
     sim.set_moving_window( v=v_plasma )
 
@@ -183,7 +185,7 @@ def run_simulation( gamma_boost, use_separate_electron_species ):
     # When different electron species are created, check the fraction of
     # each electron species
     if use_separate_electron_species:
-        for i_level in range(level_start, 7):
+        for i_level in range(level_start, level_max):
             n_N = w[ioniz_level == i_level].sum()
             assert np.allclose( target_species[i_level].w.sum(), n_N )
 

--- a/tests/test_ionization.py
+++ b/tests/test_ionization.py
@@ -143,7 +143,7 @@ def run_simulation( gamma_boost, use_separate_electron_species ):
     else:
         # Use the pre-existing, charge-neutralizing electrons
         target_species = elec
-        level_max = None # Default is going up to N6+
+        level_max = None # Default is going up to N7+
     # Define ionization
     ions.make_ionizable( element='N', level_start=level_start,
                          level_max=level_max, target_species=target_species )


### PR DESCRIPTION
A tiny convenience PR to enable user to set a maximum ionisation level for ions. Can be useful in simulations with high-Z elements (e.g. ionization injection in LPA) to avoid creating unnecessary electron species (for better compatibility with #283).