### PR TITLE
Close #342 Automatically transform the external fields to the boosted frame

### DIFF
--- a/fbpic/lpa_utils/external_fields.py
+++ b/fbpic/lpa_utils/external_fields.py
@@ -93,10 +93,10 @@ class ExternalField( object ):
             However, **when running the simulation in a boosted frame**
             (i.e. when setting the above argument ``gamma_boost``),
             the expression of the external fields **needs to be proportional
-            to ``amplitude``**. This is because, internally, the automatic
+            to** ``amplitude``. This is because, internally, the automatic
             conversion of the external fields to the boosted frame relies
-            on this variable. (There is no such constraint for ``length_scale``,
-            though.)
+            on this variable. (There is no similar constraint for
+            ``length_scale``, however.)
         """
         # Register the arguments
         self.length_scale = length_scale

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -164,7 +164,7 @@ class Simulation(object):
             For the moment, `cross-deposition` is still experimental.
 
         gamma_boost : float, optional
-            When initializing the laser in a boosted frame, set the
+            When running the simulation in a boosted frame, set the
             value of `gamma_boost` to the corresponding Lorentz factor.
             All the other quantities (zmin, zmax, n_e, etc.) are to be given
             in the lab frame.

--- a/tests/test_external_fields.py
+++ b/tests/test_external_fields.py
@@ -13,6 +13,7 @@ $ python tests/test_external_fields.py
 import numpy as np
 from scipy.constants import e, m_e, c
 from fbpic.main import Simulation
+from fbpic.lpa_utils.boosted_frame import BoostConverter
 from fbpic.lpa_utils.external_fields import ExternalField
 import math
 
@@ -41,7 +42,7 @@ k0 = 2*np.pi/lambda0
 dt = lambda0/c/200  # 200 points per laser period
 N_step = 400        # Two laser periods
 
-# Particles (one per cell, only intialized near the axis)
+# Particles (one per cell, only initialized near the axis)
 p_zmin = zmin
 p_zmax = zmax
 p_rmax = rmax/Nr
@@ -50,19 +51,31 @@ p_nr = 1
 p_nz = 1
 n = 1.
 
-def test_external_laser_field(show=False):
-    "Function that is run by py.test, when doing `python setup.py test`"
+def run_external_laser_field_simulation(show, gamma_boost=None):
+    """
+    Runs a simulation with a set of particles whose motion corresponds
+    to that of a particle that is initially at rest (in the lab frame)
+    before being reached by a plane wave (propagating to the right)
 
+    In the lab frame, the motion is given by
+    ux = a0 sin ( k0(z-ct) )
+    uz = ux^2 / 2    (from the conservation of gamma - uz)
+
+    In the boosted frame, the motion is given by
+    ux = a0 sin ( k0 gamma0 (1-beta0) (z-ct) )
+    uz = - gamma0 beta0 + gamma0 (1-beta0) ux^2 / 2
+    """
     # Initialize the simulation
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
         p_zmin, p_zmax, 0, p_rmax, p_nz, p_nr, p_nt, n,
         initialize_ions=False, zmin=zmin,
-        use_cuda=use_cuda, boundaries='periodic' )
+        use_cuda=use_cuda, boundaries='periodic',
+        gamma_boost=gamma_boost )
 
     # Add the external fields
     sim.external_fields = [
-        ExternalField( laser_func, 'Ex', a0*m_e*c**2*k0/e, lambda0 ),
-        ExternalField( laser_func, 'By', a0*m_e*c*k0/e, lambda0 )
+        ExternalField(laser_func, 'Ex', a0*m_e*c**2*k0/e, lambda0, gamma_boost),
+        ExternalField(laser_func, 'By', a0*m_e*c*k0/e, lambda0, gamma_boost)
     ]
 
     # Prepare the arrays for the time history of the pusher
@@ -71,12 +84,21 @@ def test_external_laser_field(show=False):
     y = np.zeros( (N_step, Nptcl) )
     z = np.zeros( (N_step, Nptcl) )
     ux = np.zeros( (N_step, Nptcl) )
-    uz = np.zeros( (N_step, Nptcl) )
     uy = np.zeros( (N_step, Nptcl) )
+    uz = np.zeros( (N_step, Nptcl) )
 
-    # Prepare the particles with proper transverse and longitudinal momentum
-    sim.ptcl[0].ux = a0*np.sin( k0*sim.ptcl[0].z )
-    sim.ptcl[0].uz[:] = 0.5*sim.ptcl[0].ux**2
+    # Initialize BoostConverter object
+    if gamma_boost is None:
+        boost = BoostConverter(gamma0=1.)
+    else:
+        boost = BoostConverter(gamma_boost)
+
+    # Prepare the particles with proper transverse and longitudinal momentum,
+    # at t=0 in the simulation frame
+    k0p = k0*boost.gamma0*(1.-boost.beta0)
+    sim.ptcl[0].ux = a0*np.sin( k0p*sim.ptcl[0].z )
+    sim.ptcl[0].uz[:] = -boost.gamma0*boost.beta0 \
+                    + boost.gamma0*(1-boost.beta0)*0.5*sim.ptcl[0].ux**2
 
     # Push the particles over N_step and record the corresponding history
     for i in range(N_step) :
@@ -91,13 +113,14 @@ def test_external_laser_field(show=False):
         sim.step(1)
 
     # Compute the analytical solution
-    t = dt*np.arange(N_step)
+    t = sim.dt*np.arange(N_step)
     # Conservation of ux
     ux_analytical = np.zeros( (N_step, Nptcl) )
     uz_analytical = np.zeros( (N_step, Nptcl) )
     for i in range(N_step):
-        ux_analytical[i,:] = a0*np.sin( k0*(z[i,:] - c*t[i]) )
-        uz_analytical[i,:] = 0.5*ux_analytical[i,:]**2
+        ux_analytical[i,:] = a0*np.sin( k0p*(z[i,:] - c*t[i]) )
+        uz_analytical[i,:] = -boost.gamma0*boost.beta0 \
+                    + boost.gamma0*(1-boost.beta0)*0.5*ux_analytical[i,:]**2
 
     # Show the results
     if show:
@@ -127,6 +150,15 @@ def laser_func( F, x, y, z, t, amplitude, length_scale ):
     """
     return( F + amplitude*math.cos( 2*np.pi*(z-c*t)/length_scale ) )
 
+def test_external_fields_lab(show=False):
+    "Function that is run by py.test, when doing `python setup.py test`"
+    run_external_laser_field_simulation( show, None )
+
+def test_external_fields_boost(show=False):
+    "Function that is run by py.test, when doing `python setup.py test`"
+    run_external_laser_field_simulation( show, gamma_boost=10 )
+
 if __name__ == '__main__' :
 
-    test_external_laser_field( show )
+    test_external_fields_lab( show )
+    test_external_fields_boost( show )


### PR DESCRIPTION
This pull request enables automatic conversion of the `ExternalFields` to the boosted frame.
In order to use this feature, the user simply passes `gamma_boost` to the `ExternalFields` API.

I also expanded the automated tests of the external fields, so as to test them both in the lab frame and in the boosted frame.