### PR TITLE
Fix bug in ballistic injection for lab-frame simulation

### DIFF
--- a/fbpic/particles/injection/ballistic_before_plane.py
+++ b/fbpic/particles/injection/ballistic_before_plane.py
@@ -9,23 +9,23 @@ from scipy.constants import c
 
 class BallisticBeforePlane( object ):
     """
-    Class that defines particle injection "though a plane".    
-    In practice, when using this injection method, particles 
-    move ballistically before crossing a given plane. 
+    Class that defines particle injection "though a plane".
+    In practice, when using this injection method, particles
+    move ballistically before crossing a given plane.
 
-    This is useful when running boosted-frame simulation, whereby a 
-    relativistic particle beam is initialized in vacuum and later enters the 
-    plasma. In this case, the particle beam may feel its own space charge 
-    force for a long distance (in the boosted-frame), which may alter its 
-    properties. Imposing that particles move ballistically before a plane 
-    (which corresponds to the entrance of the plasma) ensures that the 
+    This is useful when running boosted-frame simulation, whereby a
+    relativistic particle beam is initialized in vacuum and later enters the
+    plasma. In this case, the particle beam may feel its own space charge
+    force for a long distance (in the boosted-frame), which may alter its
+    properties. Imposing that particles move ballistically before a plane
+    (which corresponds to the entrance of the plasma) ensures that the
     particles do not feel this space charge force.
     """
 
     def __init__(self, z_plane_lab, boost):
         """
         Initialize the parameters of the plane.
-        
+
         Parameters
         ----------
         z_plane_lab: float (in meters)
@@ -40,13 +40,14 @@ class BallisticBeforePlane( object ):
             self.inv_gamma_boost = 1./boost.gamma0
             self.beta_boost = boost.beta0
         else:
-            self.gamma0 = 1.
-            
+            self.inv_gamma_boost = 1.
+            self.beta_boost = 0.
+
 
     def get_current_plane_position( self, t ):
         """
-        Get the current position of the plane, in the frame of the simulation 
-        
+        Get the current position of the plane, in the frame of the simulation
+
         Parameters:
         -----------
         t: float (in seconds)


### PR DESCRIPTION
As reported in #385, the ballistic injection has a bug when using it in lab-frame simulations.

This pull request fixes the bug ; I checked it locally by adding a gaussian particle beam to the standard LWFA example, with an injection plane.