### PR TITLE
Fix continuous injection of plasma when no plasma is originally in the box

### DIFF
--- a/tests/test_continuous_injection.py
+++ b/tests/test_continuous_injection.py
@@ -35,72 +35,55 @@ Nm = 2
 zmin = -10.e-6
 zmax = 5.e-6
 rmax = 20.e-6
+dz = (zmax-zmin)/Nz
 # Particles
 p_nr = 2
 p_nz = 2
 p_nt = 4
 p_rmax = rmax
-p_zmin = 0.e-6 # Chosen so that there is initially some plasma inside the box
 p_zmax = 1e6
 n = 1.e24
-
-ramp = 7.e-6 # linear density upramp in z
+ramp0 = 7.e-6 # linear density upramp in z
 smooth_r = rmax*0.5 # smooth cos**2 decrease of density in r (towards rmax)
 
 # -------------
 # Test function
 # -------------
 
-def test_rest_continuous_injection(show=False):
-    "Function that is run by py.test, when doing `python setup.py test`"
+def test_labframe_with_preexisting_plasma(show=False):
+    "Run test in lab frame with some plasma at t=0"
+    p_zmin = 0.e-6 # Chosen so there is some plasma inside the box at t=0
+    run_continuous_injection(None, ramp0, p_zmin, p_zmax, show)
 
-    # Plasma at rest, non-uniform density
-    def dens_func( z, r ):
-        dens = np.ones_like( z )
-        # Make the density smooth at rmax
-        dens = np.where( r > rmax-smooth_r,
-            np.cos(0.5*np.pi*(r-smooth_r)/smooth_r)**2, dens)
-        # Make the density 0 below p_zmin
-        dens = np.where( z < p_zmin, 0., dens )
-        # Make a linear ramp
-        dens = np.where( (z>=p_zmin) & (z<p_zmin+ramp),
-                         (z-p_zmin)/ramp*dens, dens )
-        return( dens )
-
-    # Run the test
-    uth = 0.0001
-    run_continuous_injection(None, dens_func, uth, p_zmin, p_zmax, show)
-
-def test_boosted_continuous_injection(show=False):
-    "Function that is run by py.test, when doing `python setup.py test`"
-    # Moving plasma (boosted frame), non-uniform density
+def test_boosted_with_preexisting_plasma(show=False):
+    "Run test in boosted frame with some plasma at t=0"
     gamma_boost = 15.
-
-    global ramp
     # The ramp is made longer so as to still resolve it in the boosted frame
-    ramp = 2*gamma_boost*ramp
+    ramp = 2*gamma_boost*ramp0
+    p_zmin = 0.e-6 # Chosen so there is some plasma inside the box at t=0
+    run_continuous_injection(gamma_boost, ramp, p_zmin, p_zmax, show)
 
-    def dens_func( z, r ):
-        dens = np.ones_like( z )
-        # Make the density smooth at rmax
-        dens = np.where( r > rmax-smooth_r,
-            np.cos(0.5*np.pi*(r-smooth_r)/smooth_r)**2, dens)
-        # Make the density 0 below p_zmin
-        dens = np.where( z < p_zmin, 0., dens )
-        # Make a linear ramp
-        dens = np.where( (z>=p_zmin) & (z<p_zmin+ramp),
-                         (z-p_zmin)/ramp*dens, dens )
-        return( dens )
+def test_labframe_without_preexisting_plasma(show=False):
+    "Run test in lab frame without some plasma at t=0"
+    p_zmin = zmax + 2*dz # Chosen outside the physical box
+    run_continuous_injection(None, ramp0, p_zmin, p_zmax, show)
 
-    # Run the test
-    uth = 0.0001
-    run_continuous_injection(gamma_boost, dens_func, uth, p_zmin, p_zmax, show)
-
-
-def run_continuous_injection( gamma_boost, dens_func, uth,
-                              p_zmin, p_zmax, show, N_check=3 ):
+def run_continuous_injection( gamma_boost, ramp, p_zmin, p_zmax,
+                              show, N_check=2 ):
     # Chose the time step
     dt = (zmax-zmin)/Nz/c
+
+    def dens_func( z, r ):
+        dens = np.ones_like( z )
+        # Make the density smooth at rmax
+        dens = np.where( r > rmax-smooth_r,
+            np.cos(0.5*np.pi*(r-smooth_r)/smooth_r)**2, dens)
+        # Make the density 0 below p_zmin
+        dens = np.where( z < p_zmin, 0., dens )
+        # Make a linear ramp
+        dens = np.where( (z>=p_zmin) & (z<p_zmin+ramp),
+                         (z-p_zmin)/ramp*dens, dens )
+        return( dens )
 
     # Initialize the different structures
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
@@ -110,6 +93,7 @@ def run_continuous_injection( gamma_boost, dens_func, uth,
 
     # Add another species with a different number of particles per cell
     # and with a finite temperature
+    uth = 0.0001
     sim.add_new_species( -e, m_e, 0.5*n, dens_func,
                             2*p_nz, 2*p_nr, 2*p_nt,
                             p_zmin, p_zmax, 0, p_rmax,
@@ -179,6 +163,6 @@ def check_density( sim, gamma_boost, dens_func, show ):
 
 
 if __name__ == '__main__' :
-
-    test_rest_continuous_injection(show)
-    test_boosted_continuous_injection(show)
+    test_labframe_with_preexisting_plasma(show)
+    test_boosted_with_preexisting_plasma(show)
+    test_labframe_without_preexisting_plasma(show)


### PR DESCRIPTION
PR #300 introduced a small bug in the continuous injection routines: when there is no plasma in the box at t=0, the new plasma will only start being injected *after* the damp cells and injection cells, instead of being injected immediately after the end of the physical domain. As a result, simulations typically feature an absence of plasma in the first microns of the simulation.

This PR fixes the bug.
In addition, it adds an automated test to catch similar errors in the future (up to now, the automated tests only checked cases where there is some plasma at t=0 in the box). I also refactored a bit the continous injection test, in order to avoid code duplication.