### PR TITLE
Allow FBPIC to work with numba 0.42

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes numba==0.41 scipy h5py mkl
+  - conda install --yes numba scipy h5py mkl
   - conda install --yes -c conda-forge mpi4py mpich
   - pip install pyflakes
   - python setup.py install

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ it from [here](https://www.continuum.io/downloads).
 
 - Install the dependencies of FBPIC. This can be done in two lines:
 ```
-conda install numba==0.41 scipy h5py mkl
+conda install numba scipy h5py mkl
 conda install -c conda-forge mpi4py
 ```
 - Download and install FBPIC:

--- a/docs/source/install/install_comet.rst
+++ b/docs/source/install/install_comet.rst
@@ -38,7 +38,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-      conda install -c conda-forge numba==0.41 scipy h5py mkl cudatoolkit=8.0 pyculib
+      conda install -c conda-forge numba scipy h5py mkl cudatoolkit=8.0 pyculib
 
 -  Install ``mpi4py``
 

--- a/docs/source/install/install_cori_edison.rst
+++ b/docs/source/install/install_cori_edison.rst
@@ -35,7 +35,7 @@ In order to install FBPIC, follow the steps below:
 
    ::
 
-       pip install --upgrade numba==0.41 llvmlite tbb --user
+       pip install --upgrade numba llvmlite tbb --user
 
 -  Install FBPIC
 

--- a/docs/source/install/install_jureca.rst
+++ b/docs/source/install/install_jureca.rst
@@ -44,7 +44,7 @@ In order to download and install `Anaconda <https://www.continuum.io/downloads>`
 Then install the dependencies of FBPIC:
 ::
 
-   conda install numba==0.41 mkl
+   conda install numba mkl
    conda install pyculib
 
 It is important that the following packages are **NOT** installed

--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -56,7 +56,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install numba==0.41 scipy h5py mkl
+       conda install numba scipy h5py mkl
        conda install -c conda-forge mpi4py
        conda install cudatoolkit=8 pyculib
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -14,7 +14,7 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
   ::
 
-     conda install numba==0.41 scipy h5py mkl
+     conda install numba scipy h5py mkl
      conda install -c conda-forge mpi4py
 
 -  Install ``fbpic``

--- a/docs/source/install/install_titan.rst
+++ b/docs/source/install/install_titan.rst
@@ -57,7 +57,7 @@ Installation of FBPIC and its dependencies
 
   ::
 
-    conda install numba==0.41 scipy h5py mkl
+    conda install numba scipy h5py mkl
     conda install cudatoolkit=8.0 pyculib
 
 -  Clone and install the ``fbpic`` repository using git

--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -19,55 +19,63 @@ import numpy as np
 @cuda.jit(device=True, inline=True)
 def z_shape_linear(cell_position, index):
     iz = int(math.ceil(cell_position)) - 1
+    s = 0.
     if index == 0:
-        return iz+1.-cell_position
-    if index == 1:
-        return cell_position - iz
+        s = iz+1.-cell_position
+    elif index == 1:
+        s = cell_position - iz
+    return s
 
 @cuda.jit(device=True, inline=True)
 def r_shape_linear(cell_position, index):
     flip_factor = 1.
     ir = int(math.ceil(cell_position)) - 1
+    s = 0.
     if index == 0:
         if ir < 0:
             flip_factor = -1.
-        return flip_factor*(ir+1.-cell_position)
-    if index == 1:
-        return flip_factor*(cell_position - ir)
+        s = flip_factor*(ir+1.-cell_position)
+    elif index == 1:
+        s = flip_factor*(cell_position - ir)
+    return s
 
 # Cubic shapes
 @cuda.jit(device=True, inline=True)
 def z_shape_cubic(cell_position, index):
     iz = int(math.ceil(cell_position)) - 2
+    s = 0.
     if index == 0:
-        return (-1./6.)*((cell_position-iz)-2)**3
-    if index == 1:
-        return (1./6.)*(3*((cell_position-(iz+1))**3)-6*((cell_position-(iz+1))**2)+4)
-    if index == 2:
-        return (1./6.)*(3*(((iz+2)-cell_position)**3)-6*(((iz+2)-cell_position)**2)+4)
-    if index == 3:
-        return (-1./6.)*(((iz+3)-cell_position)-2)**3
+        s = (-1./6.)*((cell_position-iz)-2)**3
+    elif index == 1:
+        s = (1./6.)*(3*((cell_position-(iz+1))**3)-6*((cell_position-(iz+1))**2)+4)
+    elif index == 2:
+        s = (1./6.)*(3*(((iz+2)-cell_position)**3)-6*(((iz+2)-cell_position)**2)+4)
+    elif index == 3:
+        s = (-1./6.)*(((iz+3)-cell_position)-2)**3
+    return s
 
 @cuda.jit(device=True, inline=True)
 def r_shape_cubic(cell_position, index):
     flip_factor = 1.
     ir = int(math.ceil(cell_position)) - 2
+    s = 0.
     if index == 0:
         if ir < 0:
             flip_factor = -1.
-        return flip_factor*(-1./6.)*((cell_position-ir)-2)**3
-    if index == 1:
+        s = flip_factor*(-1./6.)*((cell_position-ir)-2)**3
+    elif index == 1:
         if ir+1 < 0:
             flip_factor = -1.
-        return flip_factor*(1./6.)*(3*((cell_position-(ir+1))**3)-6*((cell_position-(ir+1))**2)+4)
-    if index == 2:
+        s = flip_factor*(1./6.)*(3*((cell_position-(ir+1))**3)-6*((cell_position-(ir+1))**2)+4)
+    elif index == 2:
         if ir+2 < 0:
             flip_factor = -1.
-        return flip_factor*(1./6.)*(3*(((ir+2)-cell_position)**3)-6*(((ir+2)-cell_position)**2)+4)
-    if index == 3:
+        s = flip_factor*(1./6.)*(3*(((ir+2)-cell_position)**3)-6*(((ir+2)-cell_position)**2)+4)
+    elif index == 3:
         if ir+3 < 0:
             flip_factor = -1.
-        return flip_factor*(-1./6.)*(((ir+3)-cell_position)-2)**3
+        s = flip_factor*(-1./6.)*(((ir+3)-cell_position)-2)**3
+    return s
 
 # -------------------------------
 # Field deposition - linear - rho

--- a/fbpic/particles/deposition/cuda_methods_one_mode.py
+++ b/fbpic/particles/deposition/cuda_methods_one_mode.py
@@ -11,6 +11,7 @@ import math
 from scipy.constants import c
 import numpy as np
 
+
 # -------------------------------
 # Particle shape Factor functions
 # -------------------------------
@@ -19,55 +20,63 @@ import numpy as np
 @cuda.jit(device=True, inline=True)
 def z_shape_linear(cell_position, index):
     iz = int(math.ceil(cell_position)) - 1
+    s = 0.
     if index == 0:
-        return iz+1.-cell_position
-    if index == 1:
-        return cell_position - iz
+        s = iz+1.-cell_position
+    elif index == 1:
+        s = cell_position - iz
+    return s
 
 @cuda.jit(device=True, inline=True)
 def r_shape_linear(cell_position, index):
     flip_factor = 1.
     ir = int(math.ceil(cell_position)) - 1
+    s = 0.
     if index == 0:
         if ir < 0:
             flip_factor = -1.
-        return flip_factor*(ir+1.-cell_position)
-    if index == 1:
-        return flip_factor*(cell_position - ir)
+        s = flip_factor*(ir+1.-cell_position)
+    elif index == 1:
+        s = flip_factor*(cell_position - ir)
+    return s
 
 # Cubic shapes
 @cuda.jit(device=True, inline=True)
 def z_shape_cubic(cell_position, index):
     iz = int(math.ceil(cell_position)) - 2
+    s = 0.
     if index == 0:
-        return (-1./6.)*((cell_position-iz)-2)**3
-    if index == 1:
-        return (1./6.)*(3*((cell_position-(iz+1))**3)-6*((cell_position-(iz+1))**2)+4)
-    if index == 2:
-        return (1./6.)*(3*(((iz+2)-cell_position)**3)-6*(((iz+2)-cell_position)**2)+4)
-    if index == 3:
-        return (-1./6.)*(((iz+3)-cell_position)-2)**3
+        s = (-1./6.)*((cell_position-iz)-2)**3
+    elif index == 1:
+        s = (1./6.)*(3*((cell_position-(iz+1))**3)-6*((cell_position-(iz+1))**2)+4)
+    elif index == 2:
+        s = (1./6.)*(3*(((iz+2)-cell_position)**3)-6*(((iz+2)-cell_position)**2)+4)
+    elif index == 3:
+        s = (-1./6.)*(((iz+3)-cell_position)-2)**3
+    return s
 
 @cuda.jit(device=True, inline=True)
 def r_shape_cubic(cell_position, index):
     flip_factor = 1.
     ir = int(math.ceil(cell_position)) - 2
+    s = 0.
     if index == 0:
         if ir < 0:
             flip_factor = -1.
-        return flip_factor*(-1./6.)*((cell_position-ir)-2)**3
-    if index == 1:
+        s = flip_factor*(-1./6.)*((cell_position-ir)-2)**3
+    elif index == 1:
         if ir+1 < 0:
             flip_factor = -1.
-        return flip_factor*(1./6.)*(3*((cell_position-(ir+1))**3)-6*((cell_position-(ir+1))**2)+4)
-    if index == 2:
+        s = flip_factor*(1./6.)*(3*((cell_position-(ir+1))**3)-6*((cell_position-(ir+1))**2)+4)
+    elif index == 2:
         if ir+2 < 0:
             flip_factor = -1.
-        return flip_factor*(1./6.)*(3*(((ir+2)-cell_position)**3)-6*(((ir+2)-cell_position)**2)+4)
-    if index == 3:
+        s = flip_factor*(1./6.)*(3*(((ir+2)-cell_position)**3)-6*(((ir+2)-cell_position)**2)+4)
+    elif index == 3:
         if ir+3 < 0:
             flip_factor = -1.
-        return flip_factor*(-1./6.)*(((ir+3)-cell_position)-2)**3
+        s = flip_factor*(-1./6.)*(((ir+3)-cell_position)-2)**3
+    return s
 
 # -------------------------------
 # Field deposition - linear - rho

--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -22,8 +22,10 @@ def Sz_linear(cell_position, index):
     iz = np.floor(cell_position)
     if index == 0:
         return iz+1.-cell_position
-    if index == 1:
+    elif index == 1:
         return cell_position - iz
+    else:
+        return 0.
 
 @numba.njit
 def Sr_linear(cell_position, index):
@@ -33,8 +35,10 @@ def Sr_linear(cell_position, index):
         if ir < 0:
             flip_factor = -1.
         return flip_factor*(ir+1.-cell_position)
-    if index == 1:
+    elif index == 1:
         return flip_factor*(cell_position - ir)
+    else:
+        return 0.
 
 # Cubic shapes
 @numba.njit
@@ -42,12 +46,14 @@ def Sz_cubic(cell_position, index):
     iz = np.floor(cell_position) - 1.
     if index == 0:
         return (-1./6.)*((cell_position-iz)-2)**3
-    if index == 1:
+    elif index == 1:
         return (1./6.)*(3*((cell_position-(iz+1))**3)-6*((cell_position-(iz+1))**2)+4)
-    if index == 2:
+    elif index == 2:
         return (1./6.)*(3*(((iz+2)-cell_position)**3)-6*(((iz+2)-cell_position)**2)+4)
-    if index == 3:
+    elif index == 3:
         return (-1./6.)*(((iz+3)-cell_position)-2)**3
+    else:
+        return 0.
 
 @numba.njit
 def Sr_cubic(cell_position, index):
@@ -57,18 +63,20 @@ def Sr_cubic(cell_position, index):
         if ir < 0:
             flip_factor = -1.
         return flip_factor*(-1./6.)*((cell_position-ir)-2)**3
-    if index == 1:
+    elif index == 1:
         if ir+1 < 0:
             flip_factor = -1.
         return flip_factor*(1./6.)*(3*((cell_position-(ir+1))**3)-6*((cell_position-(ir+1))**2)+4)
-    if index == 2:
+    elif index == 2:
         if ir+2 < 0:
             flip_factor = -1.
         return flip_factor*(1./6.)*(3*(((ir+2)-cell_position)**3)-6*(((ir+2)-cell_position)**2)+4)
-    if index == 3:
+    elif index == 3:
         if ir+3 < 0:
             flip_factor = -1.
         return flip_factor*(-1./6.)*(((ir+3)-cell_position)-2)**3
+    else:
+        return 0.
 
 # -------------------------------
 # Field deposition - linear - rho

--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -20,63 +20,63 @@ from scipy.constants import c
 @numba.njit
 def Sz_linear(cell_position, index):
     iz = np.floor(cell_position)
+    s = 0.
     if index == 0:
-        return iz+1.-cell_position
+        s = iz+1.-cell_position
     elif index == 1:
-        return cell_position - iz
-    else:
-        return 0.
+        s = cell_position - iz
+    return s
 
 @numba.njit
 def Sr_linear(cell_position, index):
     flip_factor = 1.
     ir = np.floor(cell_position)
+    s = 0.
     if index == 0:
         if ir < 0:
             flip_factor = -1.
-        return flip_factor*(ir+1.-cell_position)
+        s = flip_factor*(ir+1.-cell_position)
     elif index == 1:
-        return flip_factor*(cell_position - ir)
-    else:
-        return 0.
+        s = flip_factor*(cell_position - ir)
+    return s
 
 # Cubic shapes
 @numba.njit
 def Sz_cubic(cell_position, index):
     iz = np.floor(cell_position) - 1.
+    s = 0.
     if index == 0:
-        return (-1./6.)*((cell_position-iz)-2)**3
+        s = (-1./6.)*((cell_position-iz)-2)**3
     elif index == 1:
-        return (1./6.)*(3*((cell_position-(iz+1))**3)-6*((cell_position-(iz+1))**2)+4)
+        s = (1./6.)*(3*((cell_position-(iz+1))**3)-6*((cell_position-(iz+1))**2)+4)
     elif index == 2:
-        return (1./6.)*(3*(((iz+2)-cell_position)**3)-6*(((iz+2)-cell_position)**2)+4)
+        s = (1./6.)*(3*(((iz+2)-cell_position)**3)-6*(((iz+2)-cell_position)**2)+4)
     elif index == 3:
-        return (-1./6.)*(((iz+3)-cell_position)-2)**3
-    else:
-        return 0.
+        s = (-1./6.)*(((iz+3)-cell_position)-2)**3
+    return s
 
 @numba.njit
 def Sr_cubic(cell_position, index):
     flip_factor = 1.
     ir = np.floor(cell_position) - 1.
+    s = 0.
     if index == 0:
         if ir < 0:
             flip_factor = -1.
-        return flip_factor*(-1./6.)*((cell_position-ir)-2)**3
+        s = flip_factor*(-1./6.)*((cell_position-ir)-2)**3
     elif index == 1:
         if ir+1 < 0:
             flip_factor = -1.
-        return flip_factor*(1./6.)*(3*((cell_position-(ir+1))**3)-6*((cell_position-(ir+1))**2)+4)
+        s = flip_factor*(1./6.)*(3*((cell_position-(ir+1))**3)-6*((cell_position-(ir+1))**2)+4)
     elif index == 2:
         if ir+2 < 0:
             flip_factor = -1.
-        return flip_factor*(1./6.)*(3*(((ir+2)-cell_position)**3)-6*(((ir+2)-cell_position)**2)+4)
+        s = flip_factor*(1./6.)*(3*(((ir+2)-cell_position)**3)-6*(((ir+2)-cell_position)**2)+4)
     elif index == 3:
         if ir+3 < 0:
             flip_factor = -1.
-        return flip_factor*(-1./6.)*(((ir+3)-cell_position)-2)**3
-    else:
-        return 0.
+        s = flip_factor*(-1./6.)*(((ir+3)-cell_position)-2)**3
+    return s
 
 # -------------------------------
 # Field deposition - linear - rho

--- a/fbpic/utils/threading.py
+++ b/fbpic/utils/threading.py
@@ -8,17 +8,7 @@ It defines a set of generic functions for multithreaded CPU execution.
 import os, sys
 import warnings
 import numpy as np
-import numba
 from numba import njit
-
-# Impose restrictions on numba version
-numba_minor_version = int(numba.__version__.split('.')[1])
-# Numba version 0.42 causes the current deposition with cubic shape to fail
-if numba_minor_version == 42:
-    raise RuntimeError(
-        'FBPIC is incompatible with Numba version 0.42.\n'
-        'Please install Numba version 0.41 instead:\n'
-        '  conda install numba==0.41')
 
 # By default threading is enabled, except on Windows (not supported by Numba)
 threading_enabled = True
@@ -38,6 +28,8 @@ if threading_enabled:
         from numba import prange as numba_prange
         # Check that numba is version 0.34 or higher than 0.36
         # (other versions fail)
+        import numba
+        numba_minor_version = int(numba.__version__.split('.')[1])
         assert ( numba_minor_version==34 or numba_minor_version >= 36 )
     except (ImportError, AssertionError):
         threading_enabled = False


### PR DESCRIPTION
It is seems that issue with `numba 0.42` (see #317) was related to the fact the functions for the shape factors (in the deposition kernels), contained a return statement within an `if` condition. (see the functions `Sz_linear`, etc. in `fbpic/particles/deposition/threading_methods.py`)

In fact, these functions do seem a bit weird, since they have cases that result in no `return` statement (hence what value do they return in this case?!) : see for instance `Sz_linear` for the case `index=2` - although it is never used in practice.

I modified these functions, so as to take the `return` statement outside of the `if` condition (see corresponding code below). 
Although the GPU functions were not causing any issue with numba 0.42, I modified them accordingly, for consistency. I tested the performance on a GTX 1080 Ti and did not see any significant change.

Since the CPU functions now work properly with numba 0.42, I removed all the restrictions imposed by #317 .

