### PR TITLE
Gather only for particles that are inside the physical box

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -437,7 +437,7 @@ class Simulation(object):
 
             # Gather the fields from the grid at t = n dt
             for species in ptcl:
-                species.gather( fld.interp )
+                species.gather( fld.interp, self.comm )
             # Apply the external fields at t = n dt
             for ext_field in self.external_fields:
                 ext_field.apply_expression( self.ptcl, self.time )

--- a/fbpic/particles/gathering/cuda_methods.py
+++ b/fbpic/particles/gathering/cuda_methods.py
@@ -23,6 +23,7 @@ add_cubic_gather_for_mode = cuda.jit( add_cubic_gather_for_mode,
 
 @cuda.jit
 def gather_field_gpu_linear(x, y, z,
+                    rmax_gather,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m0, Et_m0, Ez_m0,
@@ -43,6 +44,9 @@ def gather_field_gpu_linear(x, y, z,
     ----------
     x, y, z : 1darray of floats (in meters)
         The position of the particles
+
+    rmax_gather: float (in meters)
+        The radius above which particle do not gather anymore
 
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
@@ -153,8 +157,8 @@ def gather_field_gpu_linear(x, y, z,
         Fr = 0.
         Ft = 0.
         Fz = 0.
-        # Only perform gathering for particles that are inside the box radially
-        if r_cell+0.5 < Nr:
+        # Only perform gathering for particles that are below rmax_gather
+        if rj < rmax_gather:
             # Add contribution from mode 0
             Fr, Ft, Fz = add_linear_gather_for_mode( 0,
                 Fr, Ft, Fz, exptheta_m0, Er_m0, Et_m0, Ez_m0,
@@ -178,8 +182,8 @@ def gather_field_gpu_linear(x, y, z,
         Fr = 0.
         Ft = 0.
         Fz = 0.
-        # Only perform gathering for particles that are inside the box radially
-        if r_cell+0.5 < Nr:
+        # Only perform gathering for particles that are below rmax_gather
+        if rj < rmax_gather:
             # Add contribution from mode 0
             Fr, Ft, Fz = add_linear_gather_for_mode( 0,
                 Fr, Ft, Fz, exptheta_m0, Br_m0, Bt_m0, Bz_m0,
@@ -202,6 +206,7 @@ def gather_field_gpu_linear(x, y, z,
 
 @cuda.jit
 def gather_field_gpu_cubic(x, y, z,
+                    rmax_gather,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m0, Et_m0, Ez_m0,
@@ -222,6 +227,9 @@ def gather_field_gpu_cubic(x, y, z,
     ----------
     x, y, z : 1darray of floats (in meters)
         The position of the particles
+
+    rmax_gather: float (in meters)
+        The radius above which particle do not gather anymore
 
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
@@ -305,8 +313,8 @@ def gather_field_gpu_cubic(x, y, z,
         Fr = 0.
         Ft = 0.
         Fz = 0.
-        # Only perform gathering for particles that are inside the box radially
-        if r_cell+0.5 < Nr:
+        # Only perform gathering for particles that are below rmax_gather
+        if rj < rmax_gather:
             # Add contribution from mode 0
             Fr, Ft, Fz = add_cubic_gather_for_mode( 0,
                 Fr, Ft, Fz, exptheta_m0, Er_m0, Et_m0, Ez_m0,
@@ -328,8 +336,8 @@ def gather_field_gpu_cubic(x, y, z,
         Fr = 0.
         Ft = 0.
         Fz = 0.
-        # Only perform gathering for particles that are inside the box radially
-        if r_cell+0.5 < Nr:
+        # Only perform gathering for particles that are below rmax_gather
+        if rj < rmax_gather:
             # Add contribution from mode 0
             Fr, Ft, Fz =  add_cubic_gather_for_mode( 0,
                 Fr, Ft, Fz, exptheta_m0, Br_m0, Bt_m0, Bz_m0,

--- a/fbpic/particles/gathering/cuda_methods_one_mode.py
+++ b/fbpic/particles/gathering/cuda_methods_one_mode.py
@@ -43,6 +43,7 @@ def erase_eb_cuda( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
 
 @cuda.jit
 def gather_field_gpu_linear_one_mode(x, y, z,
+                    rmax_gather,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m, Et_m, Ez_m,
@@ -61,6 +62,9 @@ def gather_field_gpu_linear_one_mode(x, y, z,
     ----------
     x, y, z : 1darray of floats (in meters)
         The position of the particles
+
+    rmax_gather: float (in meters)
+        The radius above which particle do not gather anymore
 
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
@@ -121,8 +125,8 @@ def gather_field_gpu_linear_one_mode(x, y, z,
         r_cell =  invdr*(rj - rmin) - 0.5
         z_cell =  invdz*(zj - zmin) - 0.5
 
-        # Only perform gathering for particles that are inside the box radially
-        if r_cell+0.5 < Nr:
+        # Only perform gathering for particles that are below rmax_gather
+        if rj < rmax_gather:
 
             # Original index of the uppper and lower cell
             ir_lower = int(math.floor( r_cell ))
@@ -209,6 +213,7 @@ def gather_field_gpu_linear_one_mode(x, y, z,
 
 @cuda.jit
 def gather_field_gpu_cubic_one_mode(x, y, z,
+                    rmax_gather,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m, Et_m, Ez_m,
@@ -227,6 +232,9 @@ def gather_field_gpu_cubic_one_mode(x, y, z,
     ----------
     x, y, z : 1darray of floats (in meters)
         The position of the particles
+
+    rmax_gather: float (in meters)
+        The radius above which particle do not gather anymore
 
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
@@ -288,8 +296,8 @@ def gather_field_gpu_cubic_one_mode(x, y, z,
         r_cell = invdr*(rj - rmin) - 0.5
         z_cell = invdz*(zj - zmin) - 0.5
 
-        # Only perform gathering for particles that are inside the box radially
-        if r_cell+0.5 < Nr:
+        # Only perform gathering for particles that are below rmax_gather
+        if rj < rmax_gather:
 
             # Calculate the shape factors
             Sr = cuda.local.array((4,), dtype=float64)

--- a/fbpic/particles/gathering/threading_methods.py
+++ b/fbpic/particles/gathering/threading_methods.py
@@ -24,6 +24,7 @@ add_cubic_gather_for_mode = numba.njit( add_cubic_gather_for_mode )
 
 @njit_parallel
 def gather_field_numba_linear(x, y, z,
+                    rmax_gather,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m0, Et_m0, Ez_m0,
@@ -44,6 +45,9 @@ def gather_field_numba_linear(x, y, z,
     ----------
     x, y, z : 1darray of floats (in meters)
         The position of the particles
+
+    rmax_gather: float (in meters)
+        The radius above which particle do not gather anymore
 
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
@@ -151,8 +155,8 @@ def gather_field_numba_linear(x, y, z,
         Fr = 0.
         Ft = 0.
         Fz = 0.
-        # Only perform gathering for particles that are inside the box radially
-        if r_cell+0.5 < Nr:
+        # Only perform gathering for particles that are below rmax_gather
+        if rj < rmax_gather:
             # Add contribution from mode 0
             Fr, Ft, Fz = add_linear_gather_for_mode( 0,
                 Fr, Ft, Fz, exptheta_m0, Er_m0, Et_m0, Ez_m0,
@@ -176,8 +180,8 @@ def gather_field_numba_linear(x, y, z,
         Fr = 0.
         Ft = 0.
         Fz = 0.
-        # Only perform gathering for particles that are inside the box radially
-        if r_cell+0.5 < Nr:
+        # Only perform gathering for particles that are below rmax_gather
+        if rj < rmax_gather:
             # Add contribution from mode 0
             Fr, Ft, Fz = add_linear_gather_for_mode( 0,
                 Fr, Ft, Fz, exptheta_m0, Br_m0, Bt_m0, Bz_m0,
@@ -202,6 +206,7 @@ def gather_field_numba_linear(x, y, z,
 
 @njit_parallel
 def gather_field_numba_cubic(x, y, z,
+                    rmax_gather,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m0, Et_m0, Ez_m0,
@@ -223,6 +228,9 @@ def gather_field_numba_cubic(x, y, z,
     ----------
     x, y, z : 1darray of floats (in meters)
         The position of the particles
+
+    rmax_gather: float (in meters)
+        The radius above which particle do not gather anymore
 
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
@@ -317,8 +325,8 @@ def gather_field_numba_cubic(x, y, z,
             Fr = 0.
             Ft = 0.
             Fz = 0.
-            # Only perform gathering for particles that are inside the box radially
-            if r_cell+0.5 < Nr:
+            # Only perform gathering for particles that are below rmax_gather
+            if rj < rmax_gather:
                 # Add contribution from mode 0
                 Fr, Ft, Fz = add_cubic_gather_for_mode( 0,
                     Fr, Ft, Fz, exptheta_m0, Er_m0, Et_m0, Ez_m0,
@@ -340,8 +348,8 @@ def gather_field_numba_cubic(x, y, z,
             Fr = 0.
             Ft = 0.
             Fz = 0.
-            # Only perform gathering for particles that are inside the box radially
-            if r_cell+0.5 < Nr:
+            # Only perform gathering for particles that are below rmax_gather
+            if rj < rmax_gather:
                 # Add contribution from mode 0
                 Fr, Ft, Fz =  add_cubic_gather_for_mode( 0,
                     Fr, Ft, Fz, exptheta_m0, Br_m0, Bt_m0, Bz_m0,

--- a/fbpic/particles/gathering/threading_methods_one_mode.py
+++ b/fbpic/particles/gathering/threading_methods_one_mode.py
@@ -45,6 +45,7 @@ def erase_eb_numba( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
 
 @njit_parallel
 def gather_field_numba_linear_one_mode(x, y, z,
+                    rmax_gather,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m, Et_m, Ez_m,
@@ -62,6 +63,9 @@ def gather_field_numba_linear_one_mode(x, y, z,
     ----------
     x, y, z : 1darray of floats (in meters)
         The position of the particles
+
+    rmax_gather: float (in meters)
+        The radius above which particle do not gather anymore
 
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
@@ -116,8 +120,8 @@ def gather_field_numba_linear_one_mode(x, y, z,
         r_cell =  invdr*(rj - rmin) - 0.5
         z_cell =  invdz*(zj - zmin) - 0.5
 
-        # Only perform gathering for particles that are inside the box radially
-        if r_cell+0.5 < Nr:
+        # Only perform gathering for particles that are below rmax_gather
+        if rj < rmax_gather:
 
             # Original index of the uppper and lower cell
             ir_lower = int(math.floor( r_cell ))
@@ -206,6 +210,7 @@ def gather_field_numba_linear_one_mode(x, y, z,
 
 @njit_parallel
 def gather_field_numba_cubic_one_mode(x, y, z,
+                    rmax_gather,
                     invdz, zmin, Nz,
                     invdr, rmin, Nr,
                     Er_m, Et_m, Ez_m,
@@ -225,6 +230,9 @@ def gather_field_numba_cubic_one_mode(x, y, z,
     ----------
     x, y, z : 1darray of floats (in meters)
         The position of the particles
+
+    rmax_gather: float (in meters)
+        The radius above which particle do not gather anymore
 
     invdz, invdr : float (in meters^-1)
         Inverse of the grid step along the considered direction
@@ -296,8 +304,8 @@ def gather_field_numba_cubic_one_mode(x, y, z,
             r_cell = invdr*(rj - rmin) - 0.5
             z_cell = invdz*(zj - zmin) - 0.5
 
-            # Only perform gathering for particles that are inside the box radially
-            if r_cell+0.5 < Nr:
+            # Only perform gathering for particles that are below rmax_gather
+            if rj < rmax_gather:
 
                 # Calculate the shape factors
                 ir_lowest = int64(math.floor(r_cell)) - 1


### PR DESCRIPTION
This PR is very similar to #398 ("Do not gather field for the particles that are outside simulation box"), but while #398 prevents particles from gathering fields *when they are outside the full simulation grid (which includes PML cells)*, the current PR prevents particles from gathering fields *when they are outside the physical domain (which excludes PML cells)*.

Thus, with this PR, particles will not gather fields from the PML, and will thus propagate in straight lines.

In practice, this PR modifies the code in the same places that #398 did, but checks if `r < rmax_gather` where `rmax_gather` is given by `comm.get_rmax( with_damp=False )` (`with_damp=False` excludes the PML) - see the file `particles.py`. As consequence, the code has been modified so that the `BoundaryCommunicator` `comm` is passed to the `Particles.gather` function.