### PR TITLE
Fix Python 2 error in particle diag

### DIFF
--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -675,8 +675,8 @@ class ParticleCatcher:
             # Calculate cell area to get particles from
             # - Get z indices of the slices in which to get the particles
             # (mirrors the index calculation in `get_cell_idx_per_particle`)
-            iz_curr = math.ceil((current_z_boost-zmin-0.5*dz)/dz)
-            iz_prev = math.ceil((previous_z_boost-zmin-0.5*dz + dt*c)/dz) + 1
+            iz_curr = int(math.ceil((current_z_boost-zmin-0.5*dz)/dz))
+            iz_prev = int(math.ceil((previous_z_boost-zmin-0.5*dz + dt*c)/dz)) + 1
             # - Get the prefix sum values that correspond to these indices
             #   (Take into account potential shift due to the moving window)
             z_cell_curr = iz_curr + pref_sum_shift


### PR DESCRIPTION
`math.ceil` returns an [integer in Python 3](https://docs.python.org/3.7/library/math.html#math.ceil) but a [float in Python 2](https://docs.python.org/2/library/math.html#math.ceil).

The fact that the returned result is a float caused the boosted-frame diagnostic to fail on GPU: see #388. It is a bit surprising that this error only shows up now, but I am guessing that maybe some of our dependencies were recently updated.

The current PR forces the return result to be an integer. 