### PR TITLE
Close #324: Pass the user-defined smoother to the space-charge calculator

### DIFF
--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -124,6 +124,7 @@ class Fields(object) :
         # Set the default smoother
         if smoother is None:
             smoother = BinomialSmoother( n_passes=1, compensator=False )
+        self.smoother = smoother
 
         # Define wether or not to use the GPU
         self.use_cuda = use_cuda

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -452,7 +452,8 @@ def get_space_charge_fields( sim, ptcl, direction='forward' ):
                     local=False, with_damp=True, with_guard=False )
     global_fld = Fields( global_Nz, global_zmax,
             sim.fld.Nr, sim.fld.rmax, sim.fld.Nm, sim.fld.dt,
-            zmin=global_zmin, n_order=sim.fld.n_order, use_cuda=False)
+            n_order=sim.fld.n_order, smoother=sim.fld.smoother,
+            zmin=global_zmin, use_cuda=False)
     # Gather the sources on the interpolation grid of global_fld
     for m in range(sim.fld.Nm):
         for field in ['Jr', 'Jt', 'Jz', 'rho']:


### PR DESCRIPTION
This fixes a small discrepancy between the space-charge calculator and Maxwell solver:
The Maxwell solver smoothes the charge/currents with a user-defined smoother, whereas the space-charge calculator always used the default smoother (one-pass binomial).