### PR TITLE
Fix restart with ionization on GPU

### DIFF
--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -326,6 +326,10 @@ def load_species( species, name, ts, iteration, comm ):
     # Sorting arrays
     if species.use_cuda:
         species.cell_idx = np.empty( Ntot, dtype=np.int32)
-        species.sorted_idx = np.arange( Ntot, dtype=np.uint32)
-        species.sorting_buffer = np.arange( Ntot, dtype=np.float64)
+        species.sorted_idx = np.empty( Ntot, dtype=np.uint32)
+        species.sorting_buffer = np.empty( Ntot, dtype=np.float64)
+        if hasattr( species, 'int_sorting_buffer'):
+            species.int_sorting_buffer = np.empty( Ntot, dtype=np.uint64 )
         species.sorted = False
+
+        


### PR DESCRIPTION
When using ionization (or tracking) and running on GPU, the particles have an additional attribute `"int_sorting_buffer"`.

In the current version of FBPIC, the code does not resize this array when doing a restart. This can lead to out-of-bound behavior after a restart, and in practice this lead the automated test `test_ionization_script_twoproc` to fail on GPU.

With the present PR, the automated `test_ionization_script_twoproc` passes on GPU.