### PR TITLE
Fix Travis CI tests by limiting the number of threads running simultaneously.

### DIFF
--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -248,7 +248,7 @@ def test_parametric_sim_twoproc():
 
     # Launch the modified script from the OS, with 2 proc
     command_line = 'cd %s; NUMBA_NUM_THREADS=1 MKL_NUM_THREADS=1 '%temporary_dir
-    command_line += 'mpirun -np 2 python boosted_frame_script.py'
+    command_line += 'mpirun -np 2 python parametric_script.py'
     response = os.system( command_line )
     assert response==0
 


### PR DESCRIPTION
It seems that something recently changed on Travis CI, and is making the simulations *very slow* when using more than 2 threads simultaneously.

This impacted the tests that use MPI, since we were running 2 MPI with 2 threads each (4 threads total running simultaneously). These tests were taking >5x longer, resulting in a timeout for the Travis build.

This PR fixes the issue by imposing a single thread when running the MPI tests.