### PR TITLE
Implement few-cycle laser pulse profile

### DIFF
--- a/docs/source/api_reference/lpa_utilities/laser.rst
+++ b/docs/source/api_reference/lpa_utilities/laser.rst
@@ -58,6 +58,7 @@ own custom laser profiles.
     laser_profiles/laguerre
     laser_profiles/donut_laguerre
     laser_profiles/flattened
+    laser_profiles/few_cycle
 
 Combining (summing) laser profiles
 **********************************

--- a/docs/source/api_reference/lpa_utilities/laser_profiles/few_cycle.rst
+++ b/docs/source/api_reference/lpa_utilities/laser_profiles/few_cycle.rst
@@ -1,0 +1,4 @@
+Few-cycle profile
+*****************
+
+.. autoclass:: fbpic.lpa_utils.laser.FewCycleLaser

--- a/fbpic/lpa_utils/laser/__init__.py
+++ b/fbpic/lpa_utils/laser/__init__.py
@@ -4,8 +4,10 @@ It imports functions which are useful when initializing a laser pulse
 """
 from .laser import add_laser, add_laser_pulse
 from .laser_profiles import GaussianLaser, LaguerreGaussLaser, \
-              DonutLikeLaguerreGaussLaser, FlattenedGaussianLaser
+              DonutLikeLaguerreGaussLaser, FlattenedGaussianLaser, \
+              FewCycleLaser
 
 __all__ = ['add_laser', 'add_laser_pulse',
-            'GaussianLaser', 'LaguerreGaussLaser', 
-            'DonutLikeLaguerreGaussLaser', 'FlattenedGaussianLaser']
+            'GaussianLaser', 'LaguerreGaussLaser',
+            'DonutLikeLaguerreGaussLaser', 'FlattenedGaussianLaser',
+            'FewCycleLaser']

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -728,11 +728,11 @@ class FewCycleLaser( LaserProfile ):
 
         .. math::
 
-            \omega_0 \\tau_{WFHM} = s\\sqrt{2(4^{1/(s+1)}-1)}
+            \omega_0 \\tau_{FWHM} = s\\sqrt{2(4^{1/(s+1)}-1)}
 
         .. note::
 
-            In the case of :math:`\omega_0 \\tau_{WFHM} \gg 1` (i.e. many
+            In the case of :math:`\omega_0 \\tau_{FWHM} \gg 1` (i.e. many
             laser cycles within the envelope), the above expression approaches
             that of a standard Gaussian laser pulse, and thus the :any:`FewCycleLaser`
             profile becomes equivalent to the :any:`GaussianLaser` profile

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -215,14 +215,20 @@ class GaussianLaser( LaserProfile ):
 
         # Diffraction and stretch_factor
         prop_dir = self.propag_direction
-        diffract_factor = 1. + 1j * prop_dir*(z - self.zf) * self.inv_zr
+        alpha = prop_dir * (z - self.zf) * self.inv_zr
+        diffract_factor = 1. + 1j * alpha
         stretch_factor = 1 - 2j * self.phi2_chirp * c**2 * self.inv_ctau2
         # Calculate the argument of the complex exponential
         exp_argument = - 1j*self.cep_phase \
             + 1j*self.k0*( prop_dir*(z - self.z0) - c*t ) \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - 1./stretch_factor*self.inv_ctau2 * \
-                                    ( prop_dir*(z - self.z0) - c*t )**2
+            - 1./stretch_factor*self.inv_ctau2 * (
+                    prop_dir*(z - self.z0) - c*t \
+                    # The last term below corresponds to the curvature of the
+                    # envelope ; see Phys. Rev. E 59, 1082 (1999), appendix B.2
+                    - alpha*(1-alpha**2)*(x**2+y**2) \
+                    /(self.k0*self.w0**2*(1+alpha**2)**2) )**2
+
         # Get the transverse profile
         profile = np.exp(exp_argument) /(diffract_factor * stretch_factor**0.5)
 
@@ -389,7 +395,8 @@ class LaguerreGaussLaser( LaserProfile ):
         """
         # Diffraction factor, waist and Gouy phase
         prop_dir = self.propag_direction
-        diffract_factor = 1. + 1j * prop_dir * (z - self.zf) * self.inv_zr
+        alpha = prop_dir * (z - self.zf) * self.inv_zr
+        diffract_factor = 1. + 1j * alpha
         w = self.w0 * abs( diffract_factor )
         psi = np.angle( diffract_factor )
         # Calculate the scaled radius and azimuthal angle
@@ -400,8 +407,13 @@ class LaguerreGaussLaser( LaserProfile ):
         exp_argument = - 1j*self.cep_phase \
             + 1j*self.k0*( prop_dir*(z - self.z0) - c*t ) \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t )**2 \
-            - 1.j*(2*self.p + self.m)*psi # *Additional* Gouy phase
+            - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t \
+                # The term below corresponds to the curvature of the
+                # envelope ; see Phys. Rev. E 59, 1082 (1999), appendix B.2
+                - alpha*(1-alpha**2)*(x**2+y**2) \
+                /(self.k0*self.w0**2*(1+alpha**2)**2) )**2 \
+            - 1.j*(2*self.p + self.m)*psi # Additional Gouy phase
+
         # Get the transverse profile
         profile = np.exp(exp_argument) / diffract_factor \
             * scaled_radius**self.m * self.laguerre_pm(scaled_radius_squared) \
@@ -549,7 +561,8 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
         """
         # Diffraction factor, waist and Gouy phase
         prop_dir = self.propag_direction
-        diffract_factor = 1. + 1j * prop_dir * ( z - self.zf ) * self.inv_zr
+        alpha = prop_dir * (z - self.zf) * self.inv_zr
+        diffract_factor = 1. + 1j * alpha
         w = self.w0 * abs( diffract_factor )
         psi = np.angle( diffract_factor )
         # Calculate the scaled radius and azimuthal angle
@@ -560,8 +573,13 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
         exp_argument = 1j*self.k0*( prop_dir*(z - self.z0) - c*t ) \
             - 1j*self.cep_phase - 1.j*self.m*theta \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t )**2 \
-            + 1.j*(2*self.p + abs(self.m))*psi # *Additional* Gouy phase
+            - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t \
+                # The last term below corresponds to the curvature of the
+                # envelope ; see Phys. Rev. E 59, 1082 (1999), appendix B.2
+                - alpha*(1-alpha**2)*(x**2+y**2) \
+                /(self.k0*self.w0**2*(1+alpha**2)**2) )**2 \
+            + 1.j*(2*self.p + abs(self.m))*psi # Additional Gouy phase
+
         # Get the transverse profile
         profile = np.exp(exp_argument) / diffract_factor \
             * scaled_radius**abs(self.m) \

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -215,20 +215,14 @@ class GaussianLaser( LaserProfile ):
 
         # Diffraction and stretch_factor
         prop_dir = self.propag_direction
-        alpha = prop_dir * (z - self.zf) * self.inv_zr
-        diffract_factor = 1. + 1j * alpha
+        diffract_factor = 1. + 1j * prop_dir*(z - self.zf) * self.inv_zr
         stretch_factor = 1 - 2j * self.phi2_chirp * c**2 * self.inv_ctau2
         # Calculate the argument of the complex exponential
         exp_argument = - 1j*self.cep_phase \
             + 1j*self.k0*( prop_dir*(z - self.z0) - c*t ) \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - 1./stretch_factor*self.inv_ctau2 * (
-                    prop_dir*(z - self.z0) - c*t \
-                    # The last term below corresponds to the curvature of the
-                    # envelope ; see Phys. Rev. E 59, 1082 (1999), appendix B.2
-                    - alpha*(1-alpha**2)*(x**2+y**2) \
-                    /(self.k0*self.w0**2*(1+alpha**2)**2) )**2
-
+            - 1./stretch_factor*self.inv_ctau2 * \
+                                    ( prop_dir*(z - self.z0) - c*t )**2
         # Get the transverse profile
         profile = np.exp(exp_argument) /(diffract_factor * stretch_factor**0.5)
 
@@ -395,8 +389,7 @@ class LaguerreGaussLaser( LaserProfile ):
         """
         # Diffraction factor, waist and Gouy phase
         prop_dir = self.propag_direction
-        alpha = prop_dir * (z - self.zf) * self.inv_zr
-        diffract_factor = 1. + 1j * alpha
+        diffract_factor = 1. + 1j * prop_dir * (z - self.zf) * self.inv_zr
         w = self.w0 * abs( diffract_factor )
         psi = np.angle( diffract_factor )
         # Calculate the scaled radius and azimuthal angle
@@ -407,13 +400,8 @@ class LaguerreGaussLaser( LaserProfile ):
         exp_argument = - 1j*self.cep_phase \
             + 1j*self.k0*( prop_dir*(z - self.z0) - c*t ) \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t \
-                # The term below corresponds to the curvature of the
-                # envelope ; see Phys. Rev. E 59, 1082 (1999), appendix B.2
-                + alpha*(x**2+y**2) \
-                /(self.k0*self.w0**2*(1+alpha**2)**2) )**2 \
-            - 1.j*(2*self.p + self.m)*psi # Additional Gouy phase
-
+            - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t )**2 \
+            - 1.j*(2*self.p + self.m)*psi # *Additional* Gouy phase
         # Get the transverse profile
         profile = np.exp(exp_argument) / diffract_factor \
             * scaled_radius**self.m * self.laguerre_pm(scaled_radius_squared) \
@@ -561,8 +549,7 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
         """
         # Diffraction factor, waist and Gouy phase
         prop_dir = self.propag_direction
-        alpha = prop_dir * (z - self.zf) * self.inv_zr
-        diffract_factor = 1. + 1j * alpha
+        diffract_factor = 1. + 1j * prop_dir * ( z - self.zf ) * self.inv_zr
         w = self.w0 * abs( diffract_factor )
         psi = np.angle( diffract_factor )
         # Calculate the scaled radius and azimuthal angle
@@ -573,13 +560,8 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
         exp_argument = 1j*self.k0*( prop_dir*(z - self.z0) - c*t ) \
             - 1j*self.cep_phase - 1.j*self.m*theta \
             - (x**2 + y**2) / (self.w0**2 * diffract_factor) \
-            - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t \
-                # The last term below corresponds to the curvature of the
-                # envelope ; see Phys. Rev. E 59, 1082 (1999), appendix B.2
-                - alpha*(1-alpha**2)*(x**2+y**2) \
-                /(self.k0*self.w0**2*(1+alpha**2)**2) )**2 \
-            + 1.j*(2*self.p + abs(self.m))*psi # Additional Gouy phase
-
+            - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t )**2 \
+            + 1.j*(2*self.p + abs(self.m))*psi # *Additional* Gouy phase
         # Get the transverse profile
         profile = np.exp(exp_argument) / diffract_factor \
             * scaled_radius**abs(self.m) \

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -719,12 +719,84 @@ class FewCycleLaser( LaserProfile ):
     def __init__( self, a0, waist, tau_fwhm, z0, zf=None, theta_pol=0.,
                     lambda0=0.8e-6, cep_phase=0., propagation_direction=1 ):
         """
-        TODO:
-        - Explain why Gaussian laser is not well adapted: static field +
-          does not focus to a tight spot (esp. due to curve-front curvature)
-        - Give reference for this profile
-        - Say that this tends to a Gaussian laser in the limit of large waist, long duration
-        - Implementation is largely inspired by N. Zaim's implementation in Warp
+        When a laser pulse is so short that it contains **only a few laser cycles**,
+        the standard Gaussian profile :any:`GaussianLaser` is not well-adapted.
+        This is because :any:`GaussianLaser` neglects the fact that different
+        frequencies focus in different ways. In particular, when initializing
+        a :any:`GaussianLaser` (with a short duration :math:`\\tau`) out of
+        focus, the profile at focus will not be the expected one.
+
+        Instead, the :any:`FewCycleLaser` profile overcomes this limitation.
+        The electric field for this profile is given by (see
+        `Caron & Potvilege, Journal of Modern Optics 46, 1881 (1999)
+        <https://www.tandfonline.com/doi/abs/10.1080/09500349908231378>`__):
+
+        .. math::
+
+            E(\\boldsymbol{x},t) = Re\\left[ a_0\\times E_0\,
+            e^{i\phi_{cep}} \\frac{i Z_R}{q(z)}
+            \\left( 1 + \\frac{ik_0}{s}\\left(z-z_0-ct+
+            \\frac{r^2}{2q(z)}\\right)\\right)^{-(s+1)} \\right]
+
+        where :math:`k_0 = 2\pi/\\lambda_0` is the wavevector,
+        :math:`E_0 = m_e c^2 k_0 / q_e` is the field amplitude for :math:`a_0=1`,
+        :math:`Z_R = k_0 w_0^2/2` is the Rayleigh length,
+        :math:`q(z) = z-z_f + iZ_R`, and where :math:`s`
+        controls the duration of the pulse and is given by:
+
+        .. math::
+
+            \omega_0 \\tau_{WFHM} = s\\sqrt{2(4^{1/(s+1)}-1)}
+
+        .. note::
+
+            In the case of :math:`\omega_0 \\tau_{WFHM} \gg 1` (i.e. many
+            laser cycles within the envelope), the above expression approaches
+            that of a standard Gaussian laser pulse, and thus the :any:`FewCycleLaser`
+            profile becomes equivalent to the :any:`GaussianLaser` profile
+            (with :math:`\\tau_{FWHM} = \\sqrt{2\\log(2)}\\tau`).
+
+        Parameters
+        ----------
+
+        a0: float (dimensionless)
+            The peak normalized vector potential at the focal plane, defined
+            as :math:`a_0` in the above formula.
+
+        waist: float (in meter)
+            Laser waist at the focal plane, defined as :math:`w_0` in the
+            above formula.
+
+        tau_FWHM: float (in second)
+            The full-width half-maximum duration of the **envelope intensity** (in
+            the lab frame), defined as :math:`\\tau_{FWHM}` in the above formula.
+
+        z0: float (in meter)
+            The initial position of the centroid of the laser
+            (in the lab frame), defined as :math:`z_0` in the above formula.
+
+        zf: float (in meter), optional
+            The position of the focal plane (in the lab frame).
+            If ``zf`` is not provided, the code assumes that ``zf=z0``, i.e.
+            that the laser pulse is at the focal plane initially.
+
+        theta_pol: float (in radian), optional
+           The angle of polarization with respect to the x axis.
+
+        lambda0: float (in meter), optional
+            The wavelength of the laser (in the lab frame), defined as
+            :math:`\\lambda_0` in the above formula.
+            Default: 0.8 microns (Ti:Sapph laser).
+
+        cep_phase: float (in radian), optional
+            The Carrier Enveloppe Phase (CEP), defined as :math:`\phi_{cep}`
+            in the above formula (i.e. the phase of the laser
+            oscillation, at the position where the laser enveloppe is maximum)
+
+        propagation_direction: int, optional
+            Indicates in which direction the laser propagates.
+            This should be either 1 (laser propagates towards positive z)
+            or -1 (laser propagates towards negative z).
         """
         # Initialize propagation direction
         LaserProfile.__init__(self, propagation_direction)
@@ -752,7 +824,7 @@ class FewCycleLaser( LaserProfile ):
         from scipy.optimize import fsolve
         w_tau = c*k0*tau_fwhm
         sol = fsolve(lambda s: s*(2*(4**(1/(s+1))-1))**.5 - w_tau, 1.)
-        self.s_Poisson = sol[0]
+        self.s = sol[0]
 
     def E_field( self, x, y, z, t ):
         """
@@ -761,12 +833,12 @@ class FewCycleLaser( LaserProfile ):
         prop_dir = self.propag_direction
         inv_q = 1./( prop_dir * (z - self.zf) + 1.j*self.zr )
         # Calculate the argument inside the power function
-        argument = 1. + 1.j*self.k0/self.s_Poisson*(
+        argument = 1. + 1.j*self.k0/self.s*(
             prop_dir*(z - self.z0) - c*t + 0.5*(x**2 + y**2)*inv_q )
 
         # Get the transverse profile
         profile = np.exp(1.j*self.cep_phase) * 1.j*self.zr*inv_q * \
-                    argument**(-self.s_Poisson-1)
+                    argument**(-self.s-1)
 
         # Get the projection along x and y, with the correct polarization
         Ex = self.E0x * profile

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -410,7 +410,7 @@ class LaguerreGaussLaser( LaserProfile ):
             - self.inv_ctau2 * ( prop_dir*(z - self.z0) - c*t \
                 # The term below corresponds to the curvature of the
                 # envelope ; see Phys. Rev. E 59, 1082 (1999), appendix B.2
-                - alpha*(1-alpha**2)*(x**2+y**2) \
+                + alpha*(x**2+y**2) \
                 /(self.k0*self.w0**2*(1+alpha**2)**2) )**2 \
             - 1.j*(2*self.p + self.m)*psi # Additional Gouy phase
 

--- a/tests/test_fewcycle_laser.py
+++ b/tests/test_fewcycle_laser.py
@@ -1,0 +1,129 @@
+# Copyright 2019, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This test file is part of FB-PIC (Fourier-Bessel Particle-In-Cell).
+
+It tests the few-cycle laser profile, by initializing a laser pulse
+out of focus, letting propagate to the focus, and checking that the
+fields at focus are the expected ones.
+
+Usage :
+-------
+In order to show the profile out of focus, and then at focus:
+$ python tests/test_fewcycle_laser.py
+(except when setting show to False in the parameters below)
+
+In order to let Python check the agreement automatically
+$ py.test -q tests/test_fewcycle_laser.py
+or
+$ python setup.py test
+"""
+import numpy as np
+from scipy.constants import c
+from fbpic.main import Simulation
+from fbpic.lpa_utils.laser import add_laser_pulse, FewCycleLaser
+
+# Parameters
+# ----------
+
+show = True  # Whether to show the plots, and check them manually
+
+use_cuda = True
+
+# The simulation box
+Nz = 200         # Number of gridpoints along z
+zmax = 5.e-6     # Right end of the simulation box (meters)
+zmin = -5.e-6    # Left end of the simulation box (meters)
+Nr = 200         # Number of gridpoints along r
+rmax = 17.e-6    # Length of the box along r (meters)
+Nm = 2           # Number of modes used
+# The laser
+a0 = 4.           # Laser amplitude
+w0 = 1.5e-6       # Laser waist
+tau_fwhm = 3.e-15 # Laser duration
+z0 = 0.e-6        # Laser centroid
+zfoc = 30e-6
+
+# Checking the results
+rtol = 5.e-2
+
+def compare_fields( grid, t, profile, show ):
+    """
+    Compare the Er field in `grid` to the theoretical fields given
+    by `profile`.
+
+    Parameters
+    ----------
+    grid: an InterpolationGrid object
+        Contains the simulated fields
+    t: float
+        Time at which to calculate the fields given by `profile`
+    profile: a LaserProfile object
+        Has the method `E_field` that allows to calculate the theoretical profile
+    show: bool
+        Whether to show the fields with matplotlib
+    """
+    # matplotlib only needs to be imported if this function is called
+    import matplotlib.pyplot as plt
+
+    # Select the field to plot
+    Er = 2*getattr( grid, 'Er' ).real
+    # Factor 2 comes from definition of field in FBPIC
+    # Calculate the theoretical profile
+    z, r = np.meshgrid( grid.z, grid.r, indexing='ij' )
+    Er_th, _ = profile.E_field( r, 0, z + c*t, t )
+
+    if show:
+        # Show the field also below the axis for a more realistic picture
+        extent = 1.e6*np.array([grid.zmin, grid.zmax, -grid.rmax, grid.rmax])
+
+        # Plot the real part
+        plt.subplot(121)
+        plt.imshow( np.hstack( (Er[:,::-1],Er) ).T, aspect='auto',
+                    interpolation='nearest', extent=extent, cmap='RdBu' )
+        plt.xlabel('z')
+        plt.ylabel('r')
+        plt.colorbar()
+        plt.title('Simulation')
+
+        plt.subplot(122)
+        plt.imshow( np.hstack( (Er_th[:,::-1],Er_th) ).T, aspect='auto',
+                    interpolation='nearest', extent=extent, cmap='RdBu' )
+        plt.xlabel('z')
+        plt.ylabel('r')
+        plt.colorbar()
+        plt.title('Theoretical')
+
+        plt.tight_layout()
+        plt.show()
+
+    # Check that the fields agree to the required precision
+    assert np.allclose( Er, Er_th, atol=rtol*Er_th.max() )
+
+
+def test_laser_periodic(show=False):
+    """
+    Function that is run by py.test, when doing `python setup.py test`
+    Test the propagation of a laser in a periodic box.
+    """
+    # Propagate the pulse in a single step
+    dt = zfoc*1./c
+
+    # Initialize the simulation object
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
+                      zmin=zmin, boundaries='periodic' )
+
+    # Initialize the laser fields
+    profile = FewCycleLaser(a0=a0, waist=w0, tau_fwhm=tau_fwhm, z0=0, zf=zfoc)
+    add_laser_pulse( sim, profile )
+
+    # Propagate the pulse
+    compare_fields(sim.fld.interp[1], sim.time, profile, show)
+    sim.step(1)
+    compare_fields(sim.fld.interp[1], sim.time, profile, show)
+
+if __name__ == '__main__' :
+
+    # Run the testing function
+    test_laser_periodic(show=show)

--- a/tests/test_fewcycle_laser.py
+++ b/tests/test_fewcycle_laser.py
@@ -64,9 +64,6 @@ def compare_fields( grid, t, profile, show ):
     show: bool
         Whether to show the fields with matplotlib
     """
-    # matplotlib only needs to be imported if this function is called
-    import matplotlib.pyplot as plt
-
     # Select the field to plot
     Er = 2*getattr( grid, 'Er' ).real
     # Factor 2 comes from definition of field in FBPIC
@@ -75,6 +72,8 @@ def compare_fields( grid, t, profile, show ):
     Er_th, _ = profile.E_field( r, 0, z + c*t, t )
 
     if show:
+        import matplotlib.pyplot as plt
+
         # Show the field also below the axis for a more realistic picture
         extent = 1.e6*np.array([grid.zmin, grid.zmax, -grid.rmax, grid.rmax])
 


### PR DESCRIPTION
When a laser pulse is so short that it contains **only a few laser cycles**, the standard Gaussian profile `GaussianLaser` is not well-adapted, as it does properly take into account spatial-temporal correlations for tightly-focussed pulses. In particular, when initializing a `GaussianLaser` with a short duration **out of focus** in FBPIC, the later profile **at focus** will not be the expected one.

This can be fixed by using the new `FewCycleLaser` introduced by this PR. I also added an automated test that checks that this laser has the proper profile after propagation to focus.

Here is how this pulse looks like:

- out of focus, at the beginning of the test:
![FewCycle_before_focus](https://user-images.githubusercontent.com/6685781/69008102-699e0a80-08fb-11ea-9a98-9efbc530133e.png)
- at focus, at the end of the test:
![Fewcycle_at_focus](https://user-images.githubusercontent.com/6685781/69008111-7f133480-08fb-11ea-916f-6a5f3aed8ee0.png)

By contrast, here is how `GaussianLaser` looks like after propagation to focus, using the same parameters (waist, propagation distance, etc.) as in the above test:
![Gaussian_at_focus](https://user-images.githubusercontent.com/6685781/69008120-9a7e3f80-08fb-11ea-8664-c6d73b871144.png)


PS: This PR is the result of discussions with Julius Huijts (LOA), based on earlier work by Neil Zaim (LOA). Many thanks to both of them!