### PR TITLE
Fix parallel laser deposition

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -371,6 +371,8 @@ class Simulation(object):
                 # are shifted by one box length, so they remain inside the box)
                 for species in self.ptcl:
                     self.comm.exchange_particles(species, fld, self.time)
+                for antenna in self.laser_antennas:
+                    antenna.update_current_rank(self.comm)
 
                 # Reproject the charge on the interpolation grid
                 # (Since particles have been removed / added to the simulation;
@@ -558,7 +560,7 @@ class Simulation(object):
                 species.deposit( fld, 'rho' )
             # Deposit the charge of the virtual particles in the antenna
             for antenna in antennas_list:
-                antenna.deposit( fld, 'rho', self.comm )
+                antenna.deposit( fld, 'rho' )
             # Sum contribution from each CPU threads (skipped on GPU)
             fld.sum_reduce_deposition_array('rho')
             # Divide by cell volume
@@ -575,7 +577,7 @@ class Simulation(object):
                 species.deposit( fld, 'J' )
             # Deposit the current of the virtual particles in the antenna
             for antenna in antennas_list:
-                antenna.deposit( fld, 'J', self.comm )
+                antenna.deposit( fld, 'J' )
             # Sum contribution from each CPU threads (skipped on GPU)
             fld.sum_reduce_deposition_array('J')
             # Divide by cell volume


### PR DESCRIPTION
When the laser antenna crosses the boundary between 2 MPI procs, the current correction gets crazy. This is because rho^{n} is deposited on one MPI rank and rho^{n+1} is deposited on the other MPI rank.

In order to avoid this problem, this PR adds a flag that controls whether the antenna deposits on the current MPI proc (reminder: all MPI rank have a copy of the virtual particles of the antenna ; unlike the actual physical macroparticles).
This flag can only be changed at the beginning of a PIC iteration (i.e. at the same time as we exchange the physical particles between MPI ranks). That way, rho^n and rho^{n+1} are always deposited on the same MPI rank.

For instance, here is the Ez field of an injected laser, around the time when the antenna crosses the boundary between the 2 MPI ranks (red line) ; the current correction is the `cross-deposition`, which should be local ;  the laser is only emitted on the right-hand side because this is a boosted-frame simulation and the antenna is moving close to the speed of light (to the left). The upper plot is the current `dev` branch (unphysical fields in the left hand side) while the bottom plot is this PR:
![deposition](https://user-images.githubusercontent.com/6685781/48236046-6893de00-e375-11e8-9829-b55c5bbb7fdd.png)
