### PR TITLE
Add filtering to ParticleChargeDensityDiagnostic

### DIFF
--- a/fbpic/openpmd_diag/particle_density_diag.py
+++ b/fbpic/openpmd_diag/particle_density_diag.py
@@ -109,7 +109,7 @@ class ParticleChargeDensityDiagnostic(FieldDiagnostic):
             # Bring filtered particle density back to the intermediate grid
             self.fld.spect2interp('rho_next')
             # Exchange (add) the particle density between domains
-            if (sim.comm is not None) and (sim.comm.size > 1) \
+            if (sim.comm is not None) and (sim.comm.size > 1):
                 sim.comm.exchange_fields(sim.fld.interp, 'rho', 'add')
 
             # If needed: Receive data from the GPU

--- a/fbpic/openpmd_diag/particle_density_diag.py
+++ b/fbpic/openpmd_diag/particle_density_diag.py
@@ -102,8 +102,15 @@ class ParticleChargeDensityDiagnostic(FieldDiagnostic):
             # affect the spectral space, and therefore it does not affect
             # the simulation
             species_object = self.species[species_name]
-            sim.deposit( 'rho', species_list=[species_object],
-                        update_spectral=False, exchange=True )
+            # Deposit and overwrite rho_next in spectral space as it will be
+            # correctly updated anyways later in this iteration by the PIC loop
+            sim.deposit( 'rho_next', species_list=[species_object],
+                        update_spectral=True, exchange=False )
+            # Bring filtered particle density back to the intermediate grid
+            self.fld.spect2interp('rho_next')
+            # Exchange (add) the particle density between domains
+            if (sim.comm is not None) and (sim.comm.size > 1) \
+                sim.comm.exchange_fields(sim.fld.interp, 'rho', 'add')
 
             # If needed: Receive data from the GPU
             if self.fld.use_cuda :


### PR DESCRIPTION
This PR adds filtering of the particle density in spectral space before writing it to disk.

This is done by depositing 'rho' and overwriting and filtering 'rho_next' in spectral space before bringing it back to real space and exchanging it between domains. As the diagnostics are called at the beginning of the iteration, 'rho_next' is replaced by the correct charge density later in the PIC loop.