### PR TITLE
removed unused `uz_m` parameter

### DIFF
--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -83,7 +83,6 @@ n_e = 3.e24      # The density in the labframe (electrons.meters^-3)
 p_nz = 2         # Number of particles per cell along z
 p_nr = 2         # Number of particles per cell along r
 p_nt = 6         # Number of particles per cell along theta
-uz_m = 0.        # Initial momentum of the electrons in the lab frame
 
 # Density profile
 # Convert parameters to boosted frame


### PR DESCRIPTION
sorry for being so pedantic, but as `uz_m` is unused it may perturb someone who learns the code, moreover since it's only accepted by `add_new_species` which is not present.

Another thing, since users may use this script as a template for their own simulations, may be theta  ppc number could be also given in a generic form (with some  comment), e.g. `p_nt = 4*(Nm-1)+(Nm==1)` ?  This way they would avoid some nasty instabilities which are not always easy to see on the final result