### PR TITLE
Update the API of the PML

### DIFF
--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -169,7 +169,9 @@ if __name__ == '__main__':
     # Initialize the simulation object
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
         v_comoving=v_comoving, gamma_boost=boost.gamma0,
-        n_order=n_order, boundaries='open', use_cuda=use_cuda )
+        n_order=n_order, use_cuda=use_cuda,
+        boundaries={'z':'open', 'r':'reflective'})
+        # 'r': 'open' can also be used, but is more computationally expensive
 
     # Add the plasma electron and plasma ions
     plasma_elec = sim.add_new_species( q=-e, m=m_e,

--- a/docs/source/example_input/ionization_script.py
+++ b/docs/source/example_input/ionization_script.py
@@ -110,7 +110,9 @@ if __name__ == '__main__':
 
     # Initialize the simulation object
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
-        boundaries='open', n_order=n_order, use_cuda=use_cuda )
+         n_order=n_order, use_cuda=use_cuda,
+         boundaries={'z':'open', 'r':'reflective'})
+         # 'r': 'open' can also be used, but is more computationally expensive
 
     # Add the Helium ions (pre-ionized up to level 1),
     # the Nitrogen ions (pre-ionized up to level 5)

--- a/docs/source/example_input/lwfa_script.py
+++ b/docs/source/example_input/lwfa_script.py
@@ -109,7 +109,9 @@ if __name__ == '__main__':
 
     # Initialize the simulation object
     sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
-        boundaries='open', n_order=n_order, use_cuda=use_cuda )
+        n_order=n_order, use_cuda=use_cuda,
+        boundaries={'z':'open', 'r':'reflective'})
+        # 'r': 'open' can also be used, but is more computationally expensive
 
     # Create the plasma electrons
     elec = sim.add_new_species( q=-e, m=m_e, n=n_e,

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -232,7 +232,7 @@ class BoundaryCommunicator(object):
         self.nz_damp = n_damp['z']
         self.nr_damp = n_damp['r']
         # For periodic boundaries, no need for damping cells
-        if boundaries['r']=='periodic':
+        if boundaries['z']=='periodic':
             self.nz_damp = 0
             self.n_inject = 0
         else:

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -47,8 +47,8 @@ class BoundaryCommunicator(object):
     # -----------------------
 
     def __init__( self, Nz, zmin, zmax, Nr, rmax, Nm, dt, v_comoving,
-            use_galilean, boundaries, r_boundary, n_order, n_guard,
-            n_damp, nr_damp, cdt_over_dr, n_inject=None, exchange_period=None,
+            use_galilean, boundaries, n_order, n_guard, n_damp,
+            cdt_over_dr, n_inject=None, exchange_period=None,
             use_all_mpi_ranks=True):
         """
         Initializes a communicator object.
@@ -82,15 +82,15 @@ class BoundaryCommunicator(object):
             When use_galilean is true, the whole grid moves
             with a speed v_comoving
 
-        boundaries: string, optional
-            The boundary condition in the longitudinal (z) direction.
-            Either "periodic" or "open" (for field-absorbing boundary)
-        r_boundary: string, optional
-            The boundary condition at the upper radial boundary (at rmax).
-            Either "reflective" or "open" (for field-absorbing boundary)
-            When "open" is selected, this adds Perfectly-Matched-Layers
-            in the radial direction ; note that the computation is
-            significantly more costly in this case.
+        boundaries: dict, optional
+            A dictionary with 'z' and 'r' as keys, and strings as values.
+            This specifies the field boundary in the longitudinal (z) and
+            transverse (r) direction respectively:
+              - `boundaries['z']` can be either `'periodic'` or `'open'`
+                (for field-absorbing boundary).
+              - `boundaries['r']` can be either `'reflective'` or `'open'`
+                (for field-absorbing boundary). For `'open'`, this adds
+                Perfectly-Matched-Layers in the radial direction.
 
         n_order: int
            The order of the stencil for the z derivatives.
@@ -109,15 +109,15 @@ class BoundaryCommunicator(object):
             in the case of open boundaries with an infinite order stencil,
             n_guard defaults to 64, if not set otherwise.
 
-        n_damp: int, optional
-            The number of damping cells in the longitudinal (z) direction.
-            The damping cells are used only if `boundaries` is `"open"`,
-            and they are added at the left and right edge of the simulation
-            domain.
-        nr_damp: int, optional
-            The number of damping cells in the radial (r) direction.
-            The damping cells are used only if `r_boundary` is `"open"`,
-            and are added at upper radial boundary (at `rmax`).
+        n_damp: dict, optional
+            A dictionary with 'z' and 'r' as keys, and integers as values.
+            The integers represent the number of damping cells in the
+            longitudinal (z) and transverse (r) directions, respectively.
+            The damping cells in z are only used if `boundaries['z']` is
+            `'open'`, and are added at the left and right edge of the
+            simulation domain. The damping cells in r are used only if
+            `boundaries['r']` is `'open'`, and are added at upper
+            radial boundary (at `rmax`).
 
         cdt_over_dr: float
             Ratio of timestep to radial cell size
@@ -159,10 +159,12 @@ class BoundaryCommunicator(object):
         self.dr = rmax/self._Nr
 
         # Check that the boundaries are valid
-        if not boundaries in ['periodic', 'open']:
-            raise ValueError('Unrecognized `boundaries`: %s' %boundaries)
-        if not r_boundary in ['reflective', 'open']:
-            raise ValueError('Unrecognized `r_boundary`: %s' %r_boundary)
+        if not boundaries['z'] in ['periodic', 'open']:
+            raise ValueError(
+                    "Unrecognized `boundaries['z']`: %s" %boundaries['z'])
+        if not boundaries['r'] in ['reflective', 'open']:
+            raise ValueError(
+                    "Unrecognized `boundaries['r']`: %s" %boundaries['r'])
 
         # MPI Setup
         self.use_all_mpi_ranks = use_all_mpi_ranks
@@ -179,13 +181,13 @@ class BoundaryCommunicator(object):
         self.right_proc = self.rank+1
         # Correct these initial values by taking into account boundaries
         self.boundaries = boundaries
-        if self.boundaries == 'periodic':
+        if self.boundaries['z'] == 'periodic':
             # Periodic boundary conditions for the domains
             if self.rank == 0:
                 self.left_proc = (self.size-1)
             if self.rank == self.size-1:
                 self.right_proc = 0
-        elif self.boundaries == 'open':
+        elif self.boundaries['z'] == 'open':
             # None means that the boundary is open
             if self.rank == 0:
                 self.left_proc = None
@@ -223,14 +225,14 @@ class BoundaryCommunicator(object):
             # Otherwise: Set user defined guard region size
             self.n_guard = n_guard
         # For single proc and periodic boundaries, no need for guard cells
-        if boundaries=='periodic' and self.size==1:
+        if boundaries['z']=='periodic' and self.size==1:
             self.n_guard = 0
 
         # Register damping cells
-        self.nz_damp = n_damp
-        self.nr_damp = nr_damp
+        self.nz_damp = n_damp['z']
+        self.nr_damp = n_damp['r']
         # For periodic boundaries, no need for damping cells
-        if boundaries=='periodic':
+        if boundaries['r']=='periodic':
             self.nz_damp = 0
             self.n_inject = 0
         else:
@@ -242,7 +244,7 @@ class BoundaryCommunicator(object):
                 # User-defined injection cells. Choose carefully.
                 self.n_inject = n_inject
         # For reflective radial boundary, no need for damping cell
-        if r_boundary=='reflective':
+        if boundaries['r']=='reflective':
             self.nr_damp = 0
             self.use_pml = False
         else:
@@ -262,7 +264,7 @@ class BoundaryCommunicator(object):
             self.exchange_period = int(((self.n_guard/2)-3)/cells_per_step)
             # Set exchange_period to 1 in the case of single-proc
             # and periodic boundary conditions.
-            if self.size == 1 and boundaries == 'periodic':
+            if self.size == 1 and boundaries['z'] == 'periodic':
                 self.exchange_period = 1
             # Check that calculated exchange_period is acceptable for given
             # simulation parameters (check that guard region is large enough).
@@ -301,9 +303,9 @@ class BoundaryCommunicator(object):
                     self.d_right_damp = cuda.to_device( self.right_damp )
 
         # Create damping object for the PML
-        self.use_pml = (r_boundary == "open")
+        self.use_pml = (boundaries['r'] == "open")
         if self.use_pml:
-            self.pml_damper = PMLDamper( nr_damp, cdt_over_dr )
+            self.pml_damper = PMLDamper( self.nr_damp, cdt_over_dr )
 
 
     def divide_into_domain( self ):

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -239,20 +239,6 @@ class Simulation(object):
         if v_comoving is None:
             self.use_galilean = False
 
-        # Handle boundaries
-        if type(boundaries) is str:
-            # Convert to dictionary
-            warnings.warn(
-                "In FBPIC version 0.15 and later, a *dictionary* is expected\n"
-                "for the argument `boundaries` of the `Simulation` class,\n"
-                "but instead a *string* was detected (`boundaries='%s'`).\n"
-                "Thus, the `boundaries` argument was automatically converted\n"
-                "to `boundaries={'z':'%s', 'r':'reflective'}`.\n"
-                "Please pass a dictionary for `boundaries`, in the future."
-                %(boundaries, boundaries) )
-            boundaries = {'z':boundaries, 'r':'reflective'}
-        self.use_pml = (boundaries['r'] == "open")
-
         # When running the simulation in a boosted frame, convert the arguments
         if gamma_boost is not None:
             self.boost = BoostConverter( gamma_boost )
@@ -268,6 +254,7 @@ class Simulation(object):
             self.v_comoving, self.use_galilean, boundaries, n_order,
             n_guard, n_damp, cdt_over_dr, None, exchange_period,
             use_all_mpi_ranks )
+        self.use_pml = self.comm.use_pml
         # Modify domain region
         zmin, zmax, Nz = self.comm.divide_into_domain()
         Nr = self.comm.get_Nr( with_damp=True )

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -243,7 +243,7 @@ class Simulation(object):
         if type(boundaries) is str:
             warnings.warn('TODO')
             # Convert to dictionary
-            boundaries = {'z':boundaries, 'r':reflective}
+            boundaries = {'z':boundaries, 'r':'reflective'}
         self.use_pml = (boundaries['r'] == "open")
 
         # When running the simulation in a boosted frame, convert the arguments
@@ -258,8 +258,8 @@ class Simulation(object):
         # Initialize the boundary communicator
         cdt_over_dr = c*dt / (rmax/Nr)
         self.comm = BoundaryCommunicator( Nz, zmin, zmax, Nr, rmax, Nm, dt,
-            self.v_comoving, self.use_galilean, boundaries, r_boundary, n_order,
-            n_guard, n_damp, nr_damp, cdt_over_dr, None, exchange_period,
+            self.v_comoving, self.use_galilean, boundaries, n_order,
+            n_guard, n_damp, cdt_over_dr, None, exchange_period,
             use_all_mpi_ranks )
         # Modify domain region
         zmin, zmax, Nz = self.comm.divide_into_domain()

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -241,8 +241,15 @@ class Simulation(object):
 
         # Handle boundaries
         if type(boundaries) is str:
-            warnings.warn('TODO')
             # Convert to dictionary
+            warnings.warn(
+                "In FBPIC version 0.15 and later, a *dictionary* is expected\n"
+                "for the argument `boundaries` of the `Simulation` class,\n"
+                "but instead a *string* was detected (`boundaries='%s'`).\n"
+                "Thus, the `boundaries` argument was automatically converted\n"
+                "to `boundaries={'z':'%s', 'r':'reflective'}`.\n"
+                "Please pass a dictionary for `boundaries`, in the future."
+                %(boundaries, boundaries) )
             boundaries = {'z':boundaries, 'r':'reflective'}
         self.use_pml = (boundaries['r'] == "open")
 

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -142,16 +142,14 @@ class Simulation(object):
             in the case of open boundaries with an infinite order stencil,
             n_guard defaults to 64, if not set otherwise.
         n_damp: dict, optional
-            A dictionary with 'z' and 'r' as keys and integers as values.
-            The integers represent the number 
-            The number of damping cells in the longitudinal (z) direction.
-            The damping cells are used only if `boundaries` is `"open"`,
-            and they are added at the left and right edge of the simulation
-            domain.
-        nr_damp: int, optional
-            The number of damping cells in the radial (r) direction.
-            The damping cells are used only if `r_boundary` is `"open"`,
-            and are added at upper radial boundary (at `rmax`).
+            A dictionary with 'z' and 'r' as keys, and integers as values.
+            The integers represent the number of damping cells in the
+            longitudinal (z) and transverse (r) directions, respectively.
+            The damping cells in z are only used if `boundaries['z']` is
+            `'open'`, and are added at the left and right edge of the
+            simulation domain. The damping cells in r are used only if
+            `boundaries['r']` is `'open'`, and are added at upper
+            radial boundary (at `rmax`).
 
         exchange_period: int, optional
             Number of iterations before which the particles are exchanged.
@@ -161,16 +159,16 @@ class Simulation(object):
             (n_guard/2 - particle_shape order) cells. (Setting exchange_period
             to small values can substantially affect the performance)
 
-        boundaries: string, optional
-            The boundary condition in the longitudinal (z) direction.
-            Either "periodic" or "open" (for field-absorbing boundary)
-
-        r_boundary: string, optional
-            The boundary condition at the upper radial boundary (at rmax).
-            Either "reflective" or "open" (for field-absorbing boundary)
-            When "open" is selected, this adds Perfectly-Matched-Layers
-            in the radial direction ; note that the computation is
-            significantly more costly in this case.
+        boundaries: dict, optional
+            A dictionary with 'z' and 'r' as keys, and strings as values.
+            This specifies the field boundary in the longitudinal (z) and
+            transverse (r) direction respectively:
+              - `boundaries['z']` can be either `'periodic'` or `'open'`
+                (for field-absorbing boundary).
+              - `boundaries['r']` can be either `'reflective'` or `'open'`
+                (for field-absorbing boundary). For `'open'`, this adds
+                Perfectly-Matched-Layers in the radial direction ; note that
+                the computation is significantly more costly in this case.
 
         current_correction: string, optional
             The method used in order to ensure that the continuity equation
@@ -246,9 +244,7 @@ class Simulation(object):
             warnings.warn('TODO')
             # Convert to dictionary
             boundaries = {'z':boundaries, 'r':reflective}
-
-
-        self.use_pml = (r_boundary == "open")
+        self.use_pml = (boundaries['r'] == "open")
 
         # When running the simulation in a boosted frame, convert the arguments
         if gamma_boost is not None:

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -48,12 +48,14 @@ class Simulation(object):
                  p_nz=None, p_nr=None, p_nt=None, n_e=None, zmin=0.,
                  n_order=-1, dens_func=None, filter_currents=True,
                  v_comoving=None, use_galilean=True,
-                 initialize_ions=False, use_cuda=False,
-                 n_guard=None, n_damp=64, exchange_period=None,
-                 current_correction='curl-free', boundaries='periodic',
+                 initialize_ions=False, use_cuda=False, n_guard=None,
+                 n_damp={'z':64, 'r':32},
+                 exchange_period=None,
+                 current_correction='curl-free',
+                 boundaries={'z':'periodic', 'r':'reflective'},
                  gamma_boost=None, use_all_mpi_ranks=True,
                  particle_shape='linear', verbose_level=1,
-                 smoother=None, r_boundary='reflective', nr_damp=32 ):
+                 smoother=None ):
         """
         Initializes a simulation.
 
@@ -139,7 +141,9 @@ class Simulation(object):
             automatically (approx 2*n_order). If no MPI is used and
             in the case of open boundaries with an infinite order stencil,
             n_guard defaults to 64, if not set otherwise.
-        n_damp: int, optional
+        n_damp: dict, optional
+            A dictionary with 'z' and 'r' as keys and integers as values.
+            The integers represent the number 
             The number of damping cells in the longitudinal (z) direction.
             The damping cells are used only if `boundaries` is `"open"`,
             and they are added at the left and right edge of the simulation
@@ -160,6 +164,7 @@ class Simulation(object):
         boundaries: string, optional
             The boundary condition in the longitudinal (z) direction.
             Either "periodic" or "open" (for field-absorbing boundary)
+
         r_boundary: string, optional
             The boundary condition at the upper radial boundary (at rmax).
             Either "reflective" or "open" (for field-absorbing boundary)
@@ -236,7 +241,13 @@ class Simulation(object):
         if v_comoving is None:
             self.use_galilean = False
 
-        # Check whether the pml should be used
+        # Handle boundaries
+        if type(boundaries) is str:
+            warnings.warn('TODO')
+            # Convert to dictionary
+            boundaries = {'z':boundaries, 'r':reflective}
+
+
         self.use_pml = (r_boundary == "open")
 
         # When running the simulation in a boosted frame, convert the arguments

--- a/fbpic/picmi/simulation.py
+++ b/fbpic/picmi/simulation.py
@@ -40,7 +40,7 @@ class Simulation( PICMI_Simulation ):
         assert grid.rmin == 0.
         assert grid.bc_zmin == grid.bc_zmax
         assert grid.bc_zmax in ['periodic', 'open']
-        assert grid.bc_rmax == 'reflective'
+        assert grid.bc_rmax in ['reflective', 'open']
 
         # Determine timestep
         if self.solver.cfl is not None:
@@ -65,8 +65,8 @@ class Simulation( PICMI_Simulation ):
         self.fbpic_sim = FBPICSimulation(
             Nz=int(grid.nz), zmin=grid.zmin, zmax=grid.zmax,
             Nr=int(grid.nr), rmax=grid.rmax, Nm=grid.n_azimuthal_modes,
-            dt=dt, use_cuda=True, boundaries=grid.bc_zmax,
-            smoother=smoother, n_order=32 )
+            dt=dt, use_cuda=True, smoother=smoother, n_order=32,
+            boundaries={'z':grid.bc_zmax, 'r':grid.bc_rmax} )
 
         # Set the moving window
         if grid.moving_window_velocity is not None:

--- a/fbpic/utils/printing.py
+++ b/fbpic/utils/printing.py
@@ -218,8 +218,8 @@ def print_simulation_setup( sim, verbose_level=1 ):
             else:
                 message += '\nPSATD stencil order: %d' %sim.fld.n_order
             message += '\nParticle shape: %s' %sim.particle_shape
-            message += '\nLongitudinal boundaries: %s' %sim.comm.boundaries
-            message += '\nTransverse boundaries: reflective'
+            message += '\nLongitudinal boundaries: %s' %sim.comm.boundaries['z']
+            message += '\nTransverse boundaries: %s' %sim.comm.boundaries['r']
             message += '\nGuard region size: %d ' %sim.comm.n_guard+'cells'
             message += '\nDamping region size: %d ' %sim.comm.nz_damp+'cells'
             message += '\nInjection region size: %d ' %sim.comm.n_inject+'cells'

--- a/tests/test_pml.py
+++ b/tests/test_pml.py
@@ -102,10 +102,10 @@ def propagate_pulse( boundaries, v_window=0, use_galilean=False,
        the agreement with the theory.
     """
     # Initialize the simulation object
-    sim = Simulation( Nz, zmax, Nr, Lr, Nm, dt, r_boundary='open',
+    sim = Simulation( Nz, zmax, Nr, Lr, Nm, dt,
                       n_order=n_order, zmin=zmin, use_cuda=use_cuda,
-                      boundaries=boundaries, v_comoving=v_comoving,
-                      use_galilean=use_galilean )
+                      boundaries={'z':boundaries, 'r':'open'},
+                      v_comoving=v_comoving, use_galilean=use_galilean )
 
     # Set the moving window object
     if v_window !=0:


### PR DESCRIPTION
This updates the API for the PML:
- `boundaries` should now be passed as a dictionary ; e.g. `boundaries = {'z':'open', 'r':'reflective'}` without PML and `boundaries = {'z':'open', 'r':'open'}` for PML.
- `n_damp` should also be passed as a dictionary (although users usually don't pass this, and use the default instead).
Note that the previous API (single string. e.g.`boundaries='open'`) still works (for backward compatibility) but will raise a warning, recommending to pass a dictionary instead.

A few minor changes related to the API were also added:
- The PICMI interface can now also activate the PML. (by passing `'open'` for the `r` boundary)
- The `r` boundary (`'open'` or `'reflective'`) is printed when doing `verbose_level=2`.
- The default example scripts now use the new API