### PR TITLE
Fix cubic CPU deposition

### DIFF
--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -419,7 +419,7 @@ def deposit_rho_numba_cubic(x, y, z, w, q,
             # Index of the lowest cell of `global_array` that gets modified
             # by this particle (note: `global_array` has 2 guard cells)
             # (`min` function avoids out-of-bounds access at high r)
-            ir_cell = min( int(math.floor(r_cell))+1, Nr+1 )
+            ir_cell = min( int(math.floor(r_cell))+1, Nr )
             iz_cell = int(math.floor( z_cell )) + 1
 
             # Add contribution of this particle to the global array
@@ -564,7 +564,7 @@ def deposit_J_numba_cubic(x, y, z, w, q,
             # Index of the lowest cell of `global_array` that gets modified
             # by this particle (note: `global_array` has 2 guard cells)
             # (`min` function avoids out-of-bounds access at high r)
-            ir_cell = min( int(math.floor(r_cell))+1, Nr+1 )
+            ir_cell = min( int(math.floor(r_cell))+1, Nr )
             iz_cell = int(math.floor( z_cell )) + 1
 
             # Add contribution of this particle to the global array


### PR DESCRIPTION
It seems that [PR #191](https://github.com/fbpic/fbpic/pull/191) did not completely remove the errors due to out-of-bounds on the CPU *in the case of cubic shape factor*. 

More specifically, for high-radius particles, FBPIC avoids out-of-bound deposition by limiting the radial index of the cell. For cubic shape factors, `ir_cell` is currently capped at `Nr+1` (for depositing into an array of size `Nr+4`: two guard cells on each side). However, because cubic shapes deposit from `ir_cell+0` to `ir_cell+3`, this can reach `Nr+4`, i.e. out-of-bound for Python-based indexing.

This bug should have been detected by the automated test that compares GPU and CPU deposition (since the problem does not occur on GPU). However, this was not the case for 2 reasons:
- This test does not have high-radius particles
- This test does not use cubic shape factors.

Therefore, this PR also modifies the automated test to fix the above 2 points. The high-radius particles are obtained by using `add_elec_bunch_gaussian`. It can be checked that the new test fails when it is run with the current `master` branch of FBPIC (but not with the branch of this PR.)


Here is a typical example of what this out-of-bound error can produce:
![compare](https://user-images.githubusercontent.com/6685781/46313804-aaaf5000-c57d-11e8-96dd-14a795258b28.png)
