### PR TITLE
Force cupy to release its memory pool

### DIFF
--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -10,6 +10,7 @@ from fbpic.utils.cuda import cupy_installed
 if cupy_installed:
     import cupy
     from cupy.cuda import thrust
+    cupy_mempool = cupy.get_default_memory_pool()
 import math
 import numpy as np
 
@@ -114,6 +115,11 @@ def sort_particles_per_cell(cell_idx, sorted_idx):
                         data_start=d_cell_idx.data.ptr,
                         keys_start=0,
                         shape=d_cell_idx.shape )
+        # As part of `thrust.argsort`, `cupy` will allocate temporarily
+        # arrays in its memory pool. For performance reasons, this
+        # memory is not automatically released, after `argsort`
+        # Here we force `cupy` to release the memory.
+        cupy_mempool.free_all_blocks()
 
 @cuda.jit
 def incl_prefix_sum(cell_idx, prefix_sum):


### PR DESCRIPTION
# Overview

@hightower8083 recently reported that the `dev` branch (which uses `cupy`) leads to an out-of-memory error on typical production simulation. (Many thanks for testing the `dev` branch, and for reporting this error! :sparkles:) 

After looking at it more closely, it seems that this is because some GPU memory is taken by `cupy`'s [memory pool](https://docs-cupy.chainer.org/en/stable/reference/memory.html), and is not available to Numba. This PR fixes the issue.

# Original problem

More precisely: in FBPIC, the `cupy` memory pool should be empty, because we do all the GPU array allocations through Numba, and give the array to `cupy` through zero-copy.
However, in practice, `thrust.argsort` requires to allocate temporary arrays internally. This means that `cupy` *will* take GPU memory for its memory pool *and will often not release that memory, after `argsort`* (for performance reasons ; see again the [documentation for the memory pool](https://docs-cupy.chainer.org/en/stable/reference/memory.html)) In practice, the memory allocated for this memory pool can be quite large, especially if the size of the array keeps growing, as in a typical simulation with a moving window.

The problem is that this is memory is:
- Not strictly needed (it is only kept around for performance reasons)
- Not released when Numba needs it, which can lead to out-of-memory

# Solution

The solution implemented in this PR is to force `cupy` to free its memory pool. The downside is that it this leads to overheads (on the order of 5ms/iteration in the quick tests that I have done).

In the future, a better solution would be to allocate all arrays on GPU through `cupy`. That way Numba does not handle any memory on the GPU, and would not have an out-of-memory because of `cupy`'s memory pool.