### PR TITLE
[WIP] Prevent gathering of the fields outside of the physical box

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -207,6 +207,12 @@ class BoundaryCommunicator(object):
             # (Particles are only allowed to reside in half of the guard
             # region as this is the stencil reach of the current correction)
             self.exchange_period = int(((self.n_guard/2)-3)/cells_per_step)
+            # When using continuous injection of plasma, the exchange_period
+            # should be small enough that the damp cells are never empty of
+            # injected particles
+            if boundaries == 'open':
+                self.exchange_period = min( self.exchange_period,
+                                        int((self.n_damp-3)/cells_per_step) )
             # Set exchange_period to 1 in the case of single-proc
             # and periodic boundary conditions.
             if self.size == 1 and boundaries == 'periodic':

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -18,10 +18,6 @@ def remove_outside_particles(species, fld, n_guard, left_proc, right_proc):
     Remove the particles that are outside of the physical domain (i.e.
     in the guard cells). Store them in sending buffers, which are returned.
 
-    When the boundaries are open, only the particles that are in the
-    outermost half of the guard cells are removed. The particles that
-    are in the innermost half are kept.
-
     Parameters
     ----------
     species: a Particles object
@@ -62,10 +58,6 @@ def remove_particles_cpu(species, fld, n_guard, left_proc, right_proc):
     """
     Remove the particles that are outside of the physical domain (i.e.
     in the guard cells). Store them in sending buffers, which are returned.
-
-    When the boundaries are open, only the particles that are in the
-    outermost half of the guard cells are removed. The particles that
-    are in the innermost half are kept.
 
     Parameters
     ----------
@@ -186,10 +178,6 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     """
     Remove the particles that are outside of the physical domain (i.e.
     in the guard cells). Store them in sending buffers, which are returned.
-
-    When the boundaries are open, only the particles that are in the
-    outermost half of the guard cells are removed. The particles that
-    are in the innermost half are kept.
 
     Parameters
     ----------

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -392,7 +392,7 @@ class Simulation(object):
 
             # Gather the fields from the grid at t = n dt
             for species in ptcl:
-                species.gather( fld.interp )
+                species.gather( fld.interp, self.comm )
             # Apply the external fields at t = n dt
             for ext_field in self.external_fields:
                 ext_field.apply_expression( self.ptcl, self.time )

--- a/fbpic/particles/gathering/cuda_methods.py
+++ b/fbpic/particles/gathering/cuda_methods.py
@@ -23,6 +23,7 @@ add_cubic_gather_for_mode = cuda.jit( add_cubic_gather_for_mode,
 
 @cuda.jit
 def gather_field_gpu_linear(x, y, z,
+                    zmin_global, zmax_global,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m0, Et_m0, Ez_m0,
@@ -44,11 +45,14 @@ def gather_field_gpu_linear(x, y, z,
     x, y, z : 1darray of floats (in meters)
         The position of the particles
 
+    zmin_global, zmax_global:
+        The positions between which particles are allowed to gather fields.
+
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
 
     zmin, rmin : float (in meters)
-        Position of the edge of the simulation box along the
+        Position of the edge of the local simulation box along the
         direction considered
 
     Nz, Nr : int
@@ -85,6 +89,16 @@ def gather_field_gpu_linear(x, y, z,
         xj = x[i]
         yj = y[i]
         zj = z[i]
+
+        # Skip this particle if it is outside the allowed bounds
+        if (zj < zmin_global) or (zj >= zmax_global):
+            Ex[i] = 0
+            Ey[i] = 0
+            Ez[i] = 0
+            Bx[i] = 0
+            By[i] = 0
+            Bz[i] = 0
+            return
 
         # Cylindrical conversion
         rj = math.sqrt( xj**2 + yj**2 )
@@ -198,6 +212,7 @@ def gather_field_gpu_linear(x, y, z,
 
 @cuda.jit
 def gather_field_gpu_cubic(x, y, z,
+                    zmin_global, zmax_global,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m0, Et_m0, Ez_m0,
@@ -219,11 +234,14 @@ def gather_field_gpu_cubic(x, y, z,
     x, y, z : 1darray of floats (in meters)
         The position of the particles
 
+    zmin_global, zmax_global:
+        The positions between which particles are allowed to gather fields.
+
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
 
     zmin, rmin : float (in meters)
-        Position of the edge of the simulation box along the
+        Position of the edge of the local simulation box along the
         direction considered
 
     Nz, Nr : int
@@ -261,6 +279,16 @@ def gather_field_gpu_cubic(x, y, z,
         xj = x[i]
         yj = y[i]
         zj = z[i]
+
+        # Skip this particle if it is outside the allowed bounds
+        if (zj < zmin_global) or (zj >= zmax_global):
+            Ex[i] = 0
+            Ey[i] = 0
+            Ez[i] = 0
+            Bx[i] = 0
+            By[i] = 0
+            Bz[i] = 0
+            return
 
         # Cylindrical conversion
         rj = math.sqrt(xj**2 + yj**2)

--- a/fbpic/particles/gathering/cuda_methods_one_mode.py
+++ b/fbpic/particles/gathering/cuda_methods_one_mode.py
@@ -43,6 +43,7 @@ def erase_eb_cuda( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
 
 @cuda.jit
 def gather_field_gpu_linear_one_mode(x, y, z,
+                    zmin_global, zmax_global,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m, Et_m, Ez_m,
@@ -62,11 +63,14 @@ def gather_field_gpu_linear_one_mode(x, y, z,
     x, y, z : 1darray of floats (in meters)
         The position of the particles
 
+    zmin_global, zmax_global:
+        The positions between which particles are allowed to gather fields.
+
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
 
     zmin, rmin : float (in meters)
-        Position of the edge of the simulation box along the
+        Position of the edge of the local simulation box along the
         direction considered
 
     Nz, Nr : int
@@ -100,6 +104,10 @@ def gather_field_gpu_linear_one_mode(x, y, z,
         xj = x[i]
         yj = y[i]
         zj = z[i]
+
+        # Skip this particle if it is outside the allowed bounds
+        if (zj < zmin_global) or (zj >= zmax_global):
+            return
 
         # Cylindrical conversion
         rj = math.sqrt( xj**2 + yj**2 )
@@ -205,6 +213,7 @@ def gather_field_gpu_linear_one_mode(x, y, z,
 
 @cuda.jit
 def gather_field_gpu_cubic_one_mode(x, y, z,
+                    zmin_global, zmax_global,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m, Et_m, Ez_m,
@@ -224,11 +233,14 @@ def gather_field_gpu_cubic_one_mode(x, y, z,
     x, y, z : 1darray of floats (in meters)
         The position of the particles
 
+    zmin_global, zmax_global:
+        The positions between which particles are allowed to gather fields.
+
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
 
     zmin, rmin : float (in meters)
-        Position of the edge of the simulation box along the
+        Position of the edge of the local simulation box along the
         direction considered
 
     Nz, Nr : int
@@ -263,6 +275,10 @@ def gather_field_gpu_cubic_one_mode(x, y, z,
         xj = x[i]
         yj = y[i]
         zj = z[i]
+
+        # Skip this particle if it is outside the allowed bounds
+        if (zj < zmin_global) or (zj >= zmax_global):
+            return
 
         # Cylindrical conversion
         rj = math.sqrt(xj**2 + yj**2)

--- a/fbpic/particles/gathering/threading_methods.py
+++ b/fbpic/particles/gathering/threading_methods.py
@@ -24,6 +24,7 @@ add_cubic_gather_for_mode = numba.njit( add_cubic_gather_for_mode )
 
 @njit_parallel
 def gather_field_numba_linear(x, y, z,
+                    zmin_global, zmax_global,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m0, Et_m0, Ez_m0,
@@ -45,11 +46,14 @@ def gather_field_numba_linear(x, y, z,
     x, y, z : 1darray of floats (in meters)
         The position of the particles
 
+    zmin_global, zmax_global:
+        The positions between which particles are allowed to gather fields.
+
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
 
     zmin, rmin : float (in meters)
-        Position of the edge of the simulation box along the
+        Position of the edge of the local simulation box along the
         direction considered
 
     Nz, Nr : int
@@ -83,6 +87,16 @@ def gather_field_numba_linear(x, y, z,
         xj = x[i]
         yj = y[i]
         zj = z[i]
+
+        # Skip this particle if it is outside the allowed bounds
+        if (zj < zmin_global) or (zj >= zmax_global):
+            Ex[i] = 0
+            Ey[i] = 0
+            Ez[i] = 0
+            Bx[i] = 0
+            By[i] = 0
+            Bz[i] = 0
+            continue
 
         # Cylindrical conversion
         rj = math.sqrt( xj**2 + yj**2 )
@@ -198,6 +212,7 @@ def gather_field_numba_linear(x, y, z,
 
 @njit_parallel
 def gather_field_numba_cubic(x, y, z,
+                    zmin_global, zmax_global,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m0, Et_m0, Ez_m0,
@@ -220,11 +235,14 @@ def gather_field_numba_cubic(x, y, z,
     x, y, z : 1darray of floats (in meters)
         The position of the particles
 
+    zmin_global, zmax_global:
+        The positions between which particles are allowed to gather fields.
+
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
 
     zmin, rmin : float (in meters)
-        Position of the edge of the simulation box along the
+        Position of the edge of the local simulation box along the
         direction considered
 
     Nz, Nr : int
@@ -275,6 +293,16 @@ def gather_field_numba_cubic(x, y, z,
             xj = x[i]
             yj = y[i]
             zj = z[i]
+
+            # Skip this particle if it is outside the allowed bounds
+            if (zj < zmin_global) or (zj >= zmax_global):
+                Ex[i] = 0
+                Ey[i] = 0
+                Ez[i] = 0
+                Bx[i] = 0
+                By[i] = 0
+                Bz[i] = 0
+                continue
 
             # Cylindrical conversion
             rj = math.sqrt(xj**2 + yj**2)

--- a/fbpic/particles/gathering/threading_methods_one_mode.py
+++ b/fbpic/particles/gathering/threading_methods_one_mode.py
@@ -45,6 +45,7 @@ def erase_eb_numba( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
 
 @njit_parallel
 def gather_field_numba_linear_one_mode(x, y, z,
+                    zmin_global, zmax_global,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m, Et_m, Ez_m,
@@ -63,11 +64,14 @@ def gather_field_numba_linear_one_mode(x, y, z,
     x, y, z : 1darray of floats (in meters)
         The position of the particles
 
+    zmin_global, zmax_global:
+        The positions between which particles are allowed to gather fields.
+
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
 
     zmin, rmin : float (in meters)
-        Position of the edge of the simulation box along the
+        Position of the edge of the local simulation box along the
         direction considered
 
     Nz, Nr : int
@@ -98,6 +102,10 @@ def gather_field_numba_linear_one_mode(x, y, z,
         xj = x[i]
         yj = y[i]
         zj = z[i]
+
+        # Skip this particle if it is outside the allowed bounds
+        if (zj < zmin_global) or (zj >= zmax_global):
+            continue
 
         # Cylindrical conversion
         rj = math.sqrt( xj**2 + yj**2 )
@@ -202,6 +210,7 @@ def gather_field_numba_linear_one_mode(x, y, z,
 
 @njit_parallel
 def gather_field_numba_cubic_one_mode(x, y, z,
+                    zmin_global, zmax_global,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m, Et_m, Ez_m,
@@ -222,11 +231,14 @@ def gather_field_numba_cubic_one_mode(x, y, z,
     x, y, z : 1darray of floats (in meters)
         The position of the particles
 
+    zmin_global, zmax_global:
+        The positions between which particles are allowed to gather fields.
+
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
 
     zmin, rmin : float (in meters)
-        Position of the edge of the simulation box along the
+        Position of the edge of the local simulation box along the
         direction considered
 
     Nz, Nr : int
@@ -274,6 +286,10 @@ def gather_field_numba_cubic_one_mode(x, y, z,
             xj = x[i]
             yj = y[i]
             zj = z[i]
+
+            # Skip this particle if it is outside the allowed bounds
+            if (zj < zmin_global) or (zj >= zmax_global):
+                continue
 
             # Cylindrical conversion
             rj = math.sqrt(xj**2 + yj**2)


### PR DESCRIPTION
As discussed offline with @MKirchen, particles should not gather fields from outside of the box (e.g. from the damp cells). This can especially influence the continuously-injected particles, before they enter the box.

This PR prevents the particles from gathering outside of the physical box.