### PR TITLE
Added more publications to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The code outputs HDF5 files, that comply with the
 
 We welcome contributions to the code! Please read [this page](https://github.com/fbpic/fbpic/blob/master/CONTRIBUTING.md) for guidelines on how to contribute.
 
-## Attribution
+## Research & Attribution
 
 FBPIC was originally developed by Remi Lehe at [Berkeley Lab](http://www.lbl.gov/),
 and Manuel Kirchen at
@@ -118,10 +118,13 @@ and Manuel Kirchen at
 benefitted from the contributions of Soeren Jalas (CFEL), Kevin Peters (CFEL),
 Irene Dornmair (CFEL) and Igor Andriyash (Weizmann Institute).
 
+FBPIC's algorithms are documented in following scientific publications:
+
+* General description of FBPIC and it's algorithm (original paper): [R. Lehe et al., CPC, 2016](http://www.sciencedirect.com/science/article/pii/S0010465516300224) ([arxiV](https://arxiv.org/abs/1507.04790))
+* Boosted-frame technique with Galilean algorithm: [M. Kirchen et al., PoP, 2016](https://aip.scitation.org/doi/10.1063/1.4964770) ([arxiV](https://arxiv.org/abs/1608.00215)) and [Lehe et al., PRE, 2016](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.94.053305) ([arxiV](https://arxiv.org/abs/1608.00227))
+* Parallel finite-order solver for multi-CPU/GPU simulations: [S. Jalas et al., PoP, 2017](https://aip.scitation.org/doi/abs/10.1063/1.4978569) ([arxiV](https://arxiv.org/abs/1611.05712))
+
 If you use FBPIC for your research project: that's great! We are
 very pleased that the code is useful to you!
 
-If your project even leads to a scientific publication, please
-consider citing FBPIC's original paper, which can be found
-[here](http://www.sciencedirect.com/science/article/pii/S0010465516300224)
-(see [this link](https://arxiv.org/abs/1507.04790) for the arxiv version).
+If your project even leads to a scientific publication, please consider citing at least FBPIC's original paper. If your project uses the more advanced algorithms, please consider citing the respective publications in addition.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,8 +66,8 @@ Github.
 We welcome contributions to the code! If you wish to contribute,
 please read `this page <https://github.com/fbpic/fbpic/blob/master/CONTRIBUTING.md>`_ .
 
-Attribution
----------------
+Research & Attribution
+----------------------
 
 FBPIC was originally developed by Remi Lehe at `Berkeley Lab <http://www.lbl.gov/>`_,
 and Manuel Kirchen at
@@ -75,8 +75,18 @@ and Manuel Kirchen at
 benefitted from the contributions of Soeren Jalas (CFEL), Kevin Peters (CFEL),
 Irene Dornmair (CFEL) and Igor Andriyash (Weizmann Institute).
 
+FBPIC's algorithms are documented in following scientific publications:
+
+    * General description of FBPIC and it's algorithm (original paper):
+      `R. Lehe et al., CPC, 2016 <http://www.sciencedirect.com/science/article/pii/S0010465516300224>`_ (`arxiV <https://arxiv.org/abs/1507.04790>`_)
+    * Boosted-frame technique with Galilean algorithm:
+      `M. Kirchen et al., PoP, 2016 <https://aip.scitation.org/doi/10.1063/1.4964770>`_ (`arxiV <https://arxiv.org/abs/1608.00215>`_) and
+      `Lehe et al., PRE, 2016 <https://journals.aps.org/pre/abstract/10.1103/PhysRevE.94.053305>`_ (`arxiV <https://arxiv.org/abs/1608.00227>`_)
+    * Parallel finite-order solver for multi-CPU/GPU simulations:
+      `S. Jalas et al., PoP, 2017 <https://aip.scitation.org/doi/abs/10.1063/1.4978569>`_ (`arxiV <https://arxiv.org/abs/1611.05712>`_)
+
 If you use FBPIC for your research project: that's great! We are
-very pleased that the code is useful to you! If your project even leads
-to a scientific publication, please consider citing FBPIC's original
-paper, which can be found `on this page <http://www.sciencedirect.com/science/article/pii/S0010465516300224>`_
-(see `this link <https://arxiv.org/abs/1507.04790>`_ for the arxiv version).
+very pleased that the code is useful to you!
+
+If your project even leads to a scientific publication, please consider citing at least FBPIC's original paper.
+If your project uses the more advanced algorithms, please consider citing the respective publications in addition.


### PR DESCRIPTION
As discussed offline with @RemiLehe, I added additional publications with links to the Readme such that new users can more easily find research papers related to the algorithms of FBPIC. Additionally, we now ask the user to also cite the additional references in their publications if they used the more advanced features of FBPIC.