### PR TITLE
Add the possibility to have an empty species in PICMI

### DIFF
--- a/fbpic/picmi/simulation.py
+++ b/fbpic/picmi/simulation.py
@@ -209,6 +209,11 @@ class Simulation( PICMI_Simulation ):
                                 n_macroparticles=layout.n_macroparticles,
                                 zf=zf, tf=tf,
                                 initialize_self_field=initialize_self_field )
+
+        # - For the case of an empty species
+        elif (s.initial_distribution is None) and (layout is None):
+            fbpic_species = self.fbpic_sim.add_new_species(q=s.charge, m=s.mass)
+
         else:
             raise ValueError('Unknown combination of layout and distribution')
 


### PR DESCRIPTION
For simulations with ionization, it is often convenient to create an electron species with no macroparticles initially. (The macroparticles will come from the ionization process of ions.)

In this case, the `layout` argument would typically be `None`. This PR corrects FBPIC so that it can handle the case `layout=None`.