### PR TITLE
Close #323: Avoid negative gamma when initialising gaussian bunch

### DIFF
--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -94,6 +94,7 @@ def add_elec_bunch( sim, gamma0, n_e, p_zmin, p_zmax, p_rmin, p_rmax,
     # Get the corresponding space-charge fields
     get_space_charge_fields( sim, relat_elec, direction=direction )
 
+
 def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0,
                         sig_gamma, Q, N, tf=0., zf=0., boost=None,
                         save_beam=None, z_injection_plane=None ):
@@ -153,38 +154,59 @@ def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0,
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
     """
-    # Get Gaussian particle distribution in x,y,z
-    x = sig_r * np.random.normal(0., 1., N)
-    y = sig_r * np.random.normal(0., 1., N)
-    z = zf + sig_z * np.random.normal(0., 1., N) # with offset in z
-    # Define sigma of ux and uy based on normalized emittance
-    sig_ur = (n_emit/sig_r)
-    # Get Gaussian distribution of transverse normalized momenta ux, uy
-    ux = sig_ur * np.random.normal(0., 1., N)
-    uy = sig_ur * np.random.normal(0., 1., N)
-    # Now we imprint an energy spread on the gammas of each particle
+    # Generate Gaussian gamma distribution of the beam
     if sig_gamma > 0.:
         gamma = np.random.normal(gamma0, sig_gamma, N)
     else:
-        # Or set it to zero
+        # Zero energy spread beam
         gamma = np.full(N, gamma0)
         if sig_gamma < 0.:
             print("Warning: Negative energy spread sig_gamma detected."
                   " sig_gamma will be set to zero. \n")
+    # Get inverse gamma
+    inv_gamma = 1. / gamma
+    # Get Gaussian particle distribution in x,y,z
+    x = sig_r * np.random.normal(0., 1., N)
+    y = sig_r * np.random.normal(0., 1., N)
+    z = zf + sig_z * np.random.normal(0., 1., N)  # with offset in z
+
+    # Define sigma of ux and uy based on normalized emittance
+    sig_ur = (n_emit / sig_r)
+    # Get Gaussian distribution of transverse normalized momenta ux, uy
+    ux = sig_ur * np.random.normal(0., 1., N)
+    uy = sig_ur * np.random.normal(0., 1., N)
+
     # Finally we calculate the uz of each particle
     # from the gamma and the transverse momenta ux, uy
-    uz = np.sqrt((gamma**2-1) - ux**2 - uy**2)
-    # Get inverse gamma
-    inv_gamma = 1./gamma
-    # Get weight of each particle
-    w = abs(Q) / (N*e) * np.ones_like(x)
+    uz_sqr = (gamma ** 2 - 1) - ux ** 2 - uy ** 2
 
+    # Check for unphysical particles with uz**2 < 0
+    mask = uz_sqr <= 0
+    N_remove = np.count_nonzero(mask)
+    if N_remove != 0:
+        print("Warning: Particles with uz**2<0 detected."
+              " %d Particles will be removed from the beam. \n"
+              "This will truncate the distribution of the beam"
+              " at gamma ~= 1. \n"
+              "However, the charge will be kept constant. \n" % N_remove)
+        # Remove unphysical particles with uz**2 < 0
+        x = x[~mask]
+        y = y[~mask]
+        z = z[~mask]
+        ux = ux[~mask]
+        uy = uy[~mask]
+        inv_gamma = inv_gamma[~mask]
+        uz_sqr = uz_sqr[~mask]
+    # Calculate longitudinal momentum of the bunch
+    uz = np.sqrt(uz_sqr)
+    # Get weight of each particle
+    w = abs(Q) / ((N - N_remove) * e) * np.ones_like(x)
     # Propagate distribution to an out-of-focus position tf.
     # (without taking space charge effects into account)
     if tf != 0.:
-        x = x - ux*inv_gamma*c*tf
-        y = y - uy*inv_gamma*c*tf
-        z = z - uz*inv_gamma*c*tf
+        x = x - ux * inv_gamma * c * tf
+        y = y - uy * inv_gamma * c * tf
+        z = z - uz * inv_gamma * c * tf
 
     # Save beam distribution to an .npz file
     if save_beam is not None:


### PR DESCRIPTION
This is a suggestion to solve the issue brought up by @RemiLehe.
The approach would be to remove those particles that result in unphysical gammas. This would of cause change the mean gamma and the std of the distribution but I see no way of avoiding that. 

It is not straightforward to only remove the particles that have a gamma < 1, since there can be the case where ux and uy which are generated according to the emittance of the beam result in a gamma that is larger than the randomly generated gamma and thous would require an imaginary uz for uz,ux,uy and gamma to be consistent.
Therefore, similar as before ux, uy and gamma are calculated independently and from that the square of uz is calculated. Then all the particles are dropped which have a uz**2 < 1. If that happens the user is issued a warning stating how many particles were removed.

The below shows what happens to the spectrum when it gets truncated. The spectra all have the same  sigma_gamma and different gamma0. There is basically a smooth transition so that dQ/d_gamma is 0 at gamma = 1.  
Right now the implementation is such that the charge is kept constant when removing the particles and therefore the spectral density increases when the beam is truncated.

![trunc_bunch](https://user-images.githubusercontent.com/10922951/52125651-6ddb8e80-262d-11e9-8b3d-976bb0858ffd.png)

