### PR TITLE
Fix potential incompatibilities between numba and cupy

### DIFF
--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -25,9 +25,10 @@ if cuda_installed:
 try:
     import cupy
     cupy_installed = cupy.is_available()
-    assert int(cupy.__version__[0]) >= 6 # Require cupy version 6
+    cupy_major_version = int(cupy.__version__[0])
 except (ImportError, AssertionError):
     cupy_installed = False
+    cupy_major_version = None
 
 # -----------------------------------------------------
 # CUDA grid utilities


### PR DESCRIPTION
`cupy` and `numba` need to have compatible versions:
- numba<=0.45 is only compatible with cupy<=6
- numba>=0.46 is only compatible with cupy>=7
(see e.g. [this issue](https://github.com/numba/numba/issues/4661))

With this PR, the code stops execution when a version incompatibility is detected, and the user is prompted to install the latest version of either package. 