### PR TITLE
update doc for installation on Lawrencium at LBNL

### DIFF
--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -58,8 +58,8 @@ Installation of FBPIC and its dependencies
 
        conda install numba scipy h5py mkl
        conda install -c conda-forge mpi4py
-       conda install cudatoolkit=8 pyculib
-
+       conda install cudatoolkit=8
+       conda install -c conda-forge pyculib
 
 -  Install ``fbpic``
 


### PR DESCRIPTION
When following the installation instructions for Lawrencium, running
```conda install pyculib```
returned error
```Solving environment: failed
UnsatisfiableError: The following specifications were found to be in conflict:
  - conda[version='>=4.6.3']
  - pyculib
```
Replacing it with 
```conda install -c conda-forge pyculib```
solved the issue, and fbpic runs well on GPU.

Note that I tried `pip install pyculib`, but got a `pyculib` error at execution
```OSError: /global/scratch/thevenet/miniconda3/lib/pyculib_radixsort.so: cannot open shared object file: No such file or directory```