### PR TITLE
Do not create particle species, when `n_e` is `None`

### DIFF
--- a/docs/source/example_input/ionization_script.py
+++ b/docs/source/example_input/ionization_script.py
@@ -109,14 +109,8 @@ T_interact = ( L_interact + (zmax-zmin) ) / v_window
 if __name__ == '__main__':
 
     # Initialize the simulation object
-    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-        zmin=zmin, boundaries='open', initialize_ions=False,
-        n_order=n_order, use_cuda=use_cuda )
-    # By default the simulation initializes an electron species (sim.ptcl[0])
-    # Because we did not pass the arguments `n`, `p_nz`, `p_nr`, `p_nz`,
-    # this electron species does not contain any macroparticles.
-    # It is okay to just remove it from the list of species.
-    sim.ptcl = []
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
+        boundaries='open', n_order=n_order, use_cuda=use_cuda )
 
     # Add the Helium ions (pre-ionized up to level 1),
     # the Nitrogen ions (pre-ionized up to level 5)

--- a/docs/source/example_input/lwfa_script.py
+++ b/docs/source/example_input/lwfa_script.py
@@ -55,9 +55,8 @@ Nm = 2           # Number of modes used
 dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
 
 # The particles
-p_zmin = 25.e-6  # Position of the beginning of the plasma (meters)
+p_zmin = 30.e-6  # Position of the beginning of the plasma (meters)
 p_zmax = 500.e-6 # Position of the end of the plasma (meters)
-p_rmin = 0.      # Minimal radial position of the plasma (meters)
 p_rmax = 18.e-6  # Maximal radial position of the plasma (meters)
 n_e = 4.e18*1.e6 # Density (electrons.meters^-3)
 p_nz = 2         # Number of particles per cell along z
@@ -109,10 +108,13 @@ T_interact = ( L_interact + (zmax-zmin) ) / v_window
 if __name__ == '__main__':
 
     # Initialize the simulation object
-    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-        p_zmin, p_zmax, p_rmin, p_rmax, p_nz, p_nr, p_nt, n_e,
-        dens_func=dens_func, zmin=zmin, boundaries='open',
-        n_order=n_order, use_cuda=use_cuda )
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
+        boundaries='open', n_order=n_order, use_cuda=use_cuda )
+
+    # Create the plasma electrons
+    elec = sim.add_new_species( q=-e, m=m_e, n=n_e,
+        dens_func=dens_func, p_zmin=p_zmin, p_zmax=p_zmax, p_rmax=p_rmax,
+        p_nz=p_nz, p_nr=p_nr, p_nt=p_nt )
 
     # Load initial fields
     # Add a laser to the fields of the simulation
@@ -121,7 +123,7 @@ if __name__ == '__main__':
     if use_restart is False:
         # Track electrons if required (species 0 correspond to the electrons)
         if track_electrons:
-            sim.ptcl[0].track( sim.comm )
+            elec.track( sim.comm )
     else:
         # Load the fields and particles from the latest checkpoint file
         restart_from_checkpoint( sim )
@@ -131,7 +133,7 @@ if __name__ == '__main__':
 
     # Add diagnostics
     sim.diags = [ FieldDiagnostic( diag_period, sim.fld, comm=sim.comm ),
-                  ParticleDiagnostic( diag_period, {"electrons" : sim.ptcl[0]},
+                  ParticleDiagnostic( diag_period, {"electrons" : elec},
                     select={"uz" : [1., None ]}, comm=sim.comm ) ]
     # Add checkpoints
     if save_checkpoints:

--- a/docs/source/example_input/lwfa_script.py
+++ b/docs/source/example_input/lwfa_script.py
@@ -18,7 +18,7 @@ where fbpic_object is any of the objects or function of FBPIC.
 # Imports
 # -------
 import numpy as np
-from scipy.constants import c
+from scipy.constants import c, e, m_e
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
 from fbpic.lpa_utils.laser import add_laser

--- a/docs/source/example_input/parametric_script.py
+++ b/docs/source/example_input/parametric_script.py
@@ -61,7 +61,6 @@ dt = (zmax-zmin)/Nz/c   # Timestep (seconds)
 # The particles
 p_zmin = 25.e-6  # Position of the beginning of the plasma (meters)
 p_zmax = 500.e-6 # Position of the end of the plasma (meters)
-p_rmin = 0.      # Minimal radial position of the plasma (meters)
 p_rmax = 18.e-6  # Maximal radial position of the plasma (meters)
 n_e = 4.e18*1.e6 # Density (electrons.meters^-3)
 p_nz = 2         # Number of particles per cell along z
@@ -121,10 +120,15 @@ if __name__ == '__main__':
     # Initialize the simulation object
     # Parametric scan: use the flag `use_all_mpi_ranks=False` to
     # have each MPI rank run an independent simulation
-    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
-        p_zmin, p_zmax, p_rmin, p_rmax, p_nz, p_nr, p_nt, n_e,
-        dens_func=dens_func, zmin=zmin, boundaries='open', n_order=n_order,
-        use_cuda=use_cuda, use_all_mpi_ranks=False )
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
+        boundaries='open', n_order=n_order, use_cuda=use_cuda,
+        use_all_mpi_ranks=False )
+
+    # Create the plasma electrons
+    elec = sim.add_new_species( q=-e, m=m_e,
+                n=n_e, dens_func=dens_func,
+                p_zmin=p_zmin, p_zmax=p_zmax, p_rmax=p_rmax,
+                p_nz=p_nz, p_nr=p_nr, p_nt=p_nt )
 
     # Load initial fields
     # Add a laser to the fields of the simulation
@@ -143,7 +147,7 @@ if __name__ == '__main__':
     write_dir = 'diags_a0_%.2f' %a0
     sim.diags = [ FieldDiagnostic( diag_period, sim.fld,
                     comm=sim.comm, write_dir=write_dir ),
-                ParticleDiagnostic( diag_period, {"electrons" : sim.ptcl[0]},
+                ParticleDiagnostic( diag_period, {"electrons" : elec},
                     select={"uz" : [1., None ]},
                     comm=sim.comm, write_dir=write_dir ) ]
 

--- a/docs/source/example_input/parametric_script.py
+++ b/docs/source/example_input/parametric_script.py
@@ -21,7 +21,7 @@ In a terminal, type:
 # Imports
 # -------
 import numpy as np
-from scipy.constants import c
+from scipy.constants import c, e, m_e
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
 from fbpic.lpa_utils.laser import add_laser

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -57,20 +57,22 @@ class Simulation(object):
         """
         Initializes a simulation.
 
-        # TODO update the documentation
-        By default the simulation contains:
-
-            - an electron species
-            - (if ``initialize_ions`` is True) an ion species (Hydrogen 1+)
-
-        These species are stored in the attribute ``ptcl`` of ``Simulation``
-        (which is a Python list, containing the different species).
+        By default, this will not create any particle species. You can
+        then add particles species to the simulation by using e.g. the method
+        ``add_new_species`` of the simulation object.
 
         .. note::
 
-            For the arguments `p_rmin`, `p_rmax`, `p_nz`, `p_nr`, `p_nt`,
-            `n_e`, and `dens_func`, see the docstring of the method
-            `add_new_species` (where `n_e` has been re-labeled as `n`).
+            As a short-cut, you can also directly create particle
+            species when initializing the ``Simulation`` object,
+            by passing the aguments `n_e`, `p_rmin`, `p_rmax`, `p_nz`,
+            `p_nr`, `p_nt`, and `dens_func`. This will create:
+
+                - an electron species
+                - (if ``initialize_ions`` is True) an ion species (Hydrogen 1+)
+
+            See the docstring of the method ``add_new_species`` for the
+            above-mentioned arguments (where `n_e` has been re-labeled as `n`).
 
         Parameters
         ----------

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -57,6 +57,7 @@ class Simulation(object):
         """
         Initializes a simulation.
 
+        # TODO update the documentation
         By default the simulation contains:
 
             - an electron species
@@ -251,17 +252,18 @@ class Simulation(object):
         self.grid_shape = self.fld.interp[0].Ez.shape
         self.particle_shape = particle_shape
         self.ptcl = []
-        # - Initialize the electrons
-        self.add_new_species( q=-e, m=m_e, n=n_e, dens_func=dens_func,
-                              p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
-                              p_zmin=p_zmin, p_zmax=p_zmax,
-                              p_rmin=p_rmin, p_rmax=p_rmax )
-        # - Initialize the ions
-        if initialize_ions:
-            self.add_new_species( q=e, m=m_p, n=n_e, dens_func=dens_func,
-                              p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
-                              p_zmin=p_zmin, p_zmax=p_zmax,
-                              p_rmin=p_rmin, p_rmax=p_rmax )
+        if n_e is not None:
+            # - Initialize the electrons
+            self.add_new_species( q=-e, m=m_e, n=n_e, dens_func=dens_func,
+                                  p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
+                                  p_zmin=p_zmin, p_zmax=p_zmax,
+                                  p_rmin=p_rmin, p_rmax=p_rmax )
+            # - Initialize the ions
+            if initialize_ions:
+                self.add_new_species( q=e, m=m_p, n=n_e, dens_func=dens_func,
+                                  p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
+                                  p_zmin=p_zmin, p_zmax=p_zmax,
+                                  p_rmin=p_rmin, p_rmax=p_rmax )
 
         # Register the time and the iteration
         self.time = 0.

--- a/tests/test_ionization.py
+++ b/tests/test_ionization.py
@@ -119,9 +119,9 @@ def run_simulation( gamma_boost, use_separate_electron_species ):
     # Initialize the simulation object, with the neutralizing electrons
     # No particles are created because we do not pass the density
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
-        initialize_ions=False, v_comoving=v_plasma,
-        use_galilean=False, boundaries='open', use_cuda=use_cuda )
-    sim.ptcl = []
+        v_comoving=v_plasma, use_galilean=False,
+        boundaries='open', use_cuda=use_cuda )
+
     # Add the charge-neutralizing electrons
     elec = sim.add_new_species( q=-e, m=m_e, n=level_start*n_atoms,
                         p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,


### PR DESCRIPTION
Currently, in FBPIC, when the user does not pass `n_e` (i.e. `n_e` is `None`), no macroparticles are created, but the the electron species itself is still created (and is empty of any macroparticles).

This is not very elegant, and usually forces users to explicitly remove that electron species with:
```
sim.ptcl = []
```

With this PR, no electron species is created, when `n_e` is None. Note that this breaks backward-compatibility in some cases, but these cases are expected to be rare.

Examples where this breaks backward capability:
- The user creates the `Simulation` object with `n_e=None`, forgets to do `sim.ptcl = []`, calls `sim.create_new_species` and then addresses particles (e.g. in `ParticleDiagnostics`) by indexing `sim.ptcl` (e.g. `sim.ptcl[1]`) instead of addressing them with the object returned by `sim.add_new_species`. In this case, this PR changes the indices that should be used (e.g. `sim.ptcl[0]` instead of `sim.ptcl[1]`.
- In the context of ionization: the user creates the `Simulation` object with `n_e=None`, and intentionally omits `sim.ptcl = []` so as to use the empty electron species to store electrons produced by ionization (by passing `sim.ptcl[0]` to `make_ionizable`). With this PR, this empty electron species should be explicitly created with `sim.add_new_species`.

In general, to avoid those issues, the recommended way to create/address particles is to use the object returned by `sim.add_new_species`.