### PR TITLE
Pass the diagnostic period as a physical time (instead of integer)

### DIFF
--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -13,18 +13,23 @@ class FieldDiagnostic(OpenPMDDiagnostic):
     Class that defines the field diagnostics to be performed.
     """
 
-    def __init__(self, period, fldobject, comm=None,
+    def __init__(self, period=None, fldobject=None, comm=None,
                  fieldtypes=["rho", "E", "B", "J"], write_dir=None,
-                 iteration_min=0, iteration_max=np.inf ) :
+                 iteration_min=0, iteration_max=np.inf, dt_period=None ) :
         """
         Initialize the field diagnostic.
 
         Parameters
         ----------
-        period : int
+        period : int, optional
             The period of the diagnostics, in number of timesteps.
             (i.e. the diagnostics are written whenever the number
-            of iterations is divisible by `period`)
+            of iterations is divisible by `period`). Specify either this or
+            `dt_period`.
+
+        dt_period : float (in seconds), optional
+            The period of the diagnostics, in physical time of the simulation.
+            Specify either this or `period`
 
         fldobject : a Fields object
             Points to the data that has to be written at each output
@@ -49,16 +54,22 @@ class FieldDiagnostic(OpenPMDDiagnostic):
             The iterations between which data should be written
             (`iteration_min` is inclusive, `iteration_max` is exclusive)
         """
+        # Check input
+        if fldobject is None:
+            raise ValueError(
+            "You need to pass the argument `fldobject` to `FieldDiagnostic`.")
+
         # General setup
         OpenPMDDiagnostic.__init__(self, period, comm, write_dir,
-                                    iteration_min, iteration_max )
+                            iteration_min, iteration_max,
+                            dt_period=dt_period, dt_sim=fldobject.dt )
 
         # Register the arguments
         self.fld = fldobject
         self.fieldtypes = fieldtypes
         self.coords = ['r', 't', 'z']
 
-    def write_hdf5( self, iteration ) :
+    def write_hdf5( self, iteration ):
         """
         Write an HDF5 file that complies with the OpenPMD standard
 

--- a/fbpic/openpmd_diag/particle_density_diag.py
+++ b/fbpic/openpmd_diag/particle_density_diag.py
@@ -13,23 +13,29 @@ class ParticleChargeDensityDiagnostic(FieldDiagnostic):
     Class that defines a diagnostic for particle density
     """
 
-    def __init__(self, period, sim, species={"electrons":None},
-                write_dir=None, iteration_min=0, iteration_max=np.inf ) :
+    def __init__(self, period=None, sim=None, species={},
+                write_dir=None, iteration_min=0, iteration_max=np.inf,
+                dt_period=None ):
         """
         Writes the charge density of the specified species in the
         openPMD file (one dataset per species)
 
         Parameters
         ----------
-        period: int
+        period : int, optional
             The period of the diagnostics, in number of timesteps.
             (i.e. the diagnostics are written whenever the number
-            of iterations is divisible by `period`)
+            of iterations is divisible by `period`). Specify either this or
+            `dt_period`.
 
-        sim: an fbpic `Simulation` object
+        dt_period : float (in seconds), optional
+            The period of the diagnostics, in physical time of the simulation.
+            Specify either this or `period`
+
+        sim: an fbpic :any:`Simulation` object
             Contains the information of the simulation
 
-        species: a dictionary of Particle objects
+        species: a dictionary of :any:`Particles` objects
             Similar to the corresponding object for `ParticleDiagnostic`
             Specifies the density of which species should be written
 
@@ -42,6 +48,12 @@ class ParticleChargeDensityDiagnostic(FieldDiagnostic):
             The iterations between which data should be written
             (`iteration_min` is inclusive, `iteration_max` is exclusive)
         """
+        # Check the arguments
+        if sim is None:
+            raise ValueError("You need to pass the argument `sim`.")
+        if len(species) == 0:
+            raise ValueError("You need to pass a valid `species` dictionary.")
+
         # Build the list of fieldtypes
         fieldtypes = []
         for species_name in species.keys():
@@ -50,7 +62,8 @@ class ParticleChargeDensityDiagnostic(FieldDiagnostic):
         # General setup
         FieldDiagnostic.__init__(self, period, fldobject=sim.fld,
                     comm=sim.comm, fieldtypes=fieldtypes, write_dir=write_dir,
-                    iteration_min=iteration_min, iteration_max=iteration_max )
+                    iteration_min=iteration_min, iteration_max=iteration_max,
+                    dt_period=dt_period )
 
         # Register the arguments
         self.sim = sim


### PR DESCRIPTION
With this PR, the user can either pass the diagnostic period as `period` (an integer) or `dt_period` (a float, in seconds). (This was discussed in the context of #334.)

As a consequence, this makes `period` on optional argument. Following Python synthax, all the following arguments of `ParticleDiagnostic` and `FieldDiagnostic` must be, from a synthax point of view, optional as well. Therefore, I added a few more check to make sure that the user still passes the minimal set of arguments that are strictly necessary.