### PR TITLE
Force numba 0.41 in automated tests and installation instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes numba scipy h5py mkl
+  - conda install --yes numba==0.41 scipy h5py mkl
   - conda install --yes -c conda-forge mpi4py mpich
   - pip install pyflakes
   - python setup.py install

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ it from [here](https://www.continuum.io/downloads).
 
 - Install the dependencies of FBPIC. This can be done in two lines:
 ```
-conda install numba scipy h5py mkl
+conda install numba==0.41 scipy h5py mkl
 conda install -c conda-forge mpi4py
 ```
 - Download and install FBPIC:

--- a/docs/source/install/install_comet.rst
+++ b/docs/source/install/install_comet.rst
@@ -38,7 +38,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-      conda install -c conda-forge numba scipy h5py mkl cudatoolkit=8.0 pyculib
+      conda install -c conda-forge numba==0.41 scipy h5py mkl cudatoolkit=8.0 pyculib
 
 -  Install ``mpi4py``
 

--- a/docs/source/install/install_cori_edison.rst
+++ b/docs/source/install/install_cori_edison.rst
@@ -35,7 +35,7 @@ In order to install FBPIC, follow the steps below:
 
    ::
 
-       pip install --upgrade numba llvmlite tbb --user
+       pip install --upgrade numba==0.41 llvmlite tbb --user
 
 -  Install FBPIC
 

--- a/docs/source/install/install_jureca.rst
+++ b/docs/source/install/install_jureca.rst
@@ -44,7 +44,7 @@ In order to download and install `Anaconda <https://www.continuum.io/downloads>`
 Then install the dependencies of FBPIC:
 ::
 
-   conda install numba mkl
+   conda install numba==0.41 mkl
    conda install pyculib
 
 It is important that the following packages are **NOT** installed

--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -56,7 +56,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install numba scipy h5py mkl
+       conda install numba==0.41 scipy h5py mkl
        conda install -c conda-forge mpi4py
        conda install cudatoolkit=8 pyculib
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -14,7 +14,7 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
   ::
 
-     conda install numba scipy h5py mkl
+     conda install numba==0.41 scipy h5py mkl
      conda install -c conda-forge mpi4py
 
 -  Install ``fbpic``

--- a/docs/source/install/install_titan.rst
+++ b/docs/source/install/install_titan.rst
@@ -57,7 +57,7 @@ Installation of FBPIC and its dependencies
 
   ::
 
-    conda install numba scipy h5py mkl
+    conda install numba==0.41 scipy h5py mkl
     conda install cudatoolkit=8.0 pyculib
 
 -  Clone and install the ``fbpic`` repository using git

--- a/fbpic/utils/threading.py
+++ b/fbpic/utils/threading.py
@@ -8,7 +8,17 @@ It defines a set of generic functions for multithreaded CPU execution.
 import os, sys
 import warnings
 import numpy as np
+import numba
 from numba import njit
+
+# Impose restrictions on numba version
+numba_minor_version = int(numba.__version__.split('.')[1])
+# Numba version 0.42 causes the current deposition with cubic shape to fail
+if numba_minor_version == 42:
+    raise RuntimeError(
+        'FBPIC is incompatible with Numba version 0.42.\n'
+        'Please install Numba version 0.41 instead:\n'
+        '  conda install numba==0.41')
 
 # By default threading is enabled, except on Windows (not supported by Numba)
 threading_enabled = True
@@ -28,8 +38,6 @@ if threading_enabled:
         from numba import prange as numba_prange
         # Check that numba is version 0.34 or higher than 0.36
         # (other versions fail)
-        import numba
-        numba_minor_version = int(numba.__version__.split('.')[1])
         assert ( numba_minor_version==34 or numba_minor_version >= 36 )
     except (ImportError, AssertionError):
         threading_enabled = False


### PR DESCRIPTION
It seems that the latest version of numba (numba 0.42) causes the CPU function `deposit_J_numba_cubic` to crash with the following error:
```
python: /tmp/build/80754af9/llvmdev_1546540969021/work/include/llvm/IR/Instructions.h:3083: llvm::Value* llvm::PHINode::removeIncomingValue(const llvm::BasicBlock*, bool): Assertion `Idx >= 0 && "Invalid basic block argument to remove!"' failed.
Aborted (core dumped)
```
Interestingly the functions `deposit_J_numba_linear` and `deposit_rho_numba_cubic` work fine.

While the problem is being investigated, I think that it would be good to avoid using numba 0.42. This is what this PR does, by:
- Raising an error if FBPIC detects that numba 0.42 is being used
- Modifying the documentation for installation, so as to recommend using numba 0.41
- Modifying the automated tests, so that numba 0.41 is used