### PR TITLE
Prevent GPU particle communication/removal bug when all particles are in the guard cells

### DIFF
--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -228,11 +228,6 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     else:
         i_min = 0
     i_max = prefix_sum.getitem( iz_max*(Nr+1) - 1 )
-    # Because of the way in which the prefix_sum is calculated, if the
-    # cell that was requested for i_max is beyond the last non-empty cell,
-    # i_max will be zero, but should in fact be species.Ntot
-    if i_max == 0:
-        i_max = species.Ntot
 
     # Total number of particles in each particle group
     N_send_l = i_min


### PR DESCRIPTION
There is currently a bug in the particle communication/removal routines on GPU **when all particles of a given species are on the right-hand guard cells**: in this case the particles are not removed from the local domain.

Fundamentally, this is because the code computes the indices `i_min` and `i_max` between which particles should be kept. When all particles are in the right hand guard cells, then `i_min=0` and `i_max=0`. But then a special-case portion of the code (removed in this PR) erroneously sets `i_max=Ntot`.

This special part of the code used to here because the last cells of `prefix_sum` used to be filled with `0`. However this is no longer the case since we introduced `prefill_prefix_sum` in #110.

Therefore that erroneous portion can be safely removed.