### PR TITLE
Make the example scripts explicitly visible in the online documentation

### DIFF
--- a/docs/source/example_input/boosted_frame_script.rst
+++ b/docs/source/example_input/boosted_frame_script.rst
@@ -1,0 +1,7 @@
+Boosted-frame simulation of laser-wakefield acceleration
+--------------------------------------------------------
+
+You can download the script below by clicking on :download:`this link <boosted_frame_script.py>`.
+
+.. literalinclude:: boosted_frame_script.py
+   :language: python

--- a/docs/source/example_input/ionization_script.rst
+++ b/docs/source/example_input/ionization_script.rst
@@ -1,0 +1,7 @@
+Laser-wakefield acceleration with ionization
+--------------------------------------------
+
+You can download the script below by clicking on :download:`this link <ionization_script.py>`.
+
+.. literalinclude:: ionization_script.py
+   :language: python

--- a/docs/source/example_input/lwfa_script.rst
+++ b/docs/source/example_input/lwfa_script.rst
@@ -1,0 +1,7 @@
+Standard simulation of laser-wakefield acceleration
+---------------------------------------------------
+
+You can download the script below by clicking on :download:`this link <lwfa_script.py>`.
+
+.. literalinclude:: lwfa_script.py
+   :language: python

--- a/docs/source/how_to_run.rst
+++ b/docs/source/how_to_run.rst
@@ -11,9 +11,12 @@ Script examples
 You can download examples of FBPIC scripts below (which you can then modify
 to suit your needs):
 
-- Standard simulation of laser-wakefield acceleration: :download:`lwfa_script.py <example_input/lwfa_script.py>`
-- Laser-wakefield acceleration with ionization: :download:`ionization_script.py <example_input/ionization_script.py>`
-- Boosted-frame simulation of laser-wakefield acceleration: :download:`boosted_frame_script.py <example_input/boosted_frame_script.py>`
+.. toctree::
+    :maxdepth: 1
+
+    example_input/lwfa_script.rst
+    example_input/ionization_script.rst
+    example_input/boosted_frame_script.rst
 
 (See the documentation of :any:`Particles.make_ionizable` for more information on ionization,
 and the section :doc:`advanced/boosted_frame` for more information on the boosted frame.)


### PR DESCRIPTION
This is more of a suggestion:

I often find myself wishing that the example scripts were quickly accessible in the online documentation. (instead of having to download them and open them locally with a text editor). This is what this PR does.

Please compile the doc locally in order to visualize the changes in practice ; please let me know if you agree with these modifications.