### PR TITLE
Make the Travis tests faster by disabling threading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_script:
   - python -m pyflakes .
   - pip install openPMD-viewer
 script:
+  - export FBPIC_DISABLE_THREADING=1
   - "python setup.py test"
 
 after_success:


### PR DESCRIPTION
In Numba, multi-threading prevents the ability to cache the compiled Numba functions.
As a result, in the Travis tests, we are currently re-compiling FBPIC (JIT compiling) for every single test. As a result, a lot of time is spent simply in compilation.

On the other hand, when deactivating threading, the functions are compiled only once, then cached, and reused for every tests. This saves ~7 min (out of 37 min on average) in the Travis tests.

We could then run the full test suite (with threading + with GPU) for every release.