### PR TITLE
Rename `BoostedDiagnostic` as `BackTransformedDiagnostic`

### DIFF
--- a/docs/source/advanced/boosted_frame.rst
+++ b/docs/source/advanced/boosted_frame.rst
@@ -137,8 +137,9 @@ the results in the lab frame, since this is usually easier to interpret.
 FBPIC implements **on-the-fly conversion** of the results,
 and can thus output the fields and macroparticles directly
 in the lab frame. See the documentation of the classes
-:class:`fbpic.openpmd_diag.BoostedFieldDiagnostic` and
-:class:`fbpic.openpmd_diag.BoostedParticleDiagnostic` in order to use this feature.
+:class:`fbpic.openpmd_diag.BackTransformedFieldDiagnostic` and
+:class:`fbpic.openpmd_diag.BackTransformedParticleDiagnostic` in order
+to use this feature.
 
 .. warning::
 

--- a/docs/source/api_reference/diagnostics.rst
+++ b/docs/source/api_reference/diagnostics.rst
@@ -39,9 +39,9 @@ during a boosted-frame simulation.
 Field diagnostic
 ~~~~~~~~~~~~~~~~
 
-.. autoclass:: fbpic.openpmd_diag.BoostedFieldDiagnostic
+.. autoclass:: fbpic.openpmd_diag.BackTransformedFieldDiagnostic
 
 Particle diagnostic
 ~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: fbpic.openpmd_diag.BoostedParticleDiagnostic
+.. autoclass:: fbpic.openpmd_diag.BackTransformedParticleDiagnostic

--- a/docs/source/api_reference/diagnostics.rst
+++ b/docs/source/api_reference/diagnostics.rst
@@ -41,7 +41,26 @@ Field diagnostic
 
 .. autoclass:: fbpic.openpmd_diag.BackTransformedFieldDiagnostic
 
+.. warning::
+
+    The former class ``BoostedFieldDiagnostic`` has been renamed as
+    ``BackTransformedFieldDiagnostic``.
+
+    Although the name ``BoostedFieldDiagnostic`` can still be used
+    (for backward compatibility), we recommend using
+    ``BackTransformedFieldDiagnostic`` instead.
+
+
 Particle diagnostic
 ~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: fbpic.openpmd_diag.BackTransformedParticleDiagnostic
+
+.. warning::
+
+    The former class ``BoostedParticleDiagnostic`` has been renamed as
+    ``BackTransformedParticleDiagnostic``.
+
+    Although the name ``BoostedParticleDiagnostic`` can still be used
+    (for backward compatibility), we recommend using
+    ``BackTransformedParticleDiagnostic`` instead.

--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -25,7 +25,7 @@ from fbpic.lpa_utils.laser import add_laser
 from fbpic.lpa_utils.bunch import add_elec_bunch
 from fbpic.lpa_utils.boosted_frame import BoostConverter
 from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic, \
-                  BoostedFieldDiagnostic, BoostedParticleDiagnostic
+        BackTransformedFieldDiagnostic, BackTransformedParticleDiagnostic
 # ----------
 # Parameters
 # ----------
@@ -145,7 +145,7 @@ T_interact = boost.interaction_time( L_interact, (zmax-zmin), v_window )
 
 ## The diagnostics
 
-# Number of discrete diagnostic snapshots, for the diagnostics in the 
+# Number of discrete diagnostic snapshots, for the diagnostics in the
 # boosted frame (i.e. simulation frame) and in the lab frame
 # (i.e. back-transformed from the simulation frame to the lab frame)
 N_boosted_diag = 15+1
@@ -199,11 +199,11 @@ if __name__ == '__main__':
                         species={"electrons":sim.ptcl[0], "bunch":sim.ptcl[2]},
                         comm=sim.comm),
                   # Diagnostics in the lab frame (back-transformed)
-                  BoostedFieldDiagnostic( zmin, zmax, v_window,
+                  BackTransformedFieldDiagnostic( zmin, zmax, v_window,
                     dt_lab_diag_period, N_lab_diag, boost.gamma0,
                     fieldtypes=['rho','E','B'], period=write_period,
                     fldobject=sim.fld, comm=sim.comm ),
-                  BoostedParticleDiagnostic( zmin, zmax, v_window,
+                  BackTransformedParticleDiagnostic( zmin, zmax, v_window,
                     dt_lab_diag_period, N_lab_diag, boost.gamma0,
                     write_period, sim.fld, select={'uz':[0.,None]},
                     species={'electrons':sim.ptcl[2]}, comm=sim.comm )

--- a/fbpic/openpmd_diag/__init__.py
+++ b/fbpic/openpmd_diag/__init__.py
@@ -8,7 +8,7 @@ from .particle_diag import ParticleDiagnostic
 from .particle_density_diag import ParticleChargeDensityDiagnostic
 from .boosted_field_diag import BoostedFieldDiagnostic, \
                                 BackTransformedFieldDiagnostic
-from .boosted_particle_diag import BoostedParticleDiagnostic \
+from .boosted_particle_diag import BoostedParticleDiagnostic, \
                                 BackTransformedParticleDiagnostic
 from .checkpoint_restart import set_periodic_checkpoint, \
      restart_from_checkpoint

--- a/fbpic/openpmd_diag/__init__.py
+++ b/fbpic/openpmd_diag/__init__.py
@@ -6,12 +6,15 @@ It imports the objects that allow to produce output in openPMD format.
 from .field_diag import FieldDiagnostic
 from .particle_diag import ParticleDiagnostic
 from .particle_density_diag import ParticleChargeDensityDiagnostic
-from .boosted_field_diag import BoostedFieldDiagnostic
-from .boosted_particle_diag import BoostedParticleDiagnostic
+from .boosted_field_diag import BoostedFieldDiagnostic, \
+                                BackTransformedFieldDiagnostic
+from .boosted_particle_diag import BoostedParticleDiagnostic \
+                                BackTransformedParticleDiagnostic
 from .checkpoint_restart import set_periodic_checkpoint, \
      restart_from_checkpoint
 
 __all__ = ['FieldDiagnostic', 'ParticleDiagnostic',
 	'BoostedFieldDiagnostic', 'BoostedParticleDiagnostic',
-        'ParticleChargeDensityDiagnostic',
-        'set_periodic_checkpoint', 'restart_from_checkpoint']
+    'BackTransformedFieldDiagnostic', 'BackTransformedParticleDiagnostic',
+    'ParticleChargeDensityDiagnostic',
+    'set_periodic_checkpoint', 'restart_from_checkpoint']

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -2,7 +2,7 @@
 # Authors: Remi Lehe, Manuel Kirchen
 # License: 3-Clause-BSD-LBNL
 """
-This file defines the class BoostedFieldDiagnostic
+This file defines the class BackTransformedFieldDiagnostic
 
 Major features:
 - The class reuses the existing methods of FieldDiagnostic

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -21,7 +21,7 @@ from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
-class BoostedFieldDiagnostic(FieldDiagnostic):
+class BackTransformedFieldDiagnostic(FieldDiagnostic):
     """
     Class that writes the fields *in the lab frame*, from
     a simulation in the boosted frame
@@ -791,3 +791,7 @@ if cuda_installed:
                 slice_arr[7,im+1,ir] = Sz*Jt[iz,ir].imag + Szp*Jt[izp,ir].imag
                 slice_arr[8,im+1,ir] = Sz*Jz[iz,ir].imag + Szp*Jz[izp,ir].imag
                 slice_arr[9,im+1,ir] = Sz*rho[iz,ir].imag + Szp*rho[izp,ir].imag
+
+
+# Alias, for backward compatibility
+BoostedFieldDiagnostic = BackTransformedFieldDiagnostic

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -21,7 +21,7 @@ from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     from .cuda_methods import extract_slice_from_gpu
 
-class BoostedParticleDiagnostic(ParticleDiagnostic):
+class BackTransformedParticleDiagnostic(ParticleDiagnostic):
     """
     Class that writes the particles *in the lab frame*,
     from a simulation in the boosted frame
@@ -916,3 +916,7 @@ class ParticleCatcher:
             slice_data_dict[quantity] = slice_data_dict[quantity][select_array]
 
         return slice_data_dict
+
+
+# Alias, for backward compatibility
+BoostedParticleDiagnostic = BackTransformedParticleDiagnostic

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -56,7 +56,7 @@ class BackTransformedParticleDiagnostic(ParticleDiagnostic):
             The output of the gathered fields on the particles
             (``particle_data=["E", "B"]``) and of the Lorentz factor
             (``particle_data=["gamma"]``) is not currently supported
-            for ``BoostedParticleDiagnostic``.
+            for ``BackTransformedParticleDiagnostic``.
 
         Parameters
         ----------

--- a/tests/test_beam_focusing.py
+++ b/tests/test_beam_focusing.py
@@ -24,7 +24,7 @@ import shutil
 from fbpic.main import Simulation
 from fbpic.lpa_utils.bunch import add_elec_bunch_gaussian
 from fbpic.lpa_utils.boosted_frame import BoostConverter
-from fbpic.openpmd_diag import BoostedParticleDiagnostic
+from fbpic.openpmd_diag import BackTransformedParticleDiagnostic
 from opmd_viewer import OpenPMDTimeSeries
 
 # ----------
@@ -114,7 +114,7 @@ def simulate_beam_focusing( z_injection_plane, write_dir ):
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
         gamma_boost=gamma_boost, boundaries='open',
         use_cuda=use_cuda, v_comoving=v_comoving )
-    # Note: no macroparticles get created because we do not pass 
+    # Note: no macroparticles get created because we do not pass
     # the density and number of particle per cell
 
     # Remove the plasma particles
@@ -130,7 +130,7 @@ def simulate_beam_focusing( z_injection_plane, write_dir ):
 
     # Add a field diagnostic
     sim.diags = [
-        BoostedParticleDiagnostic( zmin, zmax, c, dt_snapshot_lab,
+        BackTransformedParticleDiagnostic( zmin, zmax, c, dt_snapshot_lab,
             Ntot_snapshot_lab, gamma_boost, period=100, fldobject=sim.fld,
             species={'bunch':sim.ptcl[0]}, comm=sim.comm, write_dir=write_dir)
         ]

--- a/tests/test_boosted_particle_output.py
+++ b/tests/test_boosted_particle_output.py
@@ -19,7 +19,7 @@ from scipy.constants import c
 from fbpic.main import Simulation
 from fbpic.lpa_utils.boosted_frame import BoostConverter
 from fbpic.lpa_utils.bunch import add_elec_bunch_gaussian
-from fbpic.openpmd_diag import BoostedParticleDiagnostic
+from fbpic.openpmd_diag import BackTransformedParticleDiagnostic
 # Import openPMD-viewer for checking output files
 from opmd_viewer import OpenPMDTimeSeries
 
@@ -76,7 +76,7 @@ def test_boosted_output( gamma_boost=10. ):
 
     # openPMD diagnostics
     sim.diags = [
-        BoostedParticleDiagnostic( zmin_lab, zmax_lab, v_lab=c,
+        BackTransformedParticleDiagnostic( zmin_lab, zmax_lab, v_lab=c,
             dt_snapshots_lab=T_sim_lab/3., Ntot_snapshots_lab=3,
             gamma_boost=gamma_boost, period=diag_period, fldobject=sim.fld,
             species={"bunch": sim.ptcl[0]}, comm=sim.comm) ]

--- a/tests/test_ionization.py
+++ b/tests/test_ionization.py
@@ -29,7 +29,8 @@ from scipy.constants import c, m_e, m_p, e
 from fbpic.main import Simulation
 from fbpic.lpa_utils.external_fields import ExternalField
 from fbpic.lpa_utils.boosted_frame import BoostConverter
-from fbpic.openpmd_diag import ParticleDiagnostic, BoostedParticleDiagnostic
+from fbpic.openpmd_diag import ParticleDiagnostic, \
+    BackTransformedParticleDiagnostic
 # Import openPMD-viewer for checking output files
 from opmd_viewer import OpenPMDTimeSeries
 
@@ -158,13 +159,13 @@ def run_simulation( gamma_boost, use_separate_electron_species ):
     # Add a particle diagnostic
     sim.diags = [ ParticleDiagnostic( diag_period, {"ions":ions},
         particle_data=["position", "gamma", "weighting", "E", "B"],
-        # Test output of fields and gamma for standard 
+        # Test output of fields and gamma for standard
         # (non-boosted) particle diagnostics
         write_dir='tests/diags', comm=sim.comm) ]
     if gamma_boost > 1:
         T_sim_lab = (2.*40.*lambda0_lab + zmax_lab-zmin_lab)/c
         sim.diags.append(
-            BoostedParticleDiagnostic(zmin_lab, zmax_lab, v_lab=0.,
+            BackTransformedParticleDiagnostic(zmin_lab, zmax_lab, v_lab=0.,
                 dt_snapshots_lab=T_sim_lab/2., Ntot_snapshots_lab=3,
                 gamma_boost=gamma_boost, period=diag_period,
                 fldobject=sim.fld, species={"ions":ions},


### PR DESCRIPTION
I think that the names `BoostedFieldDiagnostic` and `BoostedParticleDiagnostic` might be confusing for some users, e.g. since they are dumping data in the *lab* frame, not the *boosted* frame.

Also, this odd name leads to confusing initializations, as in this example script:
https://github.com/fbpic/fbpic/blob/dev/docs/source/example_input/boosted_frame_script.py#L196-209
where `dt_boosted_...` is passed to the regular diagnostics, but `dt_lab_...` is passed to the `Boosted` diagnostics.

This PR solves this issue by renaming these classes. The `Boosted` classes are kept for backward compatibility, but are not explicitly documented anymore. All the tests and examples now use `BackTransformed`.