### PR TITLE
Fix bug in GPU-MPI communications of PML

### DIFF
--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -247,8 +247,8 @@ class BufferHandler(object):
                             # Copy regular components + PML components
                             replace_pml_from_gpu_buffer \
                                 [ dim_grid_2d, dim_block_2d ](
-                                self.d_send_l[exchange_type],
-                                self.d_send_r[exchange_type],
+                                self.d_recv_l[exchange_type],
+                                self.d_recv_r[exchange_type],
                                 grid_r[m], grid_t[m], grid_z[m],
                                 pml_r[m], pml_t[m], m,
                                 copy_left, copy_right, nz_start, nz_end )


### PR DESCRIPTION
The communications of PML fields has a typo, in the case where the code runs on GPU.

This PR fixes the typo. The code can be tested by doing:
```
mpirun -np 2 python test_pml.py
```
(and changing `n_order` to `32` in `test_pml.py`)

Many thanks to @Kookjin for testing the `finalized_pml` branch and reporting an issue in GPU-MPI simulations!! :sparkles: 