### PR TITLE
Add the option `initialize_self_fields`

### DIFF
--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -16,7 +16,8 @@ import warnings
 
 def add_particle_bunch(sim, q, m, gamma0, n, p_zmin, p_zmax, p_rmin, p_rmax,
                        p_nr=2, p_nz=2, p_nt=4, dens_func=None, boost=None,
-                       direction='forward', z_injection_plane=None):
+                       direction='forward', z_injection_plane=None,
+                       initialize_self_field=True):
     """
     Introduce a simple relativistic particle bunch in the simulation,
     along with its space charge field.
@@ -81,6 +82,10 @@ def add_particle_bunch(sim, q, m, gamma0, n, p_zmin, p_zmax, p_rmin, p_rmax,
         motion for z<z_injection_plane. This is sometimes useful in
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
+
+    initialize_self_field: bool, optional
+       Whether to calculate the initial space charge fields of the bunch
+       and add these fields to the fields on the grid (Default: True)
     """
     # Calculate the electron momentum
     uz_m = ( gamma0**2 - 1. )**0.5
@@ -100,14 +105,16 @@ def add_particle_bunch(sim, q, m, gamma0, n, p_zmin, p_zmax, p_rmin, p_rmax,
         ptcl_bunch.injector = BallisticBeforePlane( z_injection_plane, boost )
 
     # Get the corresponding space-charge fields
-    get_space_charge_fields( sim, ptcl_bunch, direction=direction )
+    if initialize_self_field:
+        get_space_charge_fields( sim, ptcl_bunch, direction=direction )
     return ptcl_bunch
 
 
 def add_particle_bunch_gaussian(sim, q, m, sig_r, sig_z, n_emit, gamma0,
                                 sig_gamma, n_physical_particles,
                                 n_macroparticles, tf=0., zf=0., boost=None,
-                                save_beam=None, z_injection_plane=None):
+                                save_beam=None, z_injection_plane=None,
+                                initialize_self_field=True):
     """
     Introduce a relativistic Gaussian particle bunch in the simulation,
     along with its space charge field.
@@ -168,6 +175,10 @@ def add_particle_bunch_gaussian(sim, q, m, sig_r, sig_z, n_emit, gamma0,
         motion for z<z_injection_plane. This is sometimes useful in
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
+
+    initialize_self_field: bool, optional
+       Whether to calculate the initial space charge fields of the bunch
+       and add these fields to the fields on the grid (Default: True)
     """
     # Generate Gaussian gamma distribution of the beam
     if sig_gamma > 0.:
@@ -234,14 +245,15 @@ def add_particle_bunch_gaussian(sim, q, m, sig_r, sig_z, n_emit, gamma0,
 
     # Add the electrons to the simulation
     ptcl_bunch = add_particle_bunch_from_arrays(sim, q, m, x, y, z, ux, uy, uz,
-                                           w, boost=boost,
-                                           z_injection_plane=z_injection_plane)
+                    w, boost=boost, z_injection_plane=z_injection_plane,
+                    initialize_self_field=initialize_self_field)
     return ptcl_bunch
 
 
 def add_particle_bunch_file(sim, q, m, filename, n_physical_particles,
                             z_off=0., boost=None, direction='forward',
-                            z_injection_plane=None):
+                            z_injection_plane=None,
+                            initialize_self_field=True):
     """
     Introduce a relativistic particle bunch in the simulation,
     along with its space charge field, loading particles from text file.
@@ -282,6 +294,10 @@ def add_particle_bunch_file(sim, q, m, filename, n_physical_particles,
         motion for z<z_injection_plane. This is sometimes useful in
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
+
+    initialize_self_field: bool, optional
+       Whether to calculate the initial space charge fields of the bunch
+       and add these fields to the fields on the grid (Default: True)
     """
     # Load particle data to numpy array
     particle_data = np.loadtxt(filename)
@@ -300,14 +316,16 @@ def add_particle_bunch_file(sim, q, m, filename, n_physical_particles,
 
     # Add the electrons to the simulation
     ptcl_bunch = add_particle_bunch_from_arrays(sim, q, m, x, y, z, ux, uy, uz,
-                                   w,boost=boost, direction=direction,
-                                   z_injection_plane=z_injection_plane)
+                           w, boost=boost, direction=direction,
+                           z_injection_plane=z_injection_plane,
+                           initialize_self_field=initialize_self_field)
     return ptcl_bunch
 
 
 def add_particle_bunch_openPMD( sim, q, m, ts_path, z_off=0., species=None,
                                 select=None, iteration=None, boost=None,
-                                z_injection_plane=None ):
+                                z_injection_plane=None,
+                                initialize_self_field=True ):
     """
     Introduce a relativistic particle bunch in the simulation,
     along with its space charge field, loading particles from an openPMD
@@ -358,6 +376,10 @@ def add_particle_bunch_openPMD( sim, q, m, ts_path, z_off=0., species=None,
         motion for z<z_injection_plane. This is sometimes useful in
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
+
+    initialize_self_field: bool, optional
+       Whether to calculate the initial space charge fields of the bunch
+       and add these fields to the fields on the grid (Default: True)
     """
     # Import openPMD viewer
     try:
@@ -381,14 +403,16 @@ def add_particle_bunch_openPMD( sim, q, m, ts_path, z_off=0., species=None,
 
     # Add the electrons to the simulation, and calculate the space charge
     ptcl_bunch = add_particle_bunch_from_arrays(sim, q, m, x, y, z, ux, uy, uz,
-                                        w, boost=boost,
-                                        z_injection_plane=z_injection_plane)
+                            w, boost=boost,
+                            z_injection_plane=z_injection_plane,
+                            initialize_self_field=initialize_self_field)
     return ptcl_bunch
 
 
 def add_particle_bunch_from_arrays(sim, q, m, x, y, z, ux, uy, uz, w,
                                    boost=None, direction='forward',
-                                   z_injection_plane=None):
+                                   z_injection_plane=None,
+                                   initialize_self_field=True):
     """
     Introduce a relativistic particle bunch in the simulation,
     along with its space charge field, loading particles from numpy arrays.
@@ -427,6 +451,10 @@ def add_particle_bunch_from_arrays(sim, q, m, x, y, z, ux, uy, uz, w,
         motion for z<z_injection_plane. This is sometimes useful in
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
+
+    initialize_self_field: bool, optional
+       Whether to calculate the initial space charge fields of the bunch
+       and add these fields to the fields on the grid (Default: True)
     """
     inv_gamma = 1./np.sqrt( 1. + ux**2 + uy**2 + uz**2 )
     # Convert the particles to the boosted-frame
@@ -470,7 +498,8 @@ def add_particle_bunch_from_arrays(sim, q, m, x, y, z, ux, uy, uz, w,
         ptcl_bunch.injector = BallisticBeforePlane( z_injection_plane, boost )
 
     # Get the corresponding space-charge fields
-    get_space_charge_fields(sim, ptcl_bunch, direction=direction)
+    if initialize_self_field:
+        get_space_charge_fields(sim, ptcl_bunch, direction=direction)
     return ptcl_bunch
 
 

--- a/fbpic/picmi/simulation.py
+++ b/fbpic/picmi/simulation.py
@@ -159,6 +159,7 @@ class Simulation( PICMI_Simulation ):
         # - For the case of a plasma defined in a gridded layout
         if (type(s.initial_distribution)==PICMI_AnalyticDistribution) and \
             (type(layout) == PICMI_GriddedLayout):
+            assert initialize_self_field == False
             import numexpr
             density_expression = s.initial_distribution.density_expression
             if s.density_scale is not None:
@@ -180,7 +181,6 @@ class Simulation( PICMI_Simulation ):
         # - For the case of a Gaussian beam
         elif (type(s.initial_distribution)==PICMI_GaussianBunchDistribution) \
              and (type(layout) == PICMI_PseudoRandomLayout):
-            assert initialize_self_field
             dist = s.initial_distribution
             gamma0_beta0 = dist.centroid_velocity[-1]/c
             gamma0 = ( 1 + gamma0_beta0**2 )**.5

--- a/fbpic/picmi/simulation.py
+++ b/fbpic/picmi/simulation.py
@@ -207,7 +207,8 @@ class Simulation( PICMI_Simulation ):
                                 sig_r=sig_r0, sig_z=sig_z, n_emit=n_emit,
                                 n_physical_particles=n_physical_particles,
                                 n_macroparticles=layout.n_macroparticles,
-                                zf=zf, tf=tf )
+                                zf=zf, tf=tf,
+                                initialize_self_field=initialize_self_field )
         else:
             raise ValueError('Unknown combination of layout and distribution')
 


### PR DESCRIPTION
In the PICMI standard, the user can choose whether the initial self fields should be initialized or not.
In order to ensure compatibility, I added the option `initialize_self_fields` to the function that add a bunch to the simulation. (Only the functions with the new API, not the `add_elec_bunch` functions.)

Note that this is not yet fully PICMI-compliant, since a bunch which is loaded with an `AnalyticalDistribution` will not have the option, through FBPIC, to have its space-charge initialized.