### PR TITLE
Implement MPI exchanges for PML

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -238,6 +238,9 @@ class BoundaryCommunicator(object):
         # For reflective radial boundary, no need for damping cell
         if r_boundary=='reflective':
             self.nr_damp = 0
+            self.use_pml = False
+        else:
+            self.use_pml = True
 
         # Initialize the period of the particle exchange and moving window
         if exchange_period is None:
@@ -273,7 +276,7 @@ class BoundaryCommunicator(object):
         if self.size > 1:
             Nr_with_damp = self.get_Nr( with_damp=True )
             self.mpi_buffers = BufferHandler( self.n_guard, Nr_with_damp, Nm,
-                                      self.left_proc, self.right_proc )
+                               self.left_proc, self.right_proc, self.use_pml )
 
         # Create damping arrays for the damping cells at the left
         # and right of the box in the case of "open" boundaries.
@@ -509,9 +512,9 @@ class BoundaryCommunicator(object):
         self.moving_win.move_grids(fld, ptcl, self, time)
 
 
-    def exchange_fields( self, interp, fieldtype, method ):
+    def exchange_fields( self, interp, fldtype, method ):
         """
-        Send and receive the proper fields, depending on fieldtype
+        Send and receive the proper fields, depending on `fldtype`
         Copy/add them consistently to the local grid.
 
         Depending on whether the field data is initially on the CPU
@@ -548,7 +551,7 @@ class BoundaryCommunicator(object):
             A list of InterpolationGrid objects
             (one element per azimuthal mode)
 
-        fieldtype: str
+        fldtype: str
             An identifier for the field to send
             (Either 'E', 'B', 'J' or 'rho')
 
@@ -562,24 +565,31 @@ class BoundaryCommunicator(object):
 
         # Build the string `exchange_type`:
         # This is either 'E:replace', 'B:replace', 'J:add', or 'rho:add'
-        exchange_type = ':'.join([ fieldtype, method ])
+        exchange_type = ':'.join([ fldtype, method ])
 
         # Shortcut
         Nm = self.Nm
         use_cuda = interp[0].use_cuda
 
         # Fill the sending buffers with data from the interpolation grid
-        if fieldtype in ('E', 'B', 'J'):
+        if fldtype in ('E', 'B', 'J'):
             # Vector field
-            grid_r = [ getattr(interp[m], fieldtype+'r') for m in range(Nm) ]
-            grid_t = [ getattr(interp[m], fieldtype+'t') for m in range(Nm) ]
-            grid_z = [ getattr(interp[m], fieldtype+'z') for m in range(Nm) ]
-            self.mpi_buffers.handle_vec_buffer(
-                    grid_r, grid_t, grid_z, method, exchange_type, use_cuda,
+            grid_r = [ getattr(interp[m], fldtype+'r') for m in range(Nm) ]
+            grid_t = [ getattr(interp[m], fldtype+'t') for m in range(Nm) ]
+            grid_z = [ getattr(interp[m], fldtype+'z') for m in range(Nm) ]
+            # Handle PML fields
+            if fldtype in ('E', 'B') and self.use_pml:
+                pml_r = [getattr(interp[m], fldtype+'r_pml') for m in range(Nm)]
+                pml_t = [getattr(interp[m], fldtype+'t_pml') for m in range(Nm)]
+            else:
+                pml_r = None
+                pml_t = None
+            self.mpi_buffers.handle_vec_buffer( grid_r, grid_t, grid_z,
+                    pml_r, pml_t, method, exchange_type, use_cuda,
                     before_sending=True, gpudirect=gpudirect_enabled )
         else:
             # Scalar field
-            grid = [ getattr(interp[m], fieldtype) for m in range(Nm) ]
+            grid = [ getattr(interp[m], fldtype) for m in range(Nm) ]
             self.mpi_buffers.handle_scal_buffer(
                     grid, method, exchange_type, use_cuda,
                     before_sending=True, gpudirect=gpudirect_enabled )
@@ -611,10 +621,11 @@ class BoundaryCommunicator(object):
         self.exchange_domains( send_l, send_r, recv_l, recv_r )
 
         # Copy/Add the received buffers to the interpolation grid
-        if fieldtype in ('E', 'B', 'J'):
+        if fldtype in ('E', 'B', 'J'):
             # Vector field
             self.mpi_buffers.handle_vec_buffer(
-                    grid_r, grid_t, grid_z, method, exchange_type, use_cuda,
+                    grid_r, grid_t, grid_z, pml_r, pml_t,
+                    method, exchange_type, use_cuda,
                     after_receiving=True, gpudirect=gpudirect_enabled )
         else:
             # Scalar field

--- a/fbpic/boundaries/cuda_methods.py
+++ b/fbpic/boundaries/cuda_methods.py
@@ -268,9 +268,9 @@ def replace_pml_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
         Arrays of shape (Nz, Nr), which contain the different component
         of the vector field (r, t, z), in the mode m
 
-    grid_r, grid_t, grid_z: ndarrays of complexs (device arrays)
-        Arrays of shape (Nz, Nr), which contain the different component
-        of the vector field (r, t, z), in the mode m
+    pml_r, pml_t: ndarrays of complexs (device arrays)
+        Arrays of shape (Nz, Nr), which contain the PML component
+        of the vector field in the mode m
 
     m: int
         The index of the azimuthal mode involved
@@ -314,7 +314,7 @@ def replace_pml_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 grid_t[ iz_right, ir ] = vec_buffer_r[5*m+1, iz, ir]
                 grid_z[ iz_right, ir ] = vec_buffer_r[5*m+2, iz, ir]
                 pml_r[ iz_right, ir ] = vec_buffer_r[5*m+3, iz, ir]
-                pml_t[ iz_right, ir ] = vec_buffer_r[5*m+4, iz, ir]                
+                pml_t[ iz_right, ir ] = vec_buffer_r[5*m+4, iz, ir]
 
 @cuda.jit
 def replace_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,

--- a/fbpic/boundaries/cuda_methods.py
+++ b/fbpic/boundaries/cuda_methods.py
@@ -69,6 +69,75 @@ def copy_vec_to_gpu_buffer( vec_buffer_l, vec_buffer_r,
 
 
 @cuda.jit
+def copy_pml_to_gpu_buffer( vec_buffer_l, vec_buffer_r,
+                            grid_r, grid_t, grid_z, pml_r, pml_t, m,
+                            copy_left, copy_right, nz_start, nz_end ):
+    """
+    Copy the ng inner domain cells of grid_r, grid_t, grid_z, pml_r, pml_t
+    to the GPU buffer vec_buffer_l and vec_buffer_r.
+
+    Parameters
+    ----------
+    vec_buffer_l, vec_buffer_r: ndarrays of complexs (device arrays)
+        Arrays of shape (5*Nm, nz_end-nz_start, Nr), which serve as buffer
+        for transmission to CPU, and then sending via MPI. They hold the
+        values of a vector field in either the ng inner cells of the domain
+        or the ng outer + ng inner cells of the domain, to the left and right.
+
+    grid_r, grid_t, grid_z: ndarrays of complexs (device arrays)
+        Arrays of shape (Nz, Nr), which contain the different component
+        of the vector field (r, t, z), in the mode m
+
+    pml_r, pml_t: ndarrays of complexs (device arrays)
+        Arrays of shape (Nz, Nr), which contain the PML component
+        of the vector field in the mode m
+
+    m: int
+        The index of the azimuthal mode involved
+
+    copy_left, copy_right: bool
+        Whether to copy the buffers to the left and right of the local domain
+        (Buffers are not copied at the left end and right end of the
+        global simulation box.)
+
+    nz_start: int
+        The start index in z, of the cell region which is copied to the
+        buffers. The start is defined as an offset from the most outer cell
+        on either the left or the right side of the enlarged domain.
+
+    nz_end: int
+        The end index in z, of the cell region which is copied to the
+        buffers. The end is defined as an offset from the most outer cell
+        on either the left or the right side of the enlarged domain.
+    """
+    # Dimension of the arrays
+    Nz, Nr = grid_r.shape
+
+    # Obtain Cuda grid
+    iz, ir = cuda.grid(2)
+
+    # Copy the inner regions of the domain to the buffer
+    if ir < Nr:
+        if iz < (nz_end - nz_start):
+            # At the left end
+            if copy_left:
+                iz_left = nz_start + iz
+                vec_buffer_l[5*m+0, iz, ir] = grid_r[ iz_left, ir ]
+                vec_buffer_l[5*m+1, iz, ir] = grid_t[ iz_left, ir ]
+                vec_buffer_l[5*m+2, iz, ir] = grid_z[ iz_left, ir ]
+                vec_buffer_l[5*m+3, iz, ir] = pml_r[ iz_left, ir ]
+                vec_buffer_l[5*m+4, iz, ir] = pml_t[ iz_left, ir ]
+            # At the right end
+            if copy_right:
+                iz_right = Nz - nz_end + iz
+                vec_buffer_r[5*m+0, iz, ir] = grid_r[ iz_right, ir ]
+                vec_buffer_r[5*m+1, iz, ir] = grid_t[ iz_right, ir ]
+                vec_buffer_r[5*m+2, iz, ir] = grid_z[ iz_right, ir ]
+                vec_buffer_r[5*m+3, iz, ir] = pml_r[ iz_right, ir ]
+                vec_buffer_r[5*m+4, iz, ir] = pml_t[ iz_right, ir ]
+
+
+@cuda.jit
 def copy_scal_to_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                              copy_left, copy_right, nz_start, nz_end ):
     """
@@ -180,6 +249,72 @@ def replace_vec_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 grid_r[ iz_right, ir ] = vec_buffer_r[3*m+0, iz, ir]
                 grid_t[ iz_right, ir ] = vec_buffer_r[3*m+1, iz, ir]
                 grid_z[ iz_right, ir ] = vec_buffer_r[3*m+2, iz, ir]
+
+@cuda.jit
+def replace_pml_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
+                                 grid_r, grid_t, grid_z, pml_r, pml_t, m,
+                                 copy_left, copy_right, nz_start, nz_end ):
+    """
+    Replace a region (guard region) of grid_0_r, ..., grid_1_z
+    by the GPU buffer vec_buffer_l and vec_buffer_r.
+
+    Parameters
+    ----------
+    vec_buffer_l, vec_buffer_r: ndarrays of complexs (device arrays)
+        Arrays of shape (5*Nm, nz_end-nz_start, Nr), which are the buffers
+        sent via MPI and received by the CPU.
+
+    grid_r, grid_t, grid_z: ndarrays of complexs (device arrays)
+        Arrays of shape (Nz, Nr), which contain the different component
+        of the vector field (r, t, z), in the mode m
+
+    grid_r, grid_t, grid_z: ndarrays of complexs (device arrays)
+        Arrays of shape (Nz, Nr), which contain the different component
+        of the vector field (r, t, z), in the mode m
+
+    m: int
+        The index of the azimuthal mode involved
+
+    copy_left, copy_right: bool
+        Whether to copy the buffers to the left and right of the local domain
+        (Buffers are not copied at the left end and right end of the
+        global simulation box.)
+
+    nz_start: int
+        The start index in z, of the cell region which is copied to the
+        buffers. The start is defined as an offset from the most outer cell
+        on either the left or the right side of the enlarged domain.
+
+    nz_end: int
+        The end index in z, of the cell region which is copied to the
+        buffers. The end is defined as an offset from the most outer cell
+        on either the left or the right side of the enlarged domain.
+    """
+    # Dimension of the arrays
+    Nz, Nr = grid_r.shape
+
+    # Obtain Cuda grid
+    iz, ir = cuda.grid(2)
+
+    # Copy the inner regions of the domain to the buffer
+    if ir < Nr:
+        if iz < (nz_end - nz_start):
+            # At the left end
+            if copy_left:
+                iz_left = iz
+                grid_r[ iz_left, ir ] = vec_buffer_l[5*m+0, iz, ir]
+                grid_t[ iz_left, ir ] = vec_buffer_l[5*m+1, iz, ir]
+                grid_z[ iz_left, ir ] = vec_buffer_l[5*m+2, iz, ir]
+                pml_r[ iz_left, ir ] = vec_buffer_l[5*m+3, iz, ir]
+                pml_t[ iz_left, ir ] = vec_buffer_l[5*m+4, iz, ir]
+            # At the right end
+            if copy_right:
+                iz_right = Nz - (nz_end - nz_start) + iz
+                grid_r[ iz_right, ir ] = vec_buffer_r[5*m+0, iz, ir]
+                grid_t[ iz_right, ir ] = vec_buffer_r[5*m+1, iz, ir]
+                grid_z[ iz_right, ir ] = vec_buffer_r[5*m+2, iz, ir]
+                pml_r[ iz_right, ir ] = vec_buffer_r[5*m+3, iz, ir]
+                pml_t[ iz_right, ir ] = vec_buffer_r[5*m+4, iz, ir]                
 
 @cuda.jit
 def replace_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,

--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -16,7 +16,9 @@ if cuda_installed:
         add_vec_from_gpu_buffer, \
         copy_scal_to_gpu_buffer, \
         replace_scal_from_gpu_buffer, \
-        add_scal_from_gpu_buffer
+        add_scal_from_gpu_buffer, \
+        copy_pml_to_gpu_buffer, \
+        replace_pml_from_gpu_buffer
 
 class BufferHandler(object):
     """
@@ -24,7 +26,7 @@ class BufferHandler(object):
     between MPI domains.
     """
 
-    def __init__( self, n_guard, Nr, Nm, left_proc, right_proc ):
+    def __init__( self, n_guard, Nr, Nm, left_proc, right_proc, use_pml ):
         """
         Initialize the guard cell buffers for the fields.
         These buffers are used in order to group the MPI exchanges.
@@ -43,6 +45,9 @@ class BufferHandler(object):
         left_proc, right_proc: int or None
            Rank of the proc to the right and to the left
            (None for open boundary)
+
+        use_pml: bool
+           Whether to use PML fields
         """
         # Register parameters
         self.Nr = Nr
@@ -52,6 +57,12 @@ class BufferHandler(object):
         self.right_proc = right_proc
         # Shortcut
         ng = self.n_guard
+
+        # Get number of field components for E and B
+        if use_pml:
+            n_fld = 5 # e.g. Er, Et, Ez, Er_pml, Et_pml
+        else:
+            n_fld = 3 # e.g. Er, Et, Ez
 
         # Allocate buffer arrays that are send via MPI to exchange
         # the fields between domains (either replacing or adding fields)
@@ -67,25 +78,25 @@ class BufferHandler(object):
             alloc_cpu = np.empty
         # Allocate buffers of different size, for the different exchange types
         self.send_l = {
-            'E:replace': alloc_cpu( (3*Nm,   ng, Nr), dtype=np.complex128),
-            'B:replace': alloc_cpu( (3*Nm,   ng, Nr), dtype=np.complex128),
-            'J:add'    : alloc_cpu( (3*Nm, 2*ng, Nr), dtype=np.complex128),
-            'rho:add'  : alloc_cpu( (  Nm, 2*ng, Nr), dtype=np.complex128) }
+            'E:replace': alloc_cpu( (n_fld*Nm,   ng, Nr), dtype=np.complex128),
+            'B:replace': alloc_cpu( (n_fld*Nm,   ng, Nr), dtype=np.complex128),
+            'J:add'    : alloc_cpu( (    3*Nm, 2*ng, Nr), dtype=np.complex128),
+            'rho:add'  : alloc_cpu( (      Nm, 2*ng, Nr), dtype=np.complex128)}
         self.send_r = {
-            'E:replace': alloc_cpu( (3*Nm,   ng, Nr), dtype=np.complex128),
-            'B:replace': alloc_cpu( (3*Nm,   ng, Nr), dtype=np.complex128),
-            'J:add'    : alloc_cpu( (3*Nm, 2*ng, Nr), dtype=np.complex128),
-            'rho:add'  : alloc_cpu( (  Nm, 2*ng, Nr), dtype=np.complex128) }
+            'E:replace': alloc_cpu( (n_fld*Nm,   ng, Nr), dtype=np.complex128),
+            'B:replace': alloc_cpu( (n_fld*Nm,   ng, Nr), dtype=np.complex128),
+            'J:add'    : alloc_cpu( (    3*Nm, 2*ng, Nr), dtype=np.complex128),
+            'rho:add'  : alloc_cpu( (      Nm, 2*ng, Nr), dtype=np.complex128)}
         self.recv_l = {
-            'E:replace': alloc_cpu( (3*Nm,   ng, Nr), dtype=np.complex128),
-            'B:replace': alloc_cpu( (3*Nm,   ng, Nr), dtype=np.complex128),
-            'J:add'    : alloc_cpu( (3*Nm, 2*ng, Nr), dtype=np.complex128),
-            'rho:add'  : alloc_cpu( (  Nm, 2*ng, Nr), dtype=np.complex128) }
+            'E:replace': alloc_cpu( (n_fld*Nm,   ng, Nr), dtype=np.complex128),
+            'B:replace': alloc_cpu( (n_fld*Nm,   ng, Nr), dtype=np.complex128),
+            'J:add'    : alloc_cpu( (    3*Nm, 2*ng, Nr), dtype=np.complex128),
+            'rho:add'  : alloc_cpu( (      Nm, 2*ng, Nr), dtype=np.complex128)}
         self.recv_r = {
-            'E:replace': alloc_cpu( (3*Nm,   ng, Nr), dtype=np.complex128),
-            'B:replace': alloc_cpu( (3*Nm,   ng, Nr), dtype=np.complex128),
-            'J:add'    : alloc_cpu( (3*Nm, 2*ng, Nr), dtype=np.complex128),
-            'rho:add'  : alloc_cpu( (  Nm, 2*ng, Nr), dtype=np.complex128) }
+            'E:replace': alloc_cpu( (n_fld*Nm,   ng, Nr), dtype=np.complex128),
+            'B:replace': alloc_cpu( (n_fld*Nm,   ng, Nr), dtype=np.complex128),
+            'J:add'    : alloc_cpu( (    3*Nm, 2*ng, Nr), dtype=np.complex128),
+            'rho:add'  : alloc_cpu( (      Nm, 2*ng, Nr), dtype=np.complex128)}
 
         # Allocate buffers on the GPU, for the different exchange types
         if cuda_installed:
@@ -99,7 +110,8 @@ class BufferHandler(object):
                                 self.recv_r.items() }
 
 
-    def handle_vec_buffer(self, grid_r, grid_t, grid_z, method, exchange_type,
+    def handle_vec_buffer(self, grid_r, grid_t, grid_z,
+                            pml_r, pml_t, method, exchange_type,
                             use_cuda, before_sending=False,
                             after_receiving=False, gpudirect=False ):
         """
@@ -130,6 +142,10 @@ class BufferHandler(object):
         grid_r, grid_t, grid_z: lists of 2darrays
             (One element per azimuthal mode)
             The 2d arrays represent the fields on the interpolation grid
+
+        pml_r, pml_t: lists of 2darrays, or None
+            The 2d arrays that represent the PML components (if present)
+            on the interpolation grid
 
         method: str
             Can either be 'replace' or 'add' depending on the type
@@ -181,10 +197,20 @@ class BufferHandler(object):
             if before_sending:
                 # Copy the inner regions of the domain to the buffers
                 for m in range(self.Nm):
-                    copy_vec_to_gpu_buffer[ dim_grid_2d, dim_block_2d ](
+                    if pml_r is None:
+                        # Copy only the regular components
+                        copy_vec_to_gpu_buffer[ dim_grid_2d, dim_block_2d ](
                             self.d_send_l[exchange_type],
                             self.d_send_r[exchange_type],
                             grid_r[m], grid_t[m], grid_z[m], m,
+                            copy_left, copy_right, nz_start, nz_end )
+                    else:
+                        # Copy regular components + PML components
+                        copy_pml_to_gpu_buffer[ dim_grid_2d, dim_block_2d ](
+                            self.d_send_l[exchange_type],
+                            self.d_send_r[exchange_type],
+                            grid_r[m], grid_t[m], grid_z[m],
+                            pml_r[m], pml_t[m], m,
                             copy_left, copy_right, nz_start, nz_end )
                 # If GPUDirect with CUDA-aware MPI is not used,
                 # copy the GPU buffers to the sending CPU buffers
@@ -209,11 +235,23 @@ class BufferHandler(object):
                 if method == 'replace':
                     # Replace the guard cells of the domain with the buffers
                     for m in range(self.Nm):
-                        replace_vec_from_gpu_buffer[dim_grid_2d, dim_block_2d](
-                            self.d_recv_l[exchange_type],
-                            self.d_recv_r[exchange_type],
-                            grid_r[m], grid_t[m], grid_z[m], m,
-                            copy_left, copy_right, nz_start, nz_end )
+                        if pml_r is None:
+                            # Copy only the regular components
+                            replace_vec_from_gpu_buffer \
+                                [dim_grid_2d, dim_block_2d](
+                                self.d_recv_l[exchange_type],
+                                self.d_recv_r[exchange_type],
+                                grid_r[m], grid_t[m], grid_z[m], m,
+                                copy_left, copy_right, nz_start, nz_end )
+                        else:
+                            # Copy regular components + PML components
+                            replace_pml_from_gpu_buffer \
+                                [ dim_grid_2d, dim_block_2d ](
+                                self.d_send_l[exchange_type],
+                                self.d_send_r[exchange_type],
+                                grid_r[m], grid_t[m], grid_z[m],
+                                pml_r[m], pml_t[m], m,
+                                copy_left, copy_right, nz_start, nz_end )
                 elif method == 'add':
                     # Add the buffers to the domain
                     for m in range(self.Nm):
@@ -233,14 +271,32 @@ class BufferHandler(object):
                 # Copy the inner regions of the domain to the buffers
                 if copy_left:
                     for m in range(self.Nm):
-                        send_l[3*m+0,:,:]=grid_r[m][nz_start:nz_end,:]
-                        send_l[3*m+1,:,:]=grid_t[m][nz_start:nz_end,:]
-                        send_l[3*m+2,:,:]=grid_z[m][nz_start:nz_end,:]
+                        if pml_r is None:
+                            # Copy only the regular components
+                            send_l[3*m+0,:,:]=grid_r[m][nz_start:nz_end,:]
+                            send_l[3*m+1,:,:]=grid_t[m][nz_start:nz_end,:]
+                            send_l[3*m+2,:,:]=grid_z[m][nz_start:nz_end,:]
+                        else:
+                            # Copy regular components + PML components
+                            send_l[5*m+0,:,:]=grid_r[m][nz_start:nz_end,:]
+                            send_l[5*m+1,:,:]=grid_t[m][nz_start:nz_end,:]
+                            send_l[5*m+2,:,:]=grid_z[m][nz_start:nz_end,:]
+                            send_l[5*m+3,:,:]=pml_r[m][nz_start:nz_end,:]
+                            send_l[5*m+4,:,:]=pml_t[m][nz_start:nz_end,:]
                 if copy_right:
                     for m in range(self.Nm):
-                        send_r[3*m+0,:,:]=grid_r[m][Nz-nz_end:Nz-nz_start,:]
-                        send_r[3*m+1,:,:]=grid_t[m][Nz-nz_end:Nz-nz_start,:]
-                        send_r[3*m+2,:,:]=grid_z[m][Nz-nz_end:Nz-nz_start,:]
+                        if pml_r is None:
+                            # Copy only the regular components
+                            send_r[3*m+0,:,:]=grid_r[m][Nz-nz_end:Nz-nz_start,:]
+                            send_r[3*m+1,:,:]=grid_t[m][Nz-nz_end:Nz-nz_start,:]
+                            send_r[3*m+2,:,:]=grid_z[m][Nz-nz_end:Nz-nz_start,:]
+                        else:
+                            # Copy regular components + PML components
+                            send_r[5*m+0,:,:]=grid_r[m][Nz-nz_end:Nz-nz_start,:]
+                            send_r[5*m+1,:,:]=grid_t[m][Nz-nz_end:Nz-nz_start,:]
+                            send_r[5*m+2,:,:]=grid_z[m][Nz-nz_end:Nz-nz_start,:]
+                            send_r[5*m+3,:,:]=pml_r[m][Nz-nz_end:Nz-nz_start,:]
+                            send_r[5*m+4,:,:]=pml_t[m][Nz-nz_end:Nz-nz_start,:]
 
             elif after_receiving:
 
@@ -249,15 +305,34 @@ class BufferHandler(object):
                 if method == 'replace':
                     # Replace the guard cells of the domain with the buffers
                     if copy_left:
-                        for m in range(self.Nm):
-                            grid_r[m][:nz_end-nz_start,:]=recv_l[3*m+0,:,:]
-                            grid_t[m][:nz_end-nz_start,:]=recv_l[3*m+1,:,:]
-                            grid_z[m][:nz_end-nz_start,:]=recv_l[3*m+2,:,:]
+                        if pml_r is None:
+                            # Copy only the regular components
+                            for m in range(self.Nm):
+                                grid_r[m][:nz_end-nz_start,:]=recv_l[3*m+0,:,:]
+                                grid_t[m][:nz_end-nz_start,:]=recv_l[3*m+1,:,:]
+                                grid_z[m][:nz_end-nz_start,:]=recv_l[3*m+2,:,:]
+                        else:
+                            # Copy regular components + PML components
+                            for m in range(self.Nm):
+                                grid_r[m][:nz_end-nz_start,:]=recv_l[5*m+0,:,:]
+                                grid_t[m][:nz_end-nz_start,:]=recv_l[5*m+1,:,:]
+                                grid_z[m][:nz_end-nz_start,:]=recv_l[5*m+2,:,:]
+                                pml_r[m][:nz_end-nz_start,:]=recv_l[5*m+3,:,:]
+                                pml_t[m][:nz_end-nz_start,:]=recv_l[5*m+4,:,:]
                     if copy_right:
                         for m in range(self.Nm):
-                            grid_r[m][-(nz_end-nz_start):,:]=recv_r[3*m+0,:,:]
-                            grid_t[m][-(nz_end-nz_start):,:]=recv_r[3*m+1,:,:]
-                            grid_z[m][-(nz_end-nz_start):,:]=recv_r[3*m+2,:,:]
+                            if pml_r is None:
+                                # Copy only the regular components
+                                grid_r[m][-(nz_end-nz_start):,:]=recv_r[3*m+0,:,:]
+                                grid_t[m][-(nz_end-nz_start):,:]=recv_r[3*m+1,:,:]
+                                grid_z[m][-(nz_end-nz_start):,:]=recv_r[3*m+2,:,:]
+                            else:
+                                # Copy regular components + PML components
+                                grid_r[m][-(nz_end-nz_start):,:]=recv_r[5*m+0,:,:]
+                                grid_t[m][-(nz_end-nz_start):,:]=recv_r[5*m+1,:,:]
+                                grid_z[m][-(nz_end-nz_start):,:]=recv_r[5*m+2,:,:]
+                                pml_r[m][-(nz_end-nz_start):,:]=recv_r[5*m+3,:,:]
+                                pml_t[m][-(nz_end-nz_start):,:]=recv_r[5*m+4,:,:]
                 elif method == 'add':
                     # Add buffers to the domain
                     if copy_left:


### PR DESCRIPTION
This is the last of the "mundane" PR that prepares the PML structure: it performs the MPI exchange of the PML fields. 

More precisely, when using the PML, the MPI buffers for E and B are made larger, so that they can hold `Er_pml`/`Et_pml` and `Br_pml`/`Bt_pml`, and these fields are copied to/from these buffers.