### PR TITLE
Adding an input deck diagnostic

### DIFF
--- a/fbpic/openpmd_diag/__init__.py
+++ b/fbpic/openpmd_diag/__init__.py
@@ -10,11 +10,12 @@ from .boosted_field_diag import BoostedFieldDiagnostic, \
                                 BackTransformedFieldDiagnostic
 from .boosted_particle_diag import BoostedParticleDiagnostic, \
                                 BackTransformedParticleDiagnostic
+from .inputscript_diag import InputScriptDiagnostic
 from .checkpoint_restart import set_periodic_checkpoint, \
      restart_from_checkpoint
 
 __all__ = ['FieldDiagnostic', 'ParticleDiagnostic',
 	'BoostedFieldDiagnostic', 'BoostedParticleDiagnostic',
     'BackTransformedFieldDiagnostic', 'BackTransformedParticleDiagnostic',
-    'ParticleChargeDensityDiagnostic',
+    'ParticleChargeDensityDiagnostic', 'InputScriptDiagnostic',
     'set_periodic_checkpoint', 'restart_from_checkpoint']

--- a/fbpic/openpmd_diag/inputdeck_diag.py
+++ b/fbpic/openpmd_diag/inputdeck_diag.py
@@ -1,0 +1,120 @@
+"""
+
+inputdeck_diag.py
+
+opmd derived diagnostic for saving the input deck
+into each simulation dump.
+
+"""
+
+import sys
+import os
+import numpy as np
+from fbpic.openpmd_diag.generic_diag import OpenPMDDiagnostic
+
+
+class InputDeckDiagnostic(OpenPMDDiagnostic):
+    """
+    Class that allows saving input decks to dumps.
+    """
+    def __init__(self, period, comm=None, param_dict=None,
+                 write_dir=None, iteration_min=0,
+                 iteration_max=np.inf, dt_period=None, dt_sim=None ):
+        """
+        Setup of the input deck diagnostic
+
+        Parameters
+        ----------
+        period : int, optional
+            The period of the diagnostics, in number of timesteps.
+            (i.e. the diagnostics are written whenever the number
+            of iterations is divisible by `period`). Specify either this or
+            `dt_period`.
+
+        comm : an fbpic BoundaryCommunicator object or None
+            If this is not None, the data is gathered on the first proc
+            Otherwise, each proc writes its own data.
+            (Make sure to use different write_dir in this case.)
+
+        param_dict : a dictionary of additional attributes
+            If this is not None, the dictionary entries will be written
+            to each file dump. The keys of the dict should be in camelCase.
+
+        write_dir : string, optional
+            The POSIX path to the directory where the results are
+            to be written. If none is provided, this will be the path
+            of the current working directory
+
+        iteration_min, iteration_max: ints
+            The iterations between which data should be written
+            (`iteration_min` is inclusive, `iteration_max` is exclusive)
+
+        dt_period : float (in seconds), optional
+            The period of the diagnostics, in physical time of the simulation.
+            Specify either this or `period`
+
+        dt_sim : float (in seconds), optional
+            The timestep of the simulation.
+            Only needed if `dt_period` is not None.
+        """
+        OpenPMDDiagnostic.__init__(self, period, comm, write_dir,
+                                   iteration_min, iteration_max,
+                                   dt_period=dt_period, dt_sim=dt_sim)
+
+        # Get the input deck and read it into memory
+        self._input_deck = self._get_input_deck()
+        self.param_dict = param_dict
+
+    def _get_input_deck(self):
+        """
+        Try to extract the text from the input deck.
+        We assume the input deck was passed as a paramater
+        to the currently running script and that it has an
+        extension of '.py'.
+
+        Returns
+        -------
+        The encoded text of the input deck, None if
+                no input deck detected
+        """
+        args = sys.argv
+        py_files = [f for f in args if '.py' in f]
+        if not py_files:
+            return
+        with open(py_files[0], 'r') as f:
+            text = f.read()
+        return text
+
+    def write_hdf5(self, iteration):
+        """
+            Write an HDF5 file that complies with the OpenPMD standard
+
+            Parameter
+            ---------
+            iteration : int
+                 The current iteration number of the simulation.
+        """
+        # Return right away if no input deck found
+        if self._input_deck is None:
+            return
+
+        filename = "data%08d.h5" % iteration
+        fullpath = os.path.join(self.write_dir, "hdf5", filename)
+
+        # Open the file again, and set the input deck as attribute
+        f = self.open_file(fullpath)
+        f.attrs["inputDeck"] = np.string_(self._input_deck)
+
+        # Write the extra parameters, if required
+        if self.param_dict is not None:
+            for key, val in self.param_dict.items():
+                if isinstance(val, str):
+                    f.attrs[key] = np.string_(val)
+                elif isinstance(val, (list, tuple)):
+                    f.attrs[key] = np.array(val)
+                else: #if isinstance(val, (int, float)):
+                    f.attrs[key] = val
+
+        # Close the file (only the first proc does this)
+        if f is not None:
+            f.close()

--- a/fbpic/openpmd_diag/inputscript_diag.py
+++ b/fbpic/openpmd_diag/inputscript_diag.py
@@ -1,10 +1,10 @@
+# Copyright 2019, FBPIC contributors
+# Authors: Kris Poder
+# License: 3-Clause-BSD-LBNL
 """
+This file defines the class InputScriptDiagnostic.
 
-inputdeck_diag.py
-
-opmd derived diagnostic for saving the input deck
-into each simulation dump.
-
+It allows saving the input script into each simulation dump.
 """
 
 import sys
@@ -13,7 +13,7 @@ import numpy as np
 from fbpic.openpmd_diag.generic_diag import OpenPMDDiagnostic
 
 
-class InputDeckDiagnostic(OpenPMDDiagnostic):
+class InputScriptDiagnostic(OpenPMDDiagnostic):
     """
     Class that allows saving input decks to dumps.
     """
@@ -21,7 +21,7 @@ class InputDeckDiagnostic(OpenPMDDiagnostic):
                  write_dir=None, iteration_min=0,
                  iteration_max=np.inf, dt_period=None, dt_sim=None ):
         """
-        Setup of the input deck diagnostic
+        Setup of the input script diagnostic
 
         Parameters
         ----------
@@ -61,21 +61,21 @@ class InputDeckDiagnostic(OpenPMDDiagnostic):
                                    iteration_min, iteration_max,
                                    dt_period=dt_period, dt_sim=dt_sim)
 
-        # Get the input deck and read it into memory
-        self._input_deck = self._get_input_deck()
+        # Get the input `script` and read it into memory
+        self._input_script = self._get_input_script()
         self.param_dict = param_dict
 
-    def _get_input_deck(self):
+    def _get_input_script(self):
         """
-        Try to extract the text from the input deck.
-        We assume the input deck was passed as a paramater
+        Try to extract the text from the input script.
+        We assume the input script was passed as a paramater
         to the currently running script and that it has an
         extension of '.py'.
 
         Returns
         -------
-        The encoded text of the input deck, None if
-                no input deck detected
+        The encoded text of the input script, None if
+                no input script detected
         """
         args = sys.argv
         py_files = [f for f in args if '.py' in f]
@@ -87,34 +87,34 @@ class InputDeckDiagnostic(OpenPMDDiagnostic):
 
     def write_hdf5(self, iteration):
         """
-            Write an HDF5 file that complies with the OpenPMD standard
+        Write an HDF5 file that complies with the OpenPMD standard
 
-            Parameter
-            ---------
-            iteration : int
-                 The current iteration number of the simulation.
+        Parameter
+        ---------
+        iteration : int
+             The current iteration number of the simulation.
         """
-        # Return right away if no input deck found
-        if self._input_deck is None:
+        # Return right away if no input script found
+        if self._input_script is None:
             return
 
         filename = "data%08d.h5" % iteration
         fullpath = os.path.join(self.write_dir, "hdf5", filename)
 
-        # Open the file again, and set the input deck as attribute
+        # Open the file again, and set the input script as attribute
         f = self.open_file(fullpath)
-        f.attrs["inputDeck"] = np.string_(self._input_deck)
-
-        # Write the extra parameters, if required
-        if self.param_dict is not None:
-            for key, val in self.param_dict.items():
-                if isinstance(val, str):
-                    f.attrs[key] = np.string_(val)
-                elif isinstance(val, (list, tuple)):
-                    f.attrs[key] = np.array(val)
-                else: #if isinstance(val, (int, float)):
-                    f.attrs[key] = val
-
-        # Close the file (only the first proc does this)
+        # Only the first proc does writing to file
         if f is not None:
+            f.attrs["inputScript"] = np.string_(self._input_script)
+
+            # Write the extra parameters, if required
+            if self.param_dict is not None:
+                for key, val in self.param_dict.items():
+                    if isinstance(val, str):
+                        f.attrs[key] = np.string_(val)
+                    elif isinstance(val, (list, tuple)):
+                        f.attrs[key] = np.array(val)
+                    else: #if isinstance(val, (int, float)):
+                        f.attrs[key] = val
+
             f.close()


### PR DESCRIPTION
This pull request would add an option for the user to store the input deck used to run the simulation as an attribute in hdf5 files via an InputDeckDiagnostic. This could allow for easy checks of exactly what parameters were used in the simulation at a later, when the input deck may have gotten lost. 
Additionally, an arbitrary list of other parameters can be written as attributes into the hdf5 files. For example, if the simulation was part of a large parameter scan (f in np.linspace(1, 3, 0.25)) the user can store the parameter range and the value used in the current simulation. This could simplify automatic analysis later on.