### PR TITLE
Add note about in-focus laser energy

### DIFF
--- a/docs/source/api_reference/lpa_utilities/laser.rst
+++ b/docs/source/api_reference/lpa_utilities/laser.rst
@@ -44,6 +44,19 @@ Generic function for arbitrary laser profile
 
 .. autofunction:: fbpic.lpa_utils.laser.add_laser_pulse
 
+.. note::
+    Even though the user does not directly input the laser *energy* into ``FBPIC``,
+    but rather its *amplitude* :math:`a_0`, making the connection between :math:`a_0`
+    and a certain energy can be important for modelling experiments.
+    *Real-life* laser pulses have complicated intensity profiles,
+    with significant wings that extend to high radius.
+    These wings are the reason why only a fraction of the energy is inside the focal spot.
+    For Gaussian pulses, the wings are very weak at high radius.
+    Depending on how one defines the focal spot, almost all the energy is inside the spot.
+    On the other hand, if one uses a :class:`FlattenedGaussianLaser <fbpic.lpa_utils.laser.FlattenedGaussianLaser>`
+    (closer to a real-life laser), the intensity profile at focus will have significant wings,
+    and the energy in the central spot will be only a fraction of the total energy.
+
 Laser profiles
 ---------------
 


### PR DESCRIPTION
This PR adds a note to the docs explaining how to relate the laser amplitude which is passed as input to FBPIC to the measured laser energy, both on-target as well as inside the focal spot.

The text is mostly a verbatim copy of @RemiLehe's reply from the official `FBPIC` [slack channel](https://slack-fbpic.herokuapp.com).