### PR TITLE
Add methods to initialise beams with arbitrary particle charge

### DIFF
--- a/docs/source/api_reference/lpa_utilities/beam.rst
+++ b/docs/source/api_reference/lpa_utilities/beam.rst
@@ -1,17 +1,26 @@
 Beam initialization
 ===================
 
-The functions below allow to **initialize a relativistic electron beam**
+The functions below allow to **initialize a relativistic particle beam**
 with various distributions in space (e.g. Gaussian, flat-top, from a file,
 etc.). In each case, the **self-consistent space-charge fields** are
 automatically calculated by the code, and added to the simulation.
 
-.. autofunction:: fbpic.lpa_utils.bunch.add_elec_bunch
+.. autofunction:: fbpic.lpa_utils.bunch.add_particle_bunch
 
-.. autofunction:: fbpic.lpa_utils.bunch.add_elec_bunch_gaussian
+.. autofunction:: fbpic.lpa_utils.bunch.add_particle_bunch_gaussian
 
-.. autofunction:: fbpic.lpa_utils.bunch.add_elec_bunch_from_arrays
+.. autofunction:: fbpic.lpa_utils.bunch.add_particle_bunch_from_arrays
 
-.. autofunction:: fbpic.lpa_utils.bunch.add_elec_bunch_openPMD
+.. autofunction:: fbpic.lpa_utils.bunch.add_particle_bunch_openPMD
 
-.. autofunction:: fbpic.lpa_utils.bunch.add_elec_bunch_file
+.. autofunction:: fbpic.lpa_utils.bunch.add_particle_bunch_file
+
+.. warning::
+
+    The former methods to initialize electron beams have been updated to allow
+    the use of arbitrary particle beams.
+
+    Although the old methods (e.g. ``add_elec_bunch``) can still be used
+    (for backward compatibility), we recommend using
+    the new more flexible methods instead.

--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -18,11 +18,11 @@ where fbpic_object is any of the objects or function of FBPIC.
 # Imports
 # -------
 import numpy as np
-from scipy.constants import c
+from scipy.constants import c, e, m_e
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
 from fbpic.lpa_utils.laser import add_laser
-from fbpic.lpa_utils.bunch import add_elec_bunch
+from fbpic.lpa_utils.bunch import add_particle_bunch
 from fbpic.lpa_utils.boosted_frame import BoostConverter
 from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic, \
         BackTransformedFieldDiagnostic, BackTransformedParticleDiagnostic
@@ -175,7 +175,7 @@ if __name__ == '__main__':
         boundaries='open', use_cuda=use_cuda )
 
     # Add an electron bunch
-    add_elec_bunch( sim, bunch_gamma, bunch_n, bunch_zmin,
+    add_particle_bunch( sim, -e, m_e, bunch_gamma, bunch_n, bunch_zmin,
                 bunch_zmax, 0, bunch_rmax, boost=boost )
     if track_bunch:
         sim.ptcl[2].track( sim.comm )

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -13,6 +13,456 @@ from fbpic.particles.elementary_process.cuda_numba_utils import \
 from fbpic.particles.injection import BallisticBeforePlane
 import warnings
 
+def add_particle_bunch( sim, gamma0, q, m, n, p_zmin, p_zmax, p_rmin, p_rmax,
+                p_nr=2, p_nz=2, p_nt=4, dens_func=None, boost=None,
+                direction='forward', z_injection_plane=None ) :
+    """
+    Introduce a simple relativistic electron bunch in the simulation,
+    along with its space charge field.
+
+    Uniform particle distribution with weights according to density function.
+
+    Parameters
+    ----------
+    sim : a Simulation object
+        The structure that contains the simulation.
+
+    gamma0 : float
+        The Lorentz factor of the electrons
+
+    q : float (in Coulomb)
+        Charge of the particle species
+
+    m : float (in kg)
+        Mass of the particle species
+
+    n : float (in particles per m^3)
+        Density of the bunch
+
+    p_zmin : float (in meters)
+        The minimal z position above which the particles are initialized
+
+    p_zmax : float (in meters)
+        The maximal z position below which the particles are initialized
+
+    p_rmin : float (in meters)
+        The minimal r position above which the particles are initialized
+
+    p_rmax : float (in meters)
+        The maximal r position below which the particles are initialized
+
+    p_nz : int
+        Number of macroparticles per cell along the z directions
+
+    p_nr : int
+        Number of macroparticles per cell along the r directions
+
+    p_nt : int
+        Number of macroparticles along the theta direction
+
+    dens_func : callable, optional
+        A function of the form :
+        `def dens_func( z, r ) ...`
+        where `z` and `r` are 1d arrays, and which returns
+        a 1d array containing the density *relative to n_e*
+        (i.e. a number between 0 and 1) at the given positions.
+
+    boost : a BoostConverter object, optional
+        A BoostConverter object defining the Lorentz boost of
+        the simulation.
+
+    direction : string, optional
+        Can be either "forward" or "backward".
+        Propagation direction of the beam.
+
+    z_injection_plane: float (in meters) or None
+        When `z_injection_plane` is not None, then particles have a ballistic
+        motion for z<z_injection_plane. This is sometimes useful in
+        boosted-frame simulations.
+        `z_injection_plane` is always given in the lab frame.
+    """
+    # Calculate the electron momentum
+    uz_m = ( gamma0**2 - 1. )**0.5
+    if direction == 'backward':
+        uz_m *= -1.
+    # Create the electron species
+    relat_elec = sim.add_new_species( q=q, m=m, n=n,
+                            p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
+                            p_zmin=p_zmin, p_zmax=p_zmax,
+                            p_rmin=p_rmin, p_rmax=p_rmax,
+                            continuous_injection=False,
+                            dens_func=dens_func, uz_m=uz_m )
+
+    # Initialize the injection plane for the particles
+    if z_injection_plane is not None:
+        assert relat_elec.injector is None #Don't overwrite a previous injector
+        relat_elec.injector = BallisticBeforePlane( z_injection_plane, boost )
+
+    # Get the corresponding space-charge fields
+    get_space_charge_fields( sim, relat_elec, direction=direction )
+
+
+def add_particle_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0,
+                        sig_gamma, Q, N, q, m, tf=0., zf=0., boost=None,
+                        save_beam=None, z_injection_plane=None ):
+    """
+    Introduce a relativistic Gaussian electron bunch in the simulation,
+    along with its space charge field.
+
+    The bunch is initialized with a normalized emittance `n_emit`,
+    in such a way that it will be focused at time `tf`, at the position `zf`.
+    Thus if `tf` is not 0, the bunch will be initially out of focus.
+    (This does not take space charge effects into account.)
+
+    Parameters
+    ----------
+    sim : a Simulation object
+        The structure that contains the simulation.
+
+    sig_r : float (in meters)
+        The transverse RMS bunch size.
+
+    sig_z : float (in meters)
+        The longitudinal RMS bunch size.
+
+    n_emit : float (in meters)
+        The normalized emittance of the bunch.
+
+    gamma0 : float
+        The Lorentz factor of the electrons.
+
+    sig_gamma : float
+        The absolute energy spread of the bunch.
+
+    Q : float (in Coulomb)
+        The total charge of the bunch (in absolute value)
+        (if a negative number is given, its absolute value will
+        automatically be taken)
+
+    N : int
+        The number of particles the bunch should consist of.
+
+    q : float (in Coulomb)
+        Charge of the particle species
+
+    m : float (in kg)
+        Mass of the particle species
+
+    zf: float (in meters), optional
+        Position of the focus.
+
+    tf : float (in seconds), optional
+        Time at which the bunch reaches focus.
+
+    boost : a BoostConverter object, optional
+        A BoostConverter object defining the Lorentz boost of
+        the simulation.
+
+    save_beam : string, optional
+        Saves the generated beam distribution as an .npz file "string".npz
+
+    z_injection_plane: float (in meters) or None
+        When `z_injection_plane` is not None, then particles have a ballistic
+        motion for z<z_injection_plane. This is sometimes useful in
+        boosted-frame simulations.
+        `z_injection_plane` is always given in the lab frame.
+    """
+    # Generate Gaussian gamma distribution of the beam
+    if sig_gamma > 0.:
+        gamma = np.random.normal(gamma0, sig_gamma, N)
+    else:
+        # Zero energy spread beam
+        gamma = np.full(N, gamma0)
+        if sig_gamma < 0.:
+            warnings.warn(
+                "Negative energy spread sig_gamma detected."
+                " sig_gamma will be set to zero. \n")
+    # Get inverse gamma
+    inv_gamma = 1. / gamma
+    # Get Gaussian particle distribution in x,y,z
+    x = sig_r * np.random.normal(0., 1., N)
+    y = sig_r * np.random.normal(0., 1., N)
+    z = zf + sig_z * np.random.normal(0., 1., N)  # with offset in z
+
+    # Define sigma of ux and uy based on normalized emittance
+    sig_ur = (n_emit / sig_r)
+    # Get Gaussian distribution of transverse normalized momenta ux, uy
+    ux = sig_ur * np.random.normal(0., 1., N)
+    uy = sig_ur * np.random.normal(0., 1., N)
+
+    # Finally we calculate the uz of each particle
+    # from the gamma and the transverse momenta ux, uy
+    uz_sqr = (gamma ** 2 - 1) - ux ** 2 - uy ** 2
+
+    # Check for unphysical particles with uz**2 < 0
+    mask = uz_sqr >= 0
+    N_new = np.count_nonzero(mask)
+    if N_new < N:
+        warnings.warn(
+              "Particles with uz**2<0 detected."
+              " %d Particles will be removed from the beam. \n"
+              "This will truncate the distribution of the beam"
+              " at gamma ~= 1. \n"
+              "However, the charge will be kept constant. \n" % (N - N_new))
+        # Remove unphysical particles with uz**2 < 0
+        x = x[mask]
+        y = y[mask]
+        z = z[mask]
+        ux = ux[mask]
+        uy = uy[mask]
+        inv_gamma = inv_gamma[mask]
+        uz_sqr = uz_sqr[mask]
+    # Calculate longitudinal momentum of the bunch
+    uz = np.sqrt(uz_sqr)
+    # Get weight of each particle
+
+    w = abs(Q) / (N_new * abs(q)) * np.ones_like(x)
+    # Propagate distribution to an out-of-focus position tf.
+    # (without taking space charge effects into account)
+    if tf != 0.:
+        x = x - ux * inv_gamma * c * tf
+        y = y - uy * inv_gamma * c * tf
+        z = z - uz * inv_gamma * c * tf
+
+    # Save beam distribution to an .npz file
+    if save_beam is not None:
+        np.savez(save_beam, x=x, y=y, z=z, ux=ux, uy=uy, uz=uz,
+            inv_gamma=inv_gamma, w=w)
+
+    # Add the electrons to the simulation
+    add_particle_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w, q, m,
+                boost=boost, z_injection_plane=z_injection_plane )
+
+
+def add_particle_bunch_file( sim, filename, Q, q, m, z_off=0., boost=None,
+                        direction='forward', z_injection_plane=None ):
+    """
+    Introduce a relativistic electron bunch in the simulation,
+    along with its space charge field, loading particles from text file.
+
+    Parameters
+    ----------
+    sim : a Simulation object
+        The structure that contains the simulation.
+
+    filename : string
+        the file containing the particle phase space in seven columns
+        all float, no header
+        x [m]  y [m]  z [m]  ux [unitless]  uy [unitless]  uz [unitless]
+
+    Q : float (in Coulomb)
+        The total charge of the bunch (in absolute value)
+        (if a negative number is given, its absolute value will
+        automatically be taken)
+
+    q : float (in Coulomb)
+        Charge of the particle species
+
+    m : float (in kg)
+        Mass of the particle species
+
+    z_off: float (in meters)
+        Shift the particle positions in z by z_off
+
+    boost : a BoostConverter object, optional
+        A BoostConverter object defining the Lorentz boost of
+        the simulation.
+
+    direction : string, optional
+        Can be either "forward" or "backward".
+        Propagation direction of the beam.
+
+    z_injection_plane: float (in meters) or None
+        When `z_injection_plane` is not None, then particles have a ballistic
+        motion for z<z_injection_plane. This is sometimes useful in
+        boosted-frame simulations.
+        `z_injection_plane` is always given in the lab frame.
+    """
+    # Load particle data to numpy array
+    particle_data = np.loadtxt(filename)
+
+    # Extract positions and momenta
+    x = particle_data[:,0]
+    y = particle_data[:,1]
+    z = particle_data[:,2] + z_off
+    ux = particle_data[:,3]
+    uy = particle_data[:,4]
+    uz = particle_data[:,5]
+    # Calculate weights (charge of macroparticle)
+    # assuming equally weighted particles as used in particle tracking codes
+    N_part = len(x)
+    w = np.abs(Q)/(N_part*abs(q)) * np.ones_like( x )
+
+    # Add the electrons to the simulation
+    add_particle_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w, q, m,
+        boost=boost, direction=direction, z_injection_plane=z_injection_plane )
+
+
+def add_particle_bunch_openPMD( sim, q, m, ts_path, z_off=0., species=None,
+                                select=None, iteration=None, boost=None,
+                                z_injection_plane=None ):
+    """
+    Introduce a relativistic electron bunch in the simulation,
+    along with its space charge field, loading particles from an openPMD
+    timeseries.
+
+    Parameters
+    ----------
+    sim : a Simulation object
+        The structure that contains the simulation.
+
+    q : float (in Coulomb)
+        Charge of the particle species
+
+    m : float (in kg)
+        Mass of the particle species
+
+    ts_path : string
+        The path to the directory where the openPMD files are.
+        For the moment, only HDF5 files are supported. There should be
+        one file per iteration, and the name of the files should end
+        with the iteration number, followed by '.h5' (e.g. data0005000.h5)
+
+    z_off: float (in meters)
+        Shift the particle positions in z by z_off. By default the initialized
+        phasespace is centered at z=0.
+
+    species: string
+        A string indicating the name of the species
+        This is optional if there is only one species
+
+    select: dict, optional
+        Either None or a dictionary of rules
+        to select the particles, of the form
+        'x' : [-4., 10.]   (Particles having x between -4 and 10 microns)
+        'ux' : [-0.1, 0.1] (Particles having ux between -0.1 and 0.1 mc)
+        'uz' : [5., None]  (Particles with uz above 5 mc)
+
+    iteration: integer (optional)
+        The iteration number of the openPMD file from which to extract the
+        particles.
+
+    boost : a BoostConverter object, optional
+        A BoostConverter object defining the Lorentz boost of
+        the simulation.
+
+    z_injection_plane: float (in meters) or None
+        When `z_injection_plane` is not None, then particles have a ballistic
+        motion for z<z_injection_plane. This is sometimes useful in
+        boosted-frame simulations.
+        `z_injection_plane` is always given in the lab frame.
+    """
+    # Import openPMD viewer
+    try:
+        from opmd_viewer import OpenPMDTimeSeries
+    except ImportError:
+        raise ImportError(
+        'The package `opmd_viewer` is required to restart from checkpoints.'
+        '\nPlease install it from https://github.com/openPMD/openPMD-viewer')
+    ts = OpenPMDTimeSeries(ts_path)
+    # Extract phasespace and particle weights
+    x, y, z, ux, uy, uz, w = ts.get_particle(
+                                ['x', 'y', 'z', 'ux', 'uy', 'uz', 'w'],
+                                iteration=iteration, species=species,
+                                select=select)
+    # Convert the positions from microns to meters
+    x *= 1.e-6
+    y *= 1.e-6
+    z *= 1.e-6
+    # Shift the center of the phasespace to z_off
+    z = z - np.average(z, weights=w) + z_off
+
+    # Add the electrons to the simulation, and calculate the space charge
+    add_particle_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w, q, m,
+                            boost=boost, z_injection_plane=z_injection_plane )
+
+
+def add_particle_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w, q, m,
+                    boost=None, direction='forward', z_injection_plane=None ):
+    """
+    Introduce a relativistic electron bunch in the simulation,
+    along with its space charge field, loading particles from numpy arrays.
+
+    Parameters
+    ----------
+    sim : a Simulation object
+        The structure that contains the simulation.
+
+    x, y, z: 1d arrays of length (N_macroparticles,)
+        The positions of the particles in x, y, z in meters
+
+    ux, uy, uz: 1d arrays of length (N_macroparticles,)
+        The dimensionless momenta of the particles in each direction
+
+    w: 1d array of length (N_macroparticles,)
+        The weight of the particles, i.e. the number of physical particles
+        that each macroparticle corresponds to.
+
+    q : float
+        Charge of the particle species
+
+    m : float
+        Mass of the particle species
+
+    boost : a BoostConverter object, optional
+        A BoostConverter object defining the Lorentz boost of
+        the simulation.
+
+    direction : string, optional
+        Can be either "forward" or "backward".
+        Propagation direction of the beam.
+
+    z_injection_plane: float (in meters) or None
+        When `z_injection_plane` is not None, then particles have a ballistic
+        motion for z<z_injection_plane. This is sometimes useful in
+        boosted-frame simulations.
+        `z_injection_plane` is always given in the lab frame.
+    """
+    inv_gamma = 1./np.sqrt( 1. + ux**2 + uy**2 + uz**2 )
+    # Convert the particles to the boosted-frame
+    if boost is not None:
+        x, y, z, ux, uy, uz, inv_gamma = boost.boost_particle_arrays(
+                                        x, y, z, ux, uy, uz, inv_gamma )
+
+    # Select the particles that are in the local subdomain
+    zmin, zmax = sim.comm.get_zmin_zmax(
+        local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
+    selected = (z >= zmin) & (z < zmax)
+    x = x[selected]
+    y = y[selected]
+    z = z[selected]
+    ux = ux[selected]
+    uy = uy[selected]
+    uz = uz[selected]
+    w = w[selected]
+    inv_gamma = inv_gamma[selected]
+
+    # Create electron species with no macroparticles
+    relat_elec = sim.add_new_species( q=q, m=m )
+
+    # Reallocate empty arrays with the right number of electrons
+    Ntot = len(x)
+    reallocate_and_copy_old( relat_elec, relat_elec.use_cuda, 0, Ntot )
+
+    # Fill the empty particle arrays with the right values
+    relat_elec.x[:] = x[:]
+    relat_elec.y[:] = y[:]
+    relat_elec.z[:] = z[:]
+    relat_elec.ux[:] = ux[:]
+    relat_elec.uy[:] = uy[:]
+    relat_elec.uz[:] = uz[:]
+    relat_elec.inv_gamma[:] = inv_gamma[:]
+    relat_elec.w[:] = w[:]
+
+    # Initialize the injection plane for the particles
+    if z_injection_plane is not None:
+        assert relat_elec.injector is None #Don't overwrite a previous injector
+        relat_elec.injector = BallisticBeforePlane( z_injection_plane, boost )
+
+    # Get the corresponding space-charge fields
+    get_space_charge_fields(sim, relat_elec, direction=direction)
+
+
 def add_elec_bunch( sim, gamma0, n_e, p_zmin, p_zmax, p_rmin, p_rmax,
                 p_nr=2, p_nz=2, p_nt=4, dens_func=None, boost=None,
                 direction='forward', z_injection_plane=None ) :
@@ -75,25 +525,11 @@ def add_elec_bunch( sim, gamma0, n_e, p_zmin, p_zmax, p_rmin, p_rmax,
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
     """
-    # Calculate the electron momentum
-    uz_m = ( gamma0**2 - 1. )**0.5
-    if direction == 'backward':
-        uz_m *= -1.
-    # Create the electron species
-    relat_elec = sim.add_new_species( q=-e, m=m_e, n=n_e,
-                            p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
-                            p_zmin=p_zmin, p_zmax=p_zmax,
-                            p_rmin=p_rmin, p_rmax=p_rmax,
-                            continuous_injection=False,
-                            dens_func=dens_func, uz_m=uz_m )
-
-    # Initialize the injection plane for the particles
-    if z_injection_plane is not None:
-        assert relat_elec.injector is None #Don't overwrite a previous injector
-        relat_elec.injector = BallisticBeforePlane( z_injection_plane, boost )
-
-    # Get the corresponding space-charge fields
-    get_space_charge_fields( sim, relat_elec, direction=direction )
+    add_particle_bunch( sim, gamma0, -e, m_e, n_e,
+                p_zmin, p_zmax, p_rmin, p_rmax,
+                p_nr=p_nr, p_nz=p_nz, p_nt=p_nz, dens_func=dens_func,
+                boost=boost, direction=direction,
+                z_injection_plane=z_injection_plane )
 
 
 def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0,
@@ -156,69 +592,10 @@ def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0,
         `z_injection_plane` is always given in the lab frame.
     """
     # Generate Gaussian gamma distribution of the beam
-    if sig_gamma > 0.:
-        gamma = np.random.normal(gamma0, sig_gamma, N)
-    else:
-        # Zero energy spread beam
-        gamma = np.full(N, gamma0)
-        if sig_gamma < 0.:
-            warnings.warn(
-                "Negative energy spread sig_gamma detected."
-                " sig_gamma will be set to zero. \n")
-    # Get inverse gamma
-    inv_gamma = 1. / gamma
-    # Get Gaussian particle distribution in x,y,z
-    x = sig_r * np.random.normal(0., 1., N)
-    y = sig_r * np.random.normal(0., 1., N)
-    z = zf + sig_z * np.random.normal(0., 1., N)  # with offset in z
-
-    # Define sigma of ux and uy based on normalized emittance
-    sig_ur = (n_emit / sig_r)
-    # Get Gaussian distribution of transverse normalized momenta ux, uy
-    ux = sig_ur * np.random.normal(0., 1., N)
-    uy = sig_ur * np.random.normal(0., 1., N)
-
-    # Finally we calculate the uz of each particle
-    # from the gamma and the transverse momenta ux, uy
-    uz_sqr = (gamma ** 2 - 1) - ux ** 2 - uy ** 2
-
-    # Check for unphysical particles with uz**2 < 0
-    mask = uz_sqr >= 0
-    N_new = np.count_nonzero(mask)
-    if N_new < N:
-        warnings.warn(
-              "Particles with uz**2<0 detected."
-              " %d Particles will be removed from the beam. \n"
-              "This will truncate the distribution of the beam"
-              " at gamma ~= 1. \n"
-              "However, the charge will be kept constant. \n" % (N-N_new))
-        # Remove unphysical particles with uz**2 < 0
-        x = x[mask]
-        y = y[mask]
-        z = z[mask]
-        ux = ux[mask]
-        uy = uy[mask]
-        inv_gamma = inv_gamma[mask]
-        uz_sqr = uz_sqr[mask]
-    # Calculate longitudinal momentum of the bunch
-    uz = np.sqrt(uz_sqr)
-    # Get weight of each particle
-    w = abs(Q) / (N_new * e) * np.ones_like(x)
-    # Propagate distribution to an out-of-focus position tf.
-    # (without taking space charge effects into account)
-    if tf != 0.:
-        x = x - ux * inv_gamma * c * tf
-        y = y - uy * inv_gamma * c * tf
-        z = z - uz * inv_gamma * c * tf
-
-    # Save beam distribution to an .npz file
-    if save_beam is not None:
-        np.savez(save_beam, x=x, y=y, z=z, ux=ux, uy=uy, uz=uz,
-            inv_gamma=inv_gamma, w=w)
-
-    # Add the electrons to the simulation
-    add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
-                boost=boost, z_injection_plane=z_injection_plane )
+    add_particle_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0,
+                        sig_gamma, Q, N, -e, m_e, tf=tf, zf=zf, boost=boost,
+                        save_beam=save_beam,
+                        z_injection_plane=z_injection_plane )
 
 
 def add_elec_bunch_file( sim, filename, Q_tot, z_off=0., boost=None,
@@ -237,8 +614,10 @@ def add_elec_bunch_file( sim, filename, Q_tot, z_off=0., boost=None,
         all float, no header
         x [m]  y [m]  z [m]  ux [unitless]  uy [unitless]  uz [unitless]
 
-    Q_tot : float (in Coulomb)
-        Total charge in bunch (should be a positive number)
+    Q : float (in Coulomb)
+        The total charge of the bunch (in absolute value)
+        (if a negative number is given, its absolute value will
+        automatically be taken)
 
     z_off: float (in meters)
         Shift the particle positions in z by z_off
@@ -257,24 +636,9 @@ def add_elec_bunch_file( sim, filename, Q_tot, z_off=0., boost=None,
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
     """
-    # Load particle data to numpy array
-    particle_data = np.loadtxt(filename)
-
-    # Extract positions and momenta
-    x = particle_data[:,0]
-    y = particle_data[:,1]
-    z = particle_data[:,2] + z_off
-    ux = particle_data[:,3]
-    uy = particle_data[:,4]
-    uz = particle_data[:,5]
-    # Calculate weights (charge of macroparticle)
-    # assuming equally weighted particles as used in particle tracking codes
-    N_part = len(x)
-    w = Q_tot/(N_part*e) * np.ones_like( x )
-
-    # Add the electrons to the simulation
-    add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
-        boost=boost, direction=direction, z_injection_plane=z_injection_plane )
+    add_particle_bunch_file(sim, filename, Q_tot, -e, m_e, z_off=z_off,
+                            boost=boost, direction=direction,
+                            z_injection_plane=z_injection_plane)
 
 
 def add_elec_bunch_openPMD( sim, ts_path, z_off=0., species=None, select=None,
@@ -324,29 +688,10 @@ def add_elec_bunch_openPMD( sim, ts_path, z_off=0., species=None, select=None,
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
     """
-    # Import openPMD viewer
-    try:
-        from opmd_viewer import OpenPMDTimeSeries
-    except ImportError:
-        raise ImportError(
-        'The package `opmd_viewer` is required to restart from checkpoints.'
-        '\nPlease install it from https://github.com/openPMD/openPMD-viewer')
-    ts = OpenPMDTimeSeries(ts_path)
-    # Extract phasespace and particle weights
-    x, y, z, ux, uy, uz, w = ts.get_particle(
-                                ['x', 'y', 'z', 'ux', 'uy', 'uz', 'w'],
-                                iteration=iteration, species=species,
-                                select=select)
-    # Convert the positions from microns to meters
-    x *= 1.e-6
-    y *= 1.e-6
-    z *= 1.e-6
-    # Shift the center of the phasespace to z_off
-    z = z - np.average(z, weights=w) + z_off
-
-    # Add the electrons to the simulation, and calculate the space charge
-    add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
-                            boost=boost, z_injection_plane=z_injection_plane )
+    add_particle_bunch_openPMD(sim, -e, m_e, ts_path, z_off=z_off,
+                               species=species, select=select,
+                               iteration=iteration, boost=boost,
+                               z_injection_plane=z_injection_plane)
 
 
 def add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
@@ -384,49 +729,9 @@ def add_elec_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w,
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
     """
-    inv_gamma = 1./np.sqrt( 1. + ux**2 + uy**2 + uz**2 )
-    # Convert the particles to the boosted-frame
-    if boost is not None:
-        x, y, z, ux, uy, uz, inv_gamma = boost.boost_particle_arrays(
-                                        x, y, z, ux, uy, uz, inv_gamma )
-
-    # Select the particles that are in the local subdomain
-    zmin, zmax = sim.comm.get_zmin_zmax(
-        local=True, with_damp=False, with_guard=False, rank=sim.comm.rank )
-    selected = (z >= zmin) & (z < zmax)
-    x = x[selected]
-    y = y[selected]
-    z = z[selected]
-    ux = ux[selected]
-    uy = uy[selected]
-    uz = uz[selected]
-    w = w[selected]
-    inv_gamma = inv_gamma[selected]
-
-    # Create electron species with no macroparticles
-    relat_elec = sim.add_new_species( q=-e, m=m_e )
-
-    # Reallocate empty arrays with the right number of electrons
-    Ntot = len(x)
-    reallocate_and_copy_old( relat_elec, relat_elec.use_cuda, 0, Ntot )
-
-    # Fill the empty particle arrays with the right values
-    relat_elec.x[:] = x[:]
-    relat_elec.y[:] = y[:]
-    relat_elec.z[:] = z[:]
-    relat_elec.ux[:] = ux[:]
-    relat_elec.uy[:] = uy[:]
-    relat_elec.uz[:] = uz[:]
-    relat_elec.inv_gamma[:] = inv_gamma[:]
-    relat_elec.w[:] = w[:]
-
-    # Initialize the injection plane for the particles
-    if z_injection_plane is not None:
-        assert relat_elec.injector is None #Don't overwrite a previous injector
-        relat_elec.injector = BallisticBeforePlane( z_injection_plane, boost )
-
-    # Get the corresponding space-charge fields
-    get_space_charge_fields( sim, relat_elec, direction=direction )
+    add_particle_bunch_from_arrays( sim, x, y, z, ux, uy, uz, w, -e, m_e,
+                    boost=boost, direction=direction,
+                    z_injection_plane=z_injection_plane )
 
 
 def get_space_charge_fields( sim, ptcl, direction='forward' ):

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -18,7 +18,7 @@ def add_particle_bunch(sim, q, m, gamma0, n, p_zmin, p_zmax, p_rmin, p_rmax,
                        p_nr=2, p_nz=2, p_nt=4, dens_func=None, boost=None,
                        direction='forward', z_injection_plane=None):
     """
-    Introduce a simple relativistic electron bunch in the simulation,
+    Introduce a simple relativistic particle bunch in the simulation,
     along with its space charge field.
 
     Uniform particle distribution with weights according to density function.
@@ -35,7 +35,7 @@ def add_particle_bunch(sim, q, m, gamma0, n, p_zmin, p_zmax, p_rmin, p_rmax,
         Mass of the particle species
 
     gamma0 : float
-        The Lorentz factor of the electrons
+        The Lorentz factor of the particles
 
     n : float (in particles per m^3)
         Density of the bunch
@@ -65,7 +65,7 @@ def add_particle_bunch(sim, q, m, gamma0, n, p_zmin, p_zmax, p_rmin, p_rmax,
         A function of the form :
         `def dens_func( z, r ) ...`
         where `z` and `r` are 1d arrays, and which returns
-        a 1d array containing the density *relative to n_e*
+        a 1d array containing the density *relative to n*
         (i.e. a number between 0 and 1) at the given positions.
 
     boost : a BoostConverter object, optional
@@ -109,7 +109,7 @@ def add_particle_bunch_gaussian(sim, q, m, sig_r, sig_z, n_emit, gamma0,
                                 n_macroparticles, tf=0., zf=0., boost=None,
                                 save_beam=None, z_injection_plane=None):
     """
-    Introduce a relativistic Gaussian electron bunch in the simulation,
+    Introduce a relativistic Gaussian particle bunch in the simulation,
     along with its space charge field.
 
     The bunch is initialized with a normalized emittance `n_emit`,
@@ -243,7 +243,7 @@ def add_particle_bunch_file(sim, q, m, filename, n_physical_particles,
                             z_off=0., boost=None, direction='forward',
                             z_injection_plane=None):
     """
-    Introduce a relativistic electron bunch in the simulation,
+    Introduce a relativistic particle bunch in the simulation,
     along with its space charge field, loading particles from text file.
 
     Parameters
@@ -309,7 +309,7 @@ def add_particle_bunch_openPMD( sim, q, m, ts_path, z_off=0., species=None,
                                 select=None, iteration=None, boost=None,
                                 z_injection_plane=None ):
     """
-    Introduce a relativistic electron bunch in the simulation,
+    Introduce a relativistic particle bunch in the simulation,
     along with its space charge field, loading particles from an openPMD
     timeseries.
 
@@ -390,7 +390,7 @@ def add_particle_bunch_from_arrays(sim, q, m, x, y, z, ux, uy, uz, w,
                                    boost=None, direction='forward',
                                    z_injection_plane=None):
     """
-    Introduce a relativistic electron bunch in the simulation,
+    Introduce a relativistic particle bunch in the simulation,
     along with its space charge field, loading particles from numpy arrays.
 
     Parameters


### PR DESCRIPTION
As requested in #358 with this PR the bunch initialisation methods now accept the arguments `q` and `m` for the charge and mass of the particle species. For backward compatibility I kept the old functions which now just call the new functions with `-e` and `m_e` as arguments.