### PR TITLE
Prepare PML split field structures

### DIFF
--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -169,6 +169,11 @@ class MovingWindow(object):
             shift_spect_array_gpu[tpb, bpg]( grid.Bp, shift, n_move )
             shift_spect_array_gpu[tpb, bpg]( grid.Bm, shift, n_move )
             shift_spect_array_gpu[tpb, bpg]( grid.Bz, shift, n_move )
+            if grid.use_pml:
+                shift_spect_array_gpu[tpb, bpg]( grid.Ep_pml, shift, n_move )
+                shift_spect_array_gpu[tpb, bpg]( grid.Em_pml, shift, n_move )
+                shift_spect_array_gpu[tpb, bpg]( grid.Bp_pml, shift, n_move )
+                shift_spect_array_gpu[tpb, bpg]( grid.Bm_pml, shift, n_move )
             if shift_rho:
                 shift_spect_array_gpu[tpb, bpg]( grid.rho_prev, shift, n_move )
             if shift_currents:
@@ -184,6 +189,11 @@ class MovingWindow(object):
             shift_spect_array_cpu( grid.Bp, shift, n_move )
             shift_spect_array_cpu( grid.Bm, shift, n_move )
             shift_spect_array_cpu( grid.Bz, shift, n_move )
+            if grid.use_pml:
+                shift_spect_array_cpu( grid.Ep_pml, shift, n_move )
+                shift_spect_array_cpu( grid.Em_pml, shift, n_move )
+                shift_spect_array_cpu( grid.Bp_pml, shift, n_move )
+                shift_spect_array_cpu( grid.Bm_pml, shift, n_move )
             if shift_rho:
                 shift_spect_array_cpu( grid.rho_prev, shift, n_move )
             if shift_currents:

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -48,7 +48,7 @@ class Fields(object) :
         Contains the coefficients to solve the Maxwell equations
     """
     def __init__( self, Nz, zmax, Nr, rmax, Nm, dt, zmin=0.,
-                  n_order=-1, v_comoving=None, use_galilean=True,
+                  n_order=-1, v_comoving=None, use_pml=False, use_galilean=True,
                   current_correction='cross-deposition', use_cuda=False,
                   smoother=None, create_threading_buffers=False ):
         """
@@ -83,6 +83,9 @@ class Fields(object) :
             This can be done in two ways: either by
             - Using a PSATD scheme that takes this hypothesis into account
             - Solving the PSATD scheme in a Galilean frame
+
+        use_pml: bool, optional
+            Whether to allocate and use Perfectly-Matched-Layers split fields
 
         use_galilean: bool, optional
             Determines which one of the two above schemes is used
@@ -154,7 +157,8 @@ class Fields(object) :
         for m in range(Nm) :
             # Create the object
             self.interp.append( InterpolationGrid(
-                Nz, Nr, m, zmin, zmax, rmax, use_cuda=self.use_cuda ) )
+                Nz, Nr, m, zmin, zmax, rmax,
+                use_pml=use_pml, use_cuda=self.use_cuda ) )
 
         # Get the kz and (finite-order) modified kz arrays
         # (According to FFT conventions, the kz array starts with
@@ -174,7 +178,8 @@ class Fields(object) :
             # Create the object
             self.spect.append( SpectralGrid( kz_modified, kr, m,
                 kz_true, self.interp[m].dz, self.interp[m].dr,
-                current_correction, smoother, use_cuda=self.use_cuda ) )
+                current_correction, smoother, use_pml=use_pml,
+                use_cuda=self.use_cuda ) )
             self.psatd.append( PsatdCoeffs( self.spect[m].kz,
                                 self.spect[m].kr, m, dt, Nz, Nr,
                                 V=self.v_comoving,
@@ -302,7 +307,7 @@ class Fields(object) :
         ---------
         fieldtype :
             A string which represents the kind of field to transform
-            (either 'E', 'B', 'J', 'rho_next', 'rho_prev')
+            (either 'E', 'B', 'E_pml', 'B_pml', 'J', 'rho_next', 'rho_prev')
         """
         # Use the appropriate transformation depending on the fieldtype.
         if fieldtype == 'E' :
@@ -321,6 +326,18 @@ class Fields(object) :
                 self.trans[m].interp2spect_vect(
                     self.interp[m].Br, self.interp[m].Bt,
                     self.spect[m].Bp, self.spect[m].Bm )
+        elif fieldtype == 'E_pml':
+            # Transform each azimuthal grid individually
+            for m in range(self.Nm):
+                self.trans[m].interp2spect_vect(
+                    self.interp[m].Er_pml, self.interp[m].Et_pml,
+                    self.spect[m].Ep_pml, self.spect[m].Em_pml )
+        elif fieldtype == 'B_pml':
+            # Transform each azimuthal grid individually
+            for m in range(self.Nm):
+                self.trans[m].interp2spect_vect(
+                    self.interp[m].Br_pml, self.interp[m].Bt_pml,
+                    self.spect[m].Bp_pml, self.spect[m].Bm_pml )
         elif fieldtype == 'J' :
             # Transform each azimuthal grid individually
             for m in range(self.Nm) :
@@ -347,7 +364,7 @@ class Fields(object) :
         ---------
         fieldtype :
             A string which represents the kind of field to transform
-            (either 'E', 'B', 'J', 'rho_next', 'rho_prev')
+            (either 'E', 'B', 'E_pml', 'B_pml', 'J', 'rho_next', 'rho_prev')
         """
         # Use the appropriate transformation depending on the fieldtype.
         if fieldtype == 'E' :
@@ -366,6 +383,18 @@ class Fields(object) :
                 self.trans[m].spect2interp_vect(
                     self.spect[m].Bp, self.spect[m].Bm,
                     self.interp[m].Br, self.interp[m].Bt )
+        elif fieldtype == 'E_pml':
+            # Transform each azimuthal grid individually
+            for m in range(self.Nm) :
+                self.trans[m].spect2interp_vect(
+                    self.spect[m].Ep_pml,  self.spect[m].Em_pml,
+                    self.interp[m].Er_pml, self.interp[m].Et_pml )
+        elif fieldtype == 'B_pml':
+            # Transform each azimuthal grid individually
+            for m in range(self.Nm) :
+                self.trans[m].spect2interp_vect(
+                    self.spect[m].Bp_pml,  self.spect[m].Bm_pml,
+                    self.interp[m].Br_pml, self.interp[m].Bt_pml )
         elif fieldtype == 'J' :
             # Transform each azimuthal grid individually
             for m in range(self.Nm) :

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -236,6 +236,9 @@ class Simulation(object):
         if v_comoving is None:
             self.use_galilean = False
 
+        # Check whether the pml should be used
+        self.use_pml = (r_boundary == "open")
+
         # When running the simulation in a boosted frame, convert the arguments
         if gamma_boost is not None:
             self.boost = BoostConverter( gamma_boost )
@@ -257,6 +260,7 @@ class Simulation(object):
         self.fld = Fields( Nz, zmax, Nr, rmax, Nm, dt,
                     n_order=n_order, zmin=zmin,
                     v_comoving=v_comoving,
+                    use_pml=self.use_pml,
                     use_galilean=use_galilean,
                     current_correction=current_correction,
                     use_cuda=self.use_cuda,


### PR DESCRIPTION
## Background info

When using PML, the fields are *split* (each split component is pushed with a different part of the curl term in the Maxwell equation, and only one of the two component is damped in PML cells while the other one is undamped).

In FBPIC, we will represent this as:
- `Er_pml`, `Et_pml` (in interpolation space) and `Ep_pml`, `Em_pml` (in spectral space): represent the split component which **is** damped.
- The pre-existing`Er`, `Et` (in interpolation space) and `Ep`, `Em` (in spectral space): represent the **sum** of the two split component (damped and undamped).

Choosing to store the *damped* component and the *sum* of the split components is equivalent to storing  the *damped* and *undamped* components  (since we can go from representation to the other by adding/substracting the damped component). However, storing the *sum* directly is less disruptive for the rest of the code. In particular, when we run without PML, we can simply not allocate the damped component (`E_pml`) and continue using the regular fields (`E`) without further changes to the code.

Note that the `Ez` field does not need to be split here (i.e. there is no `Ez_pml). This is because the PML are only applied radially in FBPIC. 

Note also that, in a finite-difference code, the damped component would only need to be allocated in the PML cells (`nr_damp` cells). However, because of the spectral nature of FBPIC and the global nature of the Hankel transform, here we allocate the PML field over the whole grid (physical cells + PML cells).

## What this PR does

This PR prepares the field structures for the split, damped component. In particular:
- Allocation of these fields
- Definition of trivial functions:
    * Shift of these fields under the moving window
    * Copy/to from GPU
    * Spectral to interpolation function

**This PR does NOT use the PML damped component at this point .** It simply prepares the structures for the next PR.