### PR TITLE
Close #396: Keep field arrays sorted whenever needed

### DIFF
--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -200,6 +200,11 @@ class Particles(object) :
         # Register particle shape
         self.particle_shape = particle_shape
 
+        # Register boolean that records whether field array should
+        # be rearranged whenever sorting particles
+        # (gets modified during the main PIC loop, on GPU)
+        self.keep_fields_sorted = False
+
         # Allocate arrays and register variables when using CUDA
         if self.use_cuda:
             if grid_shape is None:
@@ -501,6 +506,9 @@ class Particles(object) :
         attr_list = [ (self,'x'), (self,'y'), (self,'z'), \
                         (self,'ux'), (self,'uy'), (self,'uz'), \
                         (self, 'w'), (self,'inv_gamma') ]
+        if self.keep_fields_sorted:
+            attr_list += [ (self, 'Ex'), (self, 'Ey'), (self, 'Ez'), \
+                            (self, 'Bx'), (self, 'By'), (self, 'Bz') ]
         if self.ionizer is not None:
             attr_list += [ (self.ionizer,'w_times_level') ]
         for attr in attr_list:


### PR DESCRIPTION
## Overview

During the PIC loop, we typically: 
- gather the E and B fields into the arrays with one element per particle
- then use these fields to push the particles and/or perform ionization

However, when running on GPU, particles arrays may be sorted and rearranged between the time at which the field are gathered and the time at which they are used. (This may happen because of charge/current deposition and/or boosted-frame diagnostics and particle-density diagnostics.) **In the current `dev` branch, when particles are rearranged, the particle arrays for the E and B field are NOT rearranged.** This means that, if the fields are used after the particles have been rearranged, their values will be invalid. (For instance, this caused spurious ionization in #396.)

This PR fixes the issue by rearranging the fields array whenever particles are rearranged. However, because this will impact performance, this is done only when needed i.e. between the gathering step and the particle/push and/or ionization step. In order to implement this, a new flag (`keep_fields_sorted`) is introduced in the `Particles` class. 

In addition, the ionization step has been moved, so that it happens just before the current deposition (instead of just after the current deposition). This is for performance reason: in order to avoid another sort/rearranging call (associated with the current deposition) in the region of the PIC loop where the fields have to be rearranged too.

## Tests

I ran the automated tests on GPU and they passed successfully.

I also tested this PR on the original problem of #396 and it shows that the problem of spurious ionization is fixed.

![Screenshot from 2019-11-12 09-01-16](https://user-images.githubusercontent.com/6685781/68692829-03943a80-052b-11ea-84f6-992127bb748a.png)
