### PR TITLE
Add injection area to damping region

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -45,8 +45,8 @@ class BoundaryCommunicator(object):
     # -----------------------
 
     def __init__( self, Nz, zmin, zmax, Nr, rmax, Nm, dt, v_comoving,
-            use_galilean, boundaries, n_order, n_guard=None, n_damp=30,
-            exchange_period=None, use_all_mpi_ranks=True):
+            use_galilean, boundaries, n_order, n_guard=None, n_damp=64,
+            n_inject=None, exchange_period=None, use_all_mpi_ranks=True):
         """
         Initializes a communicator object.
 
@@ -81,8 +81,8 @@ class BoundaryCommunicator(object):
 
         boundaries: str
             Indicates how to exchange the fields at the left and right
-            boundaries of the global simulation box
-            Either 'periodic' or 'open'
+            boundaries of the global simulation box.
+            (Either 'periodic' or 'open')
 
         n_order: int
            The order of the stencil for the z derivatives.
@@ -92,24 +92,40 @@ class BoundaryCommunicator(object):
            is required to have a localized field push that allows
            to do simulations in parallel on multiple MPI ranks)
 
-        n_guard: int
+        n_guard: int, optional
             Number of guard cells to use at the left and right of
-            a domain, when using MPI.
+            a domain, when performing parallel (MPI) computation
+            or when using open boundaries. Defaults to None, which
+            calculates the required guard cells for n_order
+            automatically (approx 2*n_order). If no MPI is used and
+            in the case of open boundaries with an infinite order stencil,
+            n_guard defaults to 64, if not set otherwise.
 
-        n_damp: int
+        n_damp : int, optional
             Number of damping guard cells at the left and right of a
-            simulation box, for a simulation with open boundaries. The guard
+            simulation box if a moving window is attached. The guard
             region at these areas (left / right of moving window) is
-            extended by n_damp (N=n_guard+n_damp) in order to smoothly
+            extended by n_damp in order to smoothly
             damp the fields such that they do not wrap around.
             (Defaults to 64)
 
+        n_inject: int, optional
+            Number of injection cells (at the left and right) of a simulation
+            box, for a simulation with open boundaries. The damping region
+            needs to be additionally extended by n_inject cells at the
+            outer edges to have a region with zero fields where new particles
+            can be injected. For symmetry reasons those cells are added at
+            both sides of the simulation box, although particles are typically
+            injected only at the right side of the box.
+            (Defaults to None and is set to n_guard/2 automatically)
+
         exchange_period: int, optional
             Number of iterations before which the particles are exchanged.
-            If set to None, the minimum exchange period is calculated
+            If set to None, the maximum exchange period is calculated
             automatically: Within exchange_period timesteps, the
             particles should never be able to travel more than
-            (n_guard - particle_shape order) cells.
+            (n_guard/2 - particle_shape order) cells. (Setting exchange_period
+            to small values can substantially affect the performance)
 
         use_all_mpi_ranks: bool, optional
             - if `use_all_mpi_ranks` is True (default):
@@ -189,16 +205,21 @@ class BoundaryCommunicator(object):
         # For single proc and periodic boundaries, no need for guard cells
         if boundaries=='periodic' and self.size==1:
             self.n_guard = 0
+
         # Register damping cells
         self.n_damp = n_damp
         # For periodic boundaries, no need for damping cells
         if boundaries=='periodic':
             self.n_damp = 0
+            self.n_inject = 0
         else:
-            if self.n_damp < 8:
-                raise ValueError('Damping region is too small. n_damp should \
-                    be at least 8 cells to correctly initialize the \
-                    damping region.')
+            # Register additional injection cells that are part of the
+            # damping region and of size n_guard/2.
+            if self.n_inject == None:
+                self.n_inject = int(self.n_guard/2)
+            else:
+                # User-defined injection cells. Choose carefully.
+                self.n_inject = n_inject
 
         # Initialize the period of the particle exchange and moving window
         if exchange_period is None:
@@ -237,17 +258,17 @@ class BoundaryCommunicator(object):
 
         # Create damping arrays for the damping cells at the left
         # and right of the box in the case of "open" boundaries.
-        if self.n_damp > 0:
+        if (self.n_damp+self.n_inject) > 0:
             if self.left_proc is None:
                 # Create the damping arrays for left proc
                 self.left_damp = self.generate_damp_array(
-                    self.n_guard, self.n_damp )
+                    self.n_guard, self.n_damp, self.n_inject )
                 if cuda_installed:
                     self.d_left_damp = cuda.to_device( self.left_damp )
             if self.right_proc is None:
                 # Create the damping arrays for right proc
                 self.right_damp = self.generate_damp_array(
-                    self.n_guard, self.n_damp )
+                    self.n_guard, self.n_damp, self.n_inject )
                 if cuda_installed:
                     self.d_right_damp = cuda.to_device( self.right_damp )
 
@@ -301,8 +322,8 @@ class BoundaryCommunicator(object):
             Whether to consider the global grid, or a local grid.
             (In the latter case, `rank` must be provided.)
         with_damp, with_guard: bool
-            Whether to include the damp cells and guard cells in
-            the considered grid.
+            Whether to include the damp cells (inlcuding the injection cells)
+            and guard cells in the considered grid.
         rank: int
             Required when `local` is True: the MPI rank that owns the
             considered local grid.
@@ -334,10 +355,10 @@ class BoundaryCommunicator(object):
             # Add damp cells if requested (only for first and last sub-domain)
             if with_damp:
                 if rank == 0:
-                    Nz += self.n_damp
-                    iz -= self.n_damp
+                    Nz += self.n_damp+self.n_inject
+                    iz -= self.n_damp+self.n_inject
                 if rank == self.size-1:
-                    Nz += self.n_damp
+                    Nz += self.n_damp+self.n_inject
             # Add guard cells if requested
             if with_guard:
                 Nz += 2*self.n_guard
@@ -350,8 +371,8 @@ class BoundaryCommunicator(object):
             iz = 0
             # Add damp cells if requested
             if with_damp:
-                Nz += 2*self.n_damp
-                iz -= self.n_damp
+                Nz += 2*(self.n_damp+self.n_inject)
+                iz -= self.n_damp+self.n_inject
             # Add guard cells if requested
             if with_guard:
                 Nz += 2*self.n_guard
@@ -372,8 +393,8 @@ class BoundaryCommunicator(object):
             Whether to consider the global grid, or a local grid.
             (In the latter case, `rank` must be provided.)
         with_damp, with_guard: bool
-            Whether to include the damp cells and guard cells in
-            the considered grid.
+            Whether to include the damp cells (inlcuding the injection cells)
+            and guard cells in the considered grid.
         rank: int
             Required when `local` is True: the MPI rank that owns the
             considered local grid.
@@ -720,20 +741,22 @@ class BoundaryCommunicator(object):
         """
         # Do not damp the fields for 0 n_damp cells (periodic)
         if self.n_damp != 0:
+            # Total size of the damping and guard region
+            nd = self.n_guard + self.n_damp + self.n_inject
+
             if self.left_proc is None:
                 # Damp the fields on the CPU or the GPU
                 if interp[0].use_cuda:
                     # Damp the fields on the GPU
                     dim_grid, dim_block = cuda_tpb_bpg_2d(
-                        self.n_guard+self.n_damp, interp[0].Nr )
+                        nd, interp[0].Nr )
                     for m in range(len(interp)):
                         cuda_damp_EB_left[dim_grid, dim_block](
                             interp[m].Er, interp[m].Et, interp[m].Ez,
                             interp[m].Br, interp[m].Bt, interp[m].Bz,
-                            self.d_left_damp, self.n_guard, self.n_damp)
+                            self.d_left_damp, nd)
                 else:
                     # Damp the fields on the CPU
-                    nd = self.n_guard + self.n_damp
                     for m in range(len(interp)):
                         # Damp the fields in left guard cells
                         interp[m].Er[:nd,:]*=self.left_damp[:,np.newaxis]
@@ -748,15 +771,14 @@ class BoundaryCommunicator(object):
                 if interp[0].use_cuda:
                     # Damp the fields on the GPU
                     dim_grid, dim_block = cuda_tpb_bpg_2d(
-                        self.n_guard+self.n_damp, interp[0].Nr )
+                        nd, interp[0].Nr )
                     for m in range(len(interp)):
                         cuda_damp_EB_right[dim_grid, dim_block](
                             interp[m].Er, interp[m].Et, interp[m].Ez,
                             interp[m].Br, interp[m].Bt, interp[m].Bz,
-                            self.d_right_damp, self.n_guard, self.n_damp)
+                            self.d_right_damp, nd)
                 else:
                     # Damp the fields on the CPU
-                    nd = self.n_guard + self.n_damp
                     for m in range(len(interp)):
                         # Damp the fields in left guard cells
                         interp[m].Er[-nd:,:]*=self.right_damp[::-1,np.newaxis]
@@ -766,7 +788,7 @@ class BoundaryCommunicator(object):
                         interp[m].Bt[-nd:,:]*=self.right_damp[::-1,np.newaxis]
                         interp[m].Bz[-nd:,:]*=self.right_damp[::-1,np.newaxis]
 
-    def generate_damp_array( self, n_guard, n_damp ):
+    def generate_damp_array( self, n_guard, n_damp, n_inject ):
         """
         Create a 1d damping array of length n_guard.
 
@@ -778,28 +800,29 @@ class BoundaryCommunicator(object):
         n_damp: int
             Number of damping cells along z
 
+        n_inject: int
+            Number of injection cells along z
+
         Returns
         -------
-        A 1darray of doubles, of length n_guard + n_damp,
+        A 1darray of doubles, of length n_guard + n_damp + n_inject,
         which represents the damping.
         """
         # Array of cell indices
-        i_cell = np.arange( n_guard+n_damp )
+        i_cell = np.arange( n_guard+n_damp+n_inject )
 
         # Perform narrow damping, with the first n_guard of the cells at 0.
-        # Additionally, the first 4 cells of the damping area are set to 0.
-        # This area is part of the injection area at the right side of the box
-        # and there should be no field seen by the injected particles.
-        # (For max. 3rd order particle shapes we need 3 + 1 cells = 4 cells),
-        # Damping: 1/2*(n_damp-4) cells with a sinusoidal**2 rise, and finally
-        # 1/2*(n_damp-4) cells at 1 (the damping array is defined such that it
+        # Additionally, the first n_inject cells of the damping area are set
+        # to 0. This area is part of the injection area and there should be no
+        # field seen by the injected particles.
+        # Damping: 1/2*(n_damp) cells with a sinusoidal**2 rise, and finally
+        # 1/2*(n_damp) cells at 1 (the damping array is defined such that it
         # can directly be multiplied with the fields at the left boundary of
         # the box - and needs to be inverted (damping_array[::-1]) before being
         # applied to the right boundary of the box.)
-        # (The minimum number of damping cells is forced to 8)
-        damping_array = np.where( i_cell < n_guard+4+(n_damp-4)/2.,
-                np.sin((i_cell - (n_guard+4))*np.pi/(2*(n_damp-4)/2.))**2, 1. )
-        damping_array = np.where( i_cell < n_guard+4, 0., damping_array )
+        damping_array = np.where( i_cell<n_guard+n_inject+n_damp/2.,
+            np.sin((i_cell-(n_guard+n_inject))*np.pi/(2*n_damp/2.))**2, 1. )
+        damping_array = np.where( i_cell<n_guard+n_inject, 0., damping_array )
 
         return( damping_array )
 

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -215,7 +215,7 @@ class BoundaryCommunicator(object):
         else:
             # Register additional injection cells that are part of the
             # damping region and of size n_guard/2.
-            if self.n_inject == None:
+            if n_inject == None:
                 self.n_inject = int(self.n_guard/2)
             else:
                 # User-defined injection cells. Choose carefully.

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -766,7 +766,7 @@ class BoundaryCommunicator(object):
                         interp[m].Bt[-nd:,:]*=self.right_damp[::-1,np.newaxis]
                         interp[m].Bz[-nd:,:]*=self.right_damp[::-1,np.newaxis]
 
-    def generate_damp_array( n_guard, n_damp ):
+    def generate_damp_array( self, n_guard, n_damp ):
         """
         Create a 1d damping array of length n_guard.
 

--- a/fbpic/boundaries/cuda_methods.py
+++ b/fbpic/boundaries/cuda_methods.py
@@ -347,7 +347,7 @@ def add_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
 # CUDA damping kernels:
 # --------------------
 @cuda.jit
-def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, n_guard, n_damp ):
+def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
     """
     Multiply the E and B fields in the left guard cells
     by damp_array.
@@ -359,14 +359,11 @@ def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, n_guard, n_damp ):
         The first axis corresponds to z and the second to r
 
     damp_array : 1darray of floats
-        An array of length n_guard+n_damp,
+        An array of length n_guard+n_damp+n_inject,
         which contains the damping factors.
 
-    n_guard: int
-        Number of guard cells
-
-    n_damp: int
-        Number of damping cells
+    nd: int
+        Number of damping and guard cells
     """
     # Obtain Cuda grid
     iz, ir = cuda.grid(2)
@@ -377,7 +374,7 @@ def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, n_guard, n_damp ):
     # Modify the fields
     if ir < Nr :
         # Apply the damping arrays
-        if iz < n_guard+n_damp:
+        if iz < nd:
             damp_factor_left = damp_array[iz]
 
             # At the left end
@@ -389,7 +386,7 @@ def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, n_guard, n_damp ):
             Bz[iz, ir] *= damp_factor_left
 
 @cuda.jit
-def cuda_damp_EB_right( Er, Et, Ez, Br, Bt, Bz, damp_array, n_guard, n_damp ):
+def cuda_damp_EB_right( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
     """
     Multiply the E and B fields in the right guard cells
     by damp_array.
@@ -401,14 +398,11 @@ def cuda_damp_EB_right( Er, Et, Ez, Br, Bt, Bz, damp_array, n_guard, n_damp ):
         The first axis corresponds to z and the second to r
 
     damp_array : 1darray of floats
-        An array of length n_guard+n_damp,
+        An array of length n_guard+n_damp+n_inject,
         which contains the damping factors.
 
-    n_guard: int
-        Number of guard cells
-
-    n_damp: int
-        Number of damping cells
+    nd: int
+        Number of damping and guard cells
     """
     # Obtain Cuda grid
     iz, ir = cuda.grid(2)
@@ -419,7 +413,7 @@ def cuda_damp_EB_right( Er, Et, Ez, Br, Bt, Bz, damp_array, n_guard, n_damp ):
     # Modify the fields
     if ir < Nr :
         # Apply the damping arrays
-        if iz < n_guard+n_damp:
+        if iz < nd:
             damp_factor_right = damp_array[iz]
 
             # At the right end

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -18,10 +18,6 @@ def remove_outside_particles(species, fld, n_guard, left_proc, right_proc):
     Remove the particles that are outside of the physical domain (i.e.
     in the guard cells). Store them in sending buffers, which are returned.
 
-    When the boundaries are open, only the particles that are in the
-    outermost half of the guard cells are removed. The particles that
-    are in the innermost half are kept.
-
     Parameters
     ----------
     species: a Particles object
@@ -62,10 +58,6 @@ def remove_particles_cpu(species, fld, n_guard, left_proc, right_proc):
     """
     Remove the particles that are outside of the physical domain (i.e.
     in the guard cells). Store them in sending buffers, which are returned.
-
-    When the boundaries are open, only the particles that are in the
-    outermost half of the guard cells are removed. The particles that
-    are in the innermost half are kept.
 
     Parameters
     ----------
@@ -186,10 +178,6 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     """
     Remove the particles that are outside of the physical domain (i.e.
     in the guard cells). Store them in sending buffers, which are returned.
-
-    When the boundaries are open, only the particles that are in the
-    outermost half of the guard cells are removed. The particles that
-    are in the innermost half are kept.
 
     Parameters
     ----------

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -49,7 +49,7 @@ class Simulation(object):
                  n_order=-1, dens_func=None, filter_currents=True,
                  v_comoving=None, use_galilean=True,
                  initialize_ions=False, use_cuda=False,
-                 n_guard=None, n_damp=64, n_inject=None, exchange_period=None,
+                 n_guard=None, n_damp=64, exchange_period=None,
                  current_correction='curl-free', boundaries='periodic',
                  gamma_boost=None, use_all_mpi_ranks=True,
                  particle_shape='linear', verbose_level=1 ):
@@ -139,18 +139,10 @@ class Simulation(object):
             Number of damping guard cells at the left and right of a
             simulation box if a moving window is attached. The guard
             region at these areas (left / right of moving window) is
-            extended by n_damp in order to smoothly
-            damp the fields such that they do not wrap around.
+            extended by n_damp in order to smoothly damp the fields such
+            that they do not wrap around. Additionally, this region is
+            extended by an injection area of size n_guard/2 automatically.
             (Defaults to 64)
-        n_inject: int, optional
-            Number of injection cells (at the left and right) of a simulation
-            box, for a simulation with open boundaries. The damping region
-            needs to be additionally extended by n_inject cells at the
-            outer edges to have a region with zero fields where new particles
-            can be injected. For symmetry reasons those cells are added at
-            both sides of the simulation box, although particles are typically
-            injected only at the right side of the box.
-            (Defaults to None and is set to n_guard/2 automatically)
         exchange_period: int, optional
             Number of iterations before which the particles are exchanged.
             If set to None, the maximum exchange period is calculated
@@ -232,7 +224,7 @@ class Simulation(object):
         # Initialize the boundary communicator
         self.comm = BoundaryCommunicator( Nz, zmin, zmax, Nr, rmax, Nm, dt,
             self.v_comoving, self.use_galilean, boundaries, n_order,
-            n_guard, n_damp, n_inject, exchange_period, use_all_mpi_ranks )
+            n_guard, n_damp, None, exchange_period, use_all_mpi_ranks )
         # Modify domain region
         zmin, zmax, Nz = self.comm.divide_into_domain()
         # Initialize the field structure

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -573,12 +573,11 @@ class SliceHandler:
         if comm is not None:
             iz += comm.n_guard
             if comm.left_proc is None:
-                iz += comm.n_damp
+                iz += comm.n_damp+comm.n_inject
 
         # Extract the slice directly on the CPU
         # Fill the pre-allocated CPU array slice_array
         if fld.use_cuda is False :
-
             # Extract a slice of the fields *in the boosted frame*
             # at z_boost, using interpolation, and store them in slice_array
             self.extract_slice_cpu( fld, iz, Sz, slice_array )

--- a/fbpic/particles/injection/continuous_injection.py
+++ b/fbpic/particles/injection/continuous_injection.py
@@ -95,7 +95,7 @@ class ContinuousInjector( object ):
         # damping region), do not see any fields. (3 cells for a maximum of
         # 3rd order shapes factors + 1 extra cell = 4 cells)
         _, zmax_global_domain = comm.get_zmin_zmax( local=False,
-                                    with_damp=False, with_guard=False )
+                                    with_damp=True, with_guard=False )
         self.z_inject = zmax_global_domain - 1*comm.dz + \
                 comm.exchange_period*dt*(v_moving_window-self.v_end_plasma)
         self.nz_inject = 0

--- a/fbpic/utils/printing.py
+++ b/fbpic/utils/printing.py
@@ -220,8 +220,9 @@ def print_simulation_setup( sim, verbose_level=1 ):
             message += '\nParticle shape: %s' %sim.particle_shape
             message += '\nLongitudinal boundaries: %s' %sim.comm.boundaries
             message += '\nTransverse boundaries: reflective'
-            message += '\nGuard region size: %d ' %sim.comm.n_guard + 'cells'
-            message += '\nDamping region size: %d ' %sim.comm.n_damp + 'cells'
+            message += '\nGuard region size: %d ' %sim.comm.n_guard+'cells'
+            message += '\nDamping region size: %d ' %sim.comm.n_damp+'cells'
+            message += '\nInjection region size: %d ' %sim.comm.n_inject+'cells'
             message += '\nParticle exchange period: every %d ' \
                 %sim.comm.exchange_period + 'step'
             if sim.boost is not None:

--- a/tests/test_laser_antenna.py
+++ b/tests/test_laser_antenna.py
@@ -142,7 +142,8 @@ def run_and_check_laser_antenna(gamma_b, show, write_files,
 
     # Check the transverse E and B field
     Nz_half = int(sim.fld.interp[1].Nz/2) + 2
-    z = sim.fld.interp[1].z[Nz_half:-(sim.comm.n_guard+sim.comm.n_damp)]
+    z = sim.fld.interp[1].z[Nz_half:-(sim.comm.n_guard+sim.comm.n_damp+\
+                            sim.comm.n_inject)]
     r = sim.fld.interp[1].r
     # Loop through the different fields
     for fieldtype, info_in_real_part, factor in [ ('Er', True, 2.), \
@@ -151,7 +152,8 @@ def run_and_check_laser_antenna(gamma_b, show, write_files,
         # in order to get a value which is comparable to an electric field
         # (Because of the definition of the interpolation grid, the )
         field = getattr(sim.fld.interp[1], fieldtype)\
-                            [Nz_half:-(sim.comm.n_guard+sim.comm.n_damp)]
+                            [Nz_half:-(sim.comm.n_guard+sim.comm.n_damp+\
+                             sim.comm.n_inject)]
         print( 'Checking %s' %fieldtype )
         check_fields( factor*field, z, r, info_in_real_part,
                         z0, gamma_b, forward_propagating )


### PR DESCRIPTION
Fix a bug when the damping region is not entirely filled with plasma after exchange_period steps.

Before this PR, new particles where added only in the physical domain + ~ exchange_period cells ahead of the physical domain. Thus not the entire damping region was filled with plasma. In some cases, non-zero fields can appear in the damping region which can interact with particles injected at different times, causing weird oscillations in e.g. the charge density.

This PR changes this by adding new particles up to the physical domain + the damping region + an additional injection area with n_inject cells. A new parameter n_inject has been added to the Simulation object and the BoundaryCommunicator. It can be set manually but defaults to n_guard/2. It is considered to be part of the damping region.

With the new injection area, particles will never be injected in the guard region and it is ensured that newly added particles do not see any fields as they are injected only in the injection area.

In addition, the pure damping region has been changed to 50:50 (damping_function:no_damping) compared to 33:66 before.