### PR TITLE
Update documentation on number of modes

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -691,9 +691,10 @@ class Simulation(object):
         .. note::
 
             For the arguments below, it is recommended to have at least
-            ``p_nt = 4*Nm``, i.e. the required number of macroparticles
-            along `theta` (in order for the simulation to be properly resolved)
-            increases with the number of azimuthal modes used.
+            ``p_nt = 4*Nm`` (except in the case ``Nm=1``, for which
+            ``p_nt=1`` is sufficient). In other words, the required number of
+            macroparticles along `theta` (in order for the simulation to be
+            properly resolved) increases with the number of azimuthal modes used.
 
         Parameters
         ----------


### PR DESCRIPTION
The documentation did not explicitly state that one only needs 1 particle in the theta direction when `Nm=1`.

Thanks a lot to @abonatto for pointing this out to me!