### PR TITLE
Close #393: fbpic does not work with new numba release (0.46) on GPU

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -11,7 +11,7 @@ This file steers and controls the simulation.
 # as it sets the cuda context)
 from fbpic.utils.mpi import MPI
 # Check if threading is available
-from .utils.threading import threading_enabled
+from .utils.threading import threading_enabled, numba_minor_version
 # Check if CUDA is available, then import CUDA functions
 from .utils.cuda import cuda_installed, cupy_installed
 if cuda_installed:
@@ -211,6 +211,11 @@ class Simulation(object):
                 'In order to run on GPUs, FBPIC version 0.13 and later \n'
                 'require the `cupy` package (version 6).\n'
                 'See the FBPIC documentation in order to install cupy.')
+        if self.use_cuda and numba_minor_version > 45:
+            raise RuntimeError(
+                'In order to run on GPU, please install numba version 0.45:\n'
+                '  conda install numba=0.45, or:\n'
+                '  pip install numba==0.45')
         # CPU multi-threading
         self.use_threading = threading_enabled
         if self.use_threading:

--- a/fbpic/utils/threading.py
+++ b/fbpic/utils/threading.py
@@ -9,6 +9,8 @@ import os, sys
 import warnings
 import numpy as np
 from numba import njit
+import numba
+numba_minor_version = int(numba.__version__.split('.')[1])
 
 # By default threading is enabled, except on Windows (not supported by Numba)
 threading_enabled = True
@@ -28,8 +30,6 @@ if threading_enabled:
         from numba import prange as numba_prange
         # Check that numba is version 0.34 or higher than 0.36
         # (other versions fail)
-        import numba
-        numba_minor_version = int(numba.__version__.split('.')[1])
         assert ( numba_minor_version==34 or numba_minor_version >= 36 )
     except (ImportError, AssertionError):
         threading_enabled = False


### PR DESCRIPTION
This PR tells the user to install an earlier version of numba instead.