### PR TITLE
option to define a 3D plasma density profile

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -704,9 +704,11 @@ class Simulation(object):
            If `n` is not None, evenly-spaced macroparticles will be generated.
 
         dens_func : callable, optional
-           A function of the form :
+           A function of two of three arguments of the form :
            def dens_func( z, r ) ...
-           where z and r are 1d arrays, and which returns
+           or
+           def dens_func( x, y, z ) ...
+           where x, y, z and r are 1d arrays, and which returns
            a 1d array containing the density *relative to n*
            (i.e. a number between 0 and 1) at the given positions
 

--- a/fbpic/particles/injection/continuous_injection.py
+++ b/fbpic/particles/injection/continuous_injection.py
@@ -8,7 +8,14 @@ It defines a class for continuous particle injection with a moving window.
 import warnings
 import numpy as np
 from scipy.constants import c
-from inspect import signature
+import sys, inspect
+
+# convenience method retrieve arguments number of a function
+if sys.version_info[0] < 3:
+    get_args_len = lambda fu: len(inspect.getargspec(fu)[0])
+else:
+    get_args_len = lambda fu: len(inspect.signature(fu).parameters)
+
 
 class ContinuousInjector( object ):
     """
@@ -41,7 +48,7 @@ class ContinuousInjector( object ):
 
         # Define and register dimensions number for density profile
         if self.dens_func is not None:
-            self.dens_func_dim = len(signature(self.dens_func).parameters)
+            self.dens_func_dim = get_args_len(self.dens_func)
             if self.dens_func_dim not in (2, 3):
                 raise ValueError(
                 "Density function can have 2 or 3 arguments, " + \
@@ -243,7 +250,7 @@ def generate_evenly_spaced( Npz, zmin, zmax, Npr, rmin, rmax,
         w = n * r * dtheta*dr*dz
         # Modulate it by the density profile
         if dens_func is not None :
-            dens_func_dim = len(signature(dens_func).parameters)
+            dens_func_dim = get_args_len(dens_func)
             if dens_func_dim==2:
                 w *= dens_func( z, r )
             elif dens_func_dim==3:

--- a/fbpic/particles/injection/continuous_injection.py
+++ b/fbpic/particles/injection/continuous_injection.py
@@ -39,6 +39,7 @@ class ContinuousInjector( object ):
         self.uy_th = uy_th
         self.uz_th = uz_th
 
+        # Define and register dimensions number for density profile
         if self.dens_func is not None:
             self.dens_func_dim = len(signature(self.dens_func).parameters)
             if self.dens_func_dim not in (2, 3):
@@ -62,7 +63,6 @@ class ContinuousInjector( object ):
         self.nz_inject = None
         self.z_inject = None
         self.z_end_plasma = None
-
 
     def initialize_injection_positions( self, comm, v_moving_window,
                                         species_z, dt ):
@@ -162,7 +162,6 @@ class ContinuousInjector( object ):
         # and z_end_plasma, and afterwards nz_inject is set to 0.)
         self.z_end_plasma += nz_new * self.dz_particles
 
-
     def generate_particles( self, time ):
         """
         Generate new particles at the right end of the plasma
@@ -181,7 +180,7 @@ class ContinuousInjector( object ):
                     return( self.dens_func( z-self.v_end_plasma*time, r ) )
             elif self.dens_func_dim==3:
                 def dens_func( x, y, z ):
-                    return( self.dens_func(x,y, z-self.v_end_plasma*time ) )
+                    return( self.dens_func(x, y, z-self.v_end_plasma*time ) )
         else:
             dens_func = None
 
@@ -248,7 +247,7 @@ def generate_evenly_spaced( Npz, zmin, zmax, Npr, rmin, rmax,
             if dens_func_dim==2:
                 w *= dens_func( z, r )
             elif dens_func_dim==3:
-                w *= dens_func( x,y,z )
+                w *= dens_func( x, y, z )
 
         # Select the particles that have a non-zero weight
         selected = (w > 0)

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -106,9 +106,11 @@ class Particles(object) :
            Normalized thermal momenta in each direction
 
         dens_func : callable, optional
-           A function of the form :
+           A function of two of three arguments of the form :
            def dens_func( z, r ) ...
-           where z and r are 1d arrays, and which returns
+           or
+           def dens_func( x, y, z ) ...
+           where x, y, z and r are 1d arrays, and which returns
            a 1d array containing the density *relative to n*
            (i.e. a number between 0 and 1) at the given positions
 


### PR DESCRIPTION
In some cases, user could benefit using multi-mode (`Nm`>2) simulations with asymmetries in the transverse plasma profile, e.g. some non-ideal guiding potential for the laser, however, presently `dens_func` can only be purely axisymmetric.

This PR adds an option to define `dens_func` with three arguments `x`, `y` and `z`, instead of two `z` and `r`. Number of arguments is implicitly retrieved by `inspect.signature` method, so that this modification is fully backward-compatible: `2 args => (z,r)` and `3 args => (x,y,z)`