### PR TITLE
Add the possibility to add `nr_damp` cells radially, in preparation for PMLs

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -148,9 +148,9 @@ class BoundaryCommunicator(object):
         self.Nm = Nm
         self._Nz_global_domain = Nz
         self._zmin_global_domain = zmin
-        # Get the distance dz between the cells
-        # (longitudinal spacing of the grid)
+        # Get the distance dz and dr between the cells
         self.dz = (zmax - zmin)/self._Nz_global_domain
+        self.dr = rmax/self.Nr
 
         # Check that the boundaries are valid
         if not boundaries in ['periodic', 'open']:
@@ -322,6 +322,34 @@ class BoundaryCommunicator(object):
 
         # Return the new boundaries to the simulation object
         return( zmin_local_enlarged, zmax_local_enlarged, Nz_enlarged )
+
+    def get_Nr( self, with_damp ):
+        """
+        Return the number of cells in r (`Nr`)
+
+        Parameters:
+        -----------
+        with_damp: bool
+            Whether to include the damp cells in the considered grid.
+        """
+        if with_damp:
+            return self.Nr + self.nr_damp
+        else:
+            return self.Nr
+
+    def get_rmax( self, with_damp ):
+        """
+        Return the outer radius of the simulation
+
+        Parameters:
+        -----------
+        with_damp: bool
+            Whether to include the damp cells in the considered grid.
+        """
+        if with_damp:
+            return (self.Nr + self.nr_damp)*self.dr
+        else:
+            return self.Nr*self.dr
 
     def get_Nz_and_iz( self, local, with_damp, with_guard, rank=None ):
         """

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -901,10 +901,12 @@ class BoundaryCommunicator(object):
                 local=False, with_guard=False, with_damp=False )
             zmin_global, zmax_global = self.get_zmin_zmax(
                 local=False, with_guard=False, with_damp=False )
+            Nr = self.get_Nr( with_damp=False )
+            rmax = self.get_rmax( with_damp=False )
             # Initialize new InterpolationGrid object that
             # is used to gather the global grid data
-            gathered_grid = InterpolationGrid( Nz_global, grid.Nr, grid.m,
-                                    zmin_global, zmax_global, grid.rmax )
+            gathered_grid = InterpolationGrid( Nz_global, Nr, grid.m,
+                                    zmin_global, zmax_global, rmax )
         else:
             # Other processes do not need to initialize new InterpolationGrid
             gathered_grid = None
@@ -961,7 +963,10 @@ class BoundaryCommunicator(object):
         _, iz_start_local_array = self.get_Nz_and_iz(
             local=True, with_damp=True, with_guard=True, rank=self.rank )
         iz_in_array = iz_start_local_domain - iz_start_local_array
-        local_array = array[ iz_in_array:iz_in_array+Nz_local, :Nr ]
+        local_array = np.ascontiguousarray(
+                        array[ iz_in_array:iz_in_array+Nz_local, :Nr ] )
+        # Note: local_array needs to be contiguous since is is passed
+        # directly to MPI's `Gatherv`
 
         # Then send the arrays
         if self.size > 1:

--- a/fbpic/boundaries/cuda_methods.py
+++ b/fbpic/boundaries/cuda_methods.py
@@ -359,7 +359,7 @@ def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
         The first axis corresponds to z and the second to r
 
     damp_array : 1darray of floats
-        An array of length n_guard+n_damp+n_inject,
+        An array of length n_guard+nz_damp+n_inject,
         which contains the damping factors.
 
     nd: int
@@ -398,7 +398,7 @@ def cuda_damp_EB_right( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
         The first axis corresponds to z and the second to r
 
     damp_array : 1darray of floats
-        An array of length n_guard+n_damp+n_inject,
+        An array of length n_guard+nz_damp+n_inject,
         which contains the damping factors.
 
     nd: int

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -251,6 +251,8 @@ class Simulation(object):
             n_guard, n_damp, nr_damp, None, exchange_period, use_all_mpi_ranks )
         # Modify domain region
         zmin, zmax, Nz = self.comm.divide_into_domain()
+        Nr = self.comm.get_Nr( with_damp=True )
+        rmax = self.comm.get_rmax( with_damp=True )
         # Initialize the field structure
         self.fld = Fields( Nz, zmax, Nr, rmax, Nm, dt,
                     n_order=n_order, zmin=zmin,

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -49,11 +49,11 @@ class Simulation(object):
                  n_order=-1, dens_func=None, filter_currents=True,
                  v_comoving=None, use_galilean=True,
                  initialize_ions=False, use_cuda=False,
-                 n_guard=None, n_damp=(64,32), exchange_period=None,
+                 n_guard=None, n_damp=64, exchange_period=None,
                  current_correction='curl-free', boundaries='periodic',
                  gamma_boost=None, use_all_mpi_ranks=True,
                  particle_shape='linear', verbose_level=1,
-                 smoother=None, r_boundary='reflective' ):
+                 smoother=None, r_boundary='reflective', nr_damp=32 ):
         """
         Initializes a simulation.
 
@@ -139,18 +139,16 @@ class Simulation(object):
             automatically (approx 2*n_order). If no MPI is used and
             in the case of open boundaries with an infinite order stencil,
             n_guard defaults to 64, if not set otherwise.
-        n_damp : tuple or int, optional
-            The number of damping cells in the longitudinal (z) and radial (r)
-            direction.
-            If `n_damp` is a tuple of integers, then the first
-            integer corresponds to the z direction, and the second to the r
-            direction. If `n_damp` is an integer, the same number of damping
-            cells is used in z and r.
-            For the longitudinal (z) direction: the damping cells are used
-            if `boundaries` is `"open"`, and they added at the left and right
-            edge of the simulation domain.
-            For the radial (r) direction: the damping cells are used if
-            `r_boundary` is `"open"`, and are added at `rmax`.
+        n_damp: int, optional
+            The number of damping cells in the longitudinal (z) direction.
+            The damping cells are used only if `boundaries` is `"open"`,
+            and they are added at the left and right edge of the simulation
+            domain.
+        nr_damp: int, optional
+            The number of damping cells in the radial (r) direction.
+            The damping cells are used only if `r_boundary` is `"open"`,
+            and are added at upper radial boundary (at `rmax`).
+
         exchange_period: int, optional
             Number of iterations before which the particles are exchanged.
             If set to None, the maximum exchange period is calculated
@@ -162,7 +160,7 @@ class Simulation(object):
         boundaries: string, optional
             The boundary condition in the longitudinal (z) direction.
             Either "periodic" or "open" (for field-absorbing boundary)
-       r_boundary: string, optional
+        r_boundary: string, optional
             The boundary condition at the upper radial boundary (at rmax).
             Either "reflective" or "open" (for field-absorbing boundary)
             When "open" is selected, this adds Perfectly-Matched-Layers
@@ -249,8 +247,8 @@ class Simulation(object):
 
         # Initialize the boundary communicator
         self.comm = BoundaryCommunicator( Nz, zmin, zmax, Nr, rmax, Nm, dt,
-            self.v_comoving, self.use_galilean, boundaries, n_order,
-            n_guard, n_damp, None, exchange_period, use_all_mpi_ranks )
+            self.v_comoving, self.use_galilean, boundaries, r_boundary, n_order,
+            n_guard, n_damp, nr_damp, None, exchange_period, use_all_mpi_ranks )
         # Modify domain region
         zmin, zmax, Nz = self.comm.divide_into_domain()
         # Initialize the field structure

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -812,6 +812,9 @@ class Simulation(object):
                                         with_damp=False, with_guard=False )
             p_zmin = max( zmin_local_domain, p_zmin )
             p_zmax = min( zmax_local_domain, p_zmax )
+            # Avoid that particles get initialized in the radial PML cells
+            rmax = self.comm.get_rmax( with_damp=False )
+            p_rmax = min( rmax, p_rmax )
 
             # Modify again the input particle bounds, so that
             # they fall exactly on the grid, and infer the number of particles

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -49,11 +49,11 @@ class Simulation(object):
                  n_order=-1, dens_func=None, filter_currents=True,
                  v_comoving=None, use_galilean=True,
                  initialize_ions=False, use_cuda=False,
-                 n_guard=None, n_damp=64, exchange_period=None,
+                 n_guard=None, n_damp=(64,32), exchange_period=None,
                  current_correction='curl-free', boundaries='periodic',
                  gamma_boost=None, use_all_mpi_ranks=True,
                  particle_shape='linear', verbose_level=1,
-                 smoother=None ):
+                 smoother=None, r_boundary='reflective' ):
         """
         Initializes a simulation.
 
@@ -139,14 +139,18 @@ class Simulation(object):
             automatically (approx 2*n_order). If no MPI is used and
             in the case of open boundaries with an infinite order stencil,
             n_guard defaults to 64, if not set otherwise.
-        n_damp : int, optional
-            Number of damping guard cells at the left and right of a
-            simulation box if a moving window is attached. The guard
-            region at these areas (left / right of moving window) is
-            extended by n_damp in order to smoothly damp the fields such
-            that they do not wrap around. Additionally, this region is
-            extended by an injection area of size n_guard/2 automatically.
-            (Defaults to 64)
+        n_damp : tuple or int, optional
+            The number of damping cells in the longitudinal (z) and radial (r)
+            direction.
+            If `n_damp` is a tuple of integers, then the first
+            integer corresponds to the z direction, and the second to the r
+            direction. If `n_damp` is an integer, the same number of damping
+            cells is used in z and r.
+            For the longitudinal (z) direction: the damping cells are used
+            if `boundaries` is `"open"`, and they added at the left and right
+            edge of the simulation domain.
+            For the radial (r) direction: the damping cells are used if
+            `r_boundary` is `"open"`, and are added at `rmax`.
         exchange_period: int, optional
             Number of iterations before which the particles are exchanged.
             If set to None, the maximum exchange period is calculated
@@ -156,9 +160,14 @@ class Simulation(object):
             to small values can substantially affect the performance)
 
         boundaries: string, optional
-            Indicates how to exchange the fields at the left and right
-            boundaries of the global simulation box.
-            (Either 'periodic' or 'open')
+            The boundary condition in the longitudinal (z) direction.
+            Either "periodic" or "open" (for field-absorbing boundary)
+       r_boundary: string, optional
+            The boundary condition at the upper radial boundary (at rmax).
+            Either "reflective" or "open" (for field-absorbing boundary)
+            When "open" is selected, this adds Perfectly-Matched-Layers
+            in the radial direction ; note that the computation is
+            significantly more costly in this case.
 
         current_correction: string, optional
             The method used in order to ensure that the continuity equation

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -53,7 +53,7 @@ class Simulation(object):
                  current_correction='curl-free', boundaries='periodic',
                  gamma_boost=None, use_all_mpi_ranks=True,
                  particle_shape='linear', verbose_level=1,
-                 smoother=None, r_boundary='open', nr_damp=32 ):
+                 smoother=None, r_boundary='reflective', nr_damp=32 ):
         """
         Initializes a simulation.
 

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -53,7 +53,7 @@ class Simulation(object):
                  current_correction='curl-free', boundaries='periodic',
                  gamma_boost=None, use_all_mpi_ranks=True,
                  particle_shape='linear', verbose_level=1,
-                 smoother=None, r_boundary='reflective', nr_damp=32 ):
+                 smoother=None, r_boundary='open', nr_damp=32 ):
         """
         Initializes a simulation.
 

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -93,6 +93,12 @@ class BackTransformedFieldDiagnostic(FieldDiagnostic):
         dz_lab = c*self.fld.dt * self.inv_beta_boost*self.inv_gamma_boost
         Nz = int( (zmax_lab - zmin_lab)/dz_lab ) + 1
         self.inv_dz_lab = 1./dz_lab
+        # Get number of radial cells in the output
+        # (if possible, remove damp cells)
+        if self.comm is None:
+            Nr = self.fld.interp[0].Nr
+        else:
+            Nr = self.comm.get_Nr(with_damp=False)
 
         # Create the list of LabSnapshot objects
         self.snapshots = []
@@ -101,15 +107,15 @@ class BackTransformedFieldDiagnostic(FieldDiagnostic):
             snapshot = LabSnapshot( t_lab,
                                     zmin_lab + v_lab*t_lab,
                                     zmax_lab + v_lab*t_lab,
-                                    self.write_dir, i, self.fld )
+                                    self.write_dir, i, self.fld, Nr )
             self.snapshots.append( snapshot )
             # Initialize a corresponding empty file
             self.create_file_empty_meshes( snapshot.filename, i,
-                snapshot.t_lab, Nz, snapshot.zmin_lab, dz_lab, self.fld.dt )
+                snapshot.t_lab, Nr, Nz, snapshot.zmin_lab, dz_lab, self.fld.dt)
 
         # Create a slice handler, which will do all the extraction, Lorentz
         # transformation, etc for each slice to be registered in a LabSnapshot
-        self.slice_handler = SliceHandler( self.gamma_boost, self.beta_boost )
+        self.slice_handler = SliceHandler(self.gamma_boost, self.beta_boost, Nr)
 
     def write( self, iteration ):
         """
@@ -363,7 +369,7 @@ class LabSnapshot:
     in the lab frame (i.e. one given *time* in the lab frame)
     """
     def __init__(self, t_lab, zmin_lab, zmax_lab,
-                    write_dir, i, fld):
+                    write_dir, i, fld, Nr_output):
         """
         Initialize a LabSnapshot
 
@@ -385,6 +391,10 @@ class LabSnapshot:
         fld: a Fields object
            This is passed only in order to determine how to initialize
            the slice_array buffer (either on the CPU or GPU)
+
+        Nr_output: int
+            Number of cells in the r direction, in the final output
+            (This typically excludes the radial damping cells)
         """
         # Deduce the name of the filename where this snapshot writes
         self.filename = os.path.join( write_dir, 'hdf5/data%08d.h5' %i)
@@ -406,7 +416,7 @@ class LabSnapshot:
 
         # Allocate a buffer for only one slice (avoids having to
         # reallocate arrays when running on the GPU)
-        data_shape = (10, 2*fld.Nm-1, fld.Nr)
+        data_shape = (10, 2*fld.Nm-1, Nr_output)
         if fld.use_cuda is False:
             self.slice_array = np.empty( data_shape )
         else:
@@ -471,7 +481,7 @@ class LabSnapshot:
 
         Returns
         -------
-        field_array: an array of reals of shape (10, 2*Nm-1, Nr, nslices)
+        field_array: an array of reals of shape (10, 2*Nm-1, Nr_output, nslices)
         In the above nslices is the number of buffered slices
 
         iz_min, iz_max: integers
@@ -514,7 +524,7 @@ class SliceHandler:
     """
     Class that extracts, Lorentz-transforms and writes slices of the fields
     """
-    def __init__( self, gamma_boost, beta_boost ):
+    def __init__( self, gamma_boost, beta_boost, Nr_output ):
         """
         Initialize the SliceHandler object
 
@@ -522,10 +532,15 @@ class SliceHandler:
         ----------
         gamma_boost, beta_boost: floats
             The Lorentz factor of the boost and the corresponding beta
+
+        Nr_output: int
+            Number of cells in the r direction, in the final output
+            (This typically excludes the radial damping cells)
         """
         # Store the arguments
         self.gamma_boost = gamma_boost
         self.beta_boost = beta_boost
+        self.Nr_output = Nr_output
 
         # Create a dictionary that contains the correspondance
         # between the field names and array index
@@ -560,7 +575,7 @@ class SliceHandler:
             The first index of this array corresponds to the field type
             (10 different field types), and the correspondance
             between the field type and integer index is given field_to_index
-            The shape of this arrays is (10, 2*Nm-1, Nr)
+            The shape of this arrays is (10, 2*Nm-1, Nr_output)
         """
         # Find the index of the slice in the boosted frame
         # and the corresponding interpolation shape factor
@@ -586,14 +601,13 @@ class SliceHandler:
         # Fill the pre-allocated GPU array slice_array
         else:
             # Prepare kernel call
-            interp = fld.interp
-            Nr = fld.Nr
-            dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( Nr )
+            dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( self.Nr_output )
 
             # Extract the slices
+            interp = fld.interp
             for m in range(fld.Nm):
                 extract_slice_cuda[ dim_grid_1d, dim_block_1d ](
-                    Nr, iz, Sz, slice_array,
+                    self.Nr_output, iz, Sz, slice_array,
                     interp[m].Er, interp[m].Et, interp[m].Ez,
                     interp[m].Br, interp[m].Bt, interp[m].Bz,
                     interp[m].Jr, interp[m].Jt, interp[m].Jz, interp[m].rho, m)
@@ -614,7 +628,7 @@ class SliceHandler:
             Interpolation shape factor used at iz
 
         slice_array: np.ndarray
-            Array of shape (10, 2*Nm-1, Nr )
+            Array of shape (10, 2*Nm-1, Nr_output )
         """
         # Shortcut for the correspondance between field and integer index
         f2i = self.field_to_index
@@ -649,17 +663,20 @@ class SliceHandler:
         In particular, the array of fields is of shape ( 2*Nm-1, Nr)
         (real and imaginary part are separated for each mode)
         """
+        # Shortcut
+        Nr = self.Nr_output
+
         # Allocate the array to be returned
-        data_shape = ( 2*fld.Nm-1, fld.Nr )
+        data_shape = (2*fld.Nm-1, Nr)
         output_array = np.empty( data_shape )
 
         # Get the mode 0 : only the real part is non-zero
-        output_array[0,:] = getattr(fld.interp[0], quantity)[iz_slice,:].real
+        output_array[0,:] = getattr(fld.interp[0], quantity)[iz_slice,:Nr].real
         # Get the higher modes
         # There is a factor 2 here so as to comply with the convention in
         # Lifschitz et al., which is also the convention adopted in FBPIC
         for m in range(1,fld.Nm):
-            higher_mode_slice = 2*getattr(fld.interp[m], quantity)[iz_slice,:]
+            higher_mode_slice = 2*getattr(fld.interp[m], quantity)[iz_slice,:Nr]
             output_array[2*m-1, :] = higher_mode_slice.real
             output_array[2*m, :] = higher_mode_slice.imag
 
@@ -683,7 +700,7 @@ class SliceHandler:
         ---------
         fields: array of floats
             An array that packs together the slices of the different fields.
-            The shape of this arrays is (10, 2*Nm-1, Nr, nslices)
+            The shape of this arrays is (10, 2*Nm-1, Nr_output, nslices)
             where nslices is the number of slices that have been buffered
         """
         # Some shortcuts

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -573,7 +573,7 @@ class SliceHandler:
         if comm is not None:
             iz += comm.n_guard
             if comm.left_proc is None:
-                iz += comm.n_damp+comm.n_inject
+                iz += comm.nz_damp+comm.n_inject
 
         # Extract the slice directly on the CPU
         # Fill the pre-allocated CPU array slice_array

--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -104,19 +104,23 @@ class FieldDiagnostic(OpenPMDDiagnostic):
         dz = self.fld.interp[0].dz
         if self.comm is None:
             # No communicator: dump all the present subdomain
+            # (including damp cells and guard cells)
             zmin = self.fld.interp[0].zmin
             Nz = self.fld.interp[0].Nz
+            Nr = self.fld.interp[0].Nr
         else:
+            # Communicator present: only dump physical cells
             zmin, _ = self.comm.get_zmin_zmax(
                     local=False, with_damp=False, with_guard=False )
             Nz, _ = self.comm.get_Nz_and_iz(
                     local=False, with_damp=False, with_guard=False )
+            Nr = self.comm.get_Nr( with_damp=False )
 
         # Create the file with these attributes
         filename = "data%08d.h5" %iteration
         fullpath = os.path.join( self.write_dir, "hdf5", filename )
         self.create_file_empty_meshes(
-            fullpath, iteration, time, Nz, zmin, dz, dt )
+            fullpath, iteration, time, Nr, Nz, zmin, dz, dt )
 
         # Open the file again, and get the field path
         f = self.open_file( fullpath )
@@ -217,7 +221,7 @@ class FieldDiagnostic(OpenPMDDiagnostic):
     # ---------------------
 
     def create_file_empty_meshes( self, fullpath, iteration,
-                                   time, Nz, zmin, dz, dt ):
+                                   time, Nr, Nz, zmin, dz, dt ):
         """
         Create an openPMD file with empty meshes and setup all its attributes
 
@@ -232,8 +236,8 @@ class FieldDiagnostic(OpenPMDDiagnostic):
         time: float (seconds)
             The physical time at this iteration
 
-        Nz: int
-            The number of gridpoints along z in this diagnostics
+        Nr, Nz: int
+            The number of gridpoints along r and z in this diagnostics
 
         zmin: float (meters)
             The position of the left end of the box
@@ -246,7 +250,7 @@ class FieldDiagnostic(OpenPMDDiagnostic):
         """
         # Determine the shape of the datasets that will be written
         # First write real part mode 0, then imaginary part of higher modes
-        data_shape = ( 2*self.fld.Nm - 1, self.fld.Nr, Nz )
+        data_shape = ( 2*self.fld.Nm - 1, Nr, Nz )
 
         # Create the file
         f = self.open_file( fullpath )

--- a/fbpic/openpmd_diag/particle_density_diag.py
+++ b/fbpic/openpmd_diag/particle_density_diag.py
@@ -88,12 +88,13 @@ class ParticleChargeDensityDiagnostic(FieldDiagnostic):
                 local=False, with_damp=False, with_guard=False )
         Nz, _ = self.comm.get_Nz_and_iz(
                 local=False, with_damp=False, with_guard=False )
+        Nr = self.comm.get_Nr(with_damp=False)
 
         # Create the file with these attributes
         filename = "data%08d.h5" %iteration
         fullpath = os.path.join( self.write_dir, "hdf5", filename )
         self.create_file_empty_meshes(
-            fullpath, iteration, time, Nz, zmin, dz, dt )
+            fullpath, iteration, time, Nr, Nz, zmin, dz, dt )
 
         # Loop over the requested species
         for species_name in self.species.keys():

--- a/fbpic/utils/printing.py
+++ b/fbpic/utils/printing.py
@@ -221,7 +221,7 @@ def print_simulation_setup( sim, verbose_level=1 ):
             message += '\nLongitudinal boundaries: %s' %sim.comm.boundaries
             message += '\nTransverse boundaries: reflective'
             message += '\nGuard region size: %d ' %sim.comm.n_guard+'cells'
-            message += '\nDamping region size: %d ' %sim.comm.n_damp+'cells'
+            message += '\nDamping region size: %d ' %sim.comm.nz_damp+'cells'
             message += '\nInjection region size: %d ' %sim.comm.n_inject+'cells'
             message += '\nParticle exchange period: every %d ' \
                 %sim.comm.exchange_period + 'step'

--- a/tests/test_laser_antenna.py
+++ b/tests/test_laser_antenna.py
@@ -142,7 +142,7 @@ def run_and_check_laser_antenna(gamma_b, show, write_files,
 
     # Check the transverse E and B field
     Nz_half = int(sim.fld.interp[1].Nz/2) + 2
-    z = sim.fld.interp[1].z[Nz_half:-(sim.comm.n_guard+sim.comm.n_damp+\
+    z = sim.fld.interp[1].z[Nz_half:-(sim.comm.n_guard+sim.comm.nz_damp+\
                             sim.comm.n_inject)]
     r = sim.fld.interp[1].r
     # Loop through the different fields
@@ -152,7 +152,7 @@ def run_and_check_laser_antenna(gamma_b, show, write_files,
         # in order to get a value which is comparable to an electric field
         # (Because of the definition of the interpolation grid, the )
         field = getattr(sim.fld.interp[1], fieldtype)\
-                            [Nz_half:-(sim.comm.n_guard+sim.comm.n_damp+\
+                            [Nz_half:-(sim.comm.n_guard+sim.comm.nz_damp+\
                              sim.comm.n_inject)]
         print( 'Checking %s' %fieldtype )
         check_fields( factor*field, z, r, info_in_real_part,


### PR DESCRIPTION
This PR adds the possibility to add `nr_damp` cells in a simulation.

Here is a list of the changes:

- 2 new arguments have been added to the API of the `Simulation` object: `nr_damp` and `r_boundary` (which can be either `"reflective"` - the default - or `"open"`). Note that the radial damp cells are only added if `r_boundary` is `"open"`. For backward compatibility, the number of damp cells and boundary in the `z` direction are still called `n_damp` and `boundaries` (without an explicitly `z`).

- In the `BoundaryCommunicator` object: `self.n_damp` has been replaced by `self.nz_damp` throughout the code, and a new attribute `self.nr_damp` has been added. In addition, 2 new methods have been added: `get_Nr` and `get_rmax`, which have an optional argument `with_damp`. They return the transverse size of the box with or without the damp cells.

- `get_Nr` and `get_rmax` are used throughout the code, pretty much in the same places where the pre-existing functions `get_zmin_zmax` and `get_Nz_and_iz` are used. In particular:
    * The `Fields` object is initialized with `Nr` and `rmax` **including** the damp cells.
    * All the diagnostics are performed with `Nr` **excluding** the guard cells (except when `comm` is `None`, which is again the same behavior as with the longitudinal damp cells). This required to also change the API of some of the `openPMD` output functions (esp. in the back-transformed diagnostics)

I ran tests with `r_boundary="open"` (i.e. non-zero number of transverse damp cells), and everything seems to be fine. (For the moment, the fields are not absorbed of course, but all the initialization/output machinery seems to work properly.)