### PR TITLE
[WIP] Use `cupy` more extensively

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -18,7 +18,9 @@ from .pml_damping import PMLDamper
 from .particle_buffer_handling import remove_outside_particles, \
      add_buffers_to_particles, shift_particles_periodic_subdomain
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d
     from .cuda_methods import cuda_damp_EB_left, cuda_damp_EB_right, \
@@ -320,13 +322,13 @@ class BoundaryCommunicator(object):
                 self.left_damp = self.generate_damp_array(
                     self.n_guard, self.nz_damp, self.n_inject )
                 if cuda_installed:
-                    self.d_left_damp = cuda.to_device( self.left_damp )
+                    self.d_left_damp = cupy.asarray( self.left_damp )
             if self.right_proc is None:
                 # Create the damping arrays for right proc
                 self.right_damp = self.generate_damp_array(
                     self.n_guard, self.nz_damp, self.n_inject )
                 if cuda_installed:
-                    self.d_right_damp = cuda.to_device( self.right_damp )
+                    self.d_right_damp = cupy.asarray( self.right_damp )
 
         # Create damping object for the PML
         self.use_pml = (boundaries['r'] == "open")

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -8,8 +8,10 @@ It defines the structure necessary to handle mpi buffers for the particles
 import numpy as np
 import numba
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
 from fbpic.utils.printing import catch_gpu_memory_error
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
@@ -224,10 +226,10 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     # Reminder: prefix_sum[i] is the cumulative sum of the number of particles
     # in cells 0 to i (where cell i is included)
     if iz_min*(Nr+1) - 1 >= 0:
-        i_min = prefix_sum.getitem( iz_min*(Nr+1) - 1 )
+        i_min = int(prefix_sum[ iz_min*(Nr+1) - 1 ])
     else:
         i_min = 0
-    i_max = prefix_sum.getitem( iz_max*(Nr+1) - 1 )
+    i_max = int(prefix_sum[ iz_max*(Nr+1) - 1 ])
 
     # Total number of particles in each particle group
     N_send_l = i_min
@@ -263,9 +265,9 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     for i_attr in range(n_float):
         # Initialize 3 buffer arrays on the GPU (need to be initialized
         # inside the loop, as `copy_to_host` invalidates these arrays)
-        left_buffer = cuda.device_array((N_send_l,), dtype=np.float64)
-        right_buffer = cuda.device_array((N_send_r,), dtype=np.float64)
-        stay_buffer = cuda.device_array((new_Ntot,), dtype=np.float64)
+        left_buffer = cupy.empty((N_send_l,), dtype=np.float64)
+        right_buffer = cupy.empty((N_send_r,), dtype=np.float64)
+        stay_buffer = cupy.empty((new_Ntot,), dtype=np.float64)
         # Check that the buffers are still on GPU
         # (safeguard against automatic memory management)
         assert type(left_buffer) != np.ndarray
@@ -279,9 +281,9 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
         # and fill the sending buffers (if needed for MPI)
         setattr( attr_list[i_attr][0], attr_list[i_attr][1], stay_buffer)
         if left_proc is not None:
-            left_buffer.copy_to_host( float_send_left[i_attr] )
+            left_buffer.get( out=float_send_left[i_attr] )
         if right_proc is not None:
-            right_buffer.copy_to_host( float_send_right[i_attr] )
+            right_buffer.get( out=float_send_right[i_attr] )
 
     # Integer quantities:
     if n_int > 0:
@@ -293,9 +295,9 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     for i_attr in range(n_int):
         # Initialize 3 buffer arrays on the GPU (need to be initialized
         # inside the loop, as `copy_to_host` invalidates these arrays)
-        left_buffer = cuda.device_array((N_send_l,), dtype=np.uint64)
-        right_buffer = cuda.device_array((N_send_r,), dtype=np.uint64)
-        stay_buffer = cuda.device_array((new_Ntot,), dtype=np.uint64)
+        left_buffer = cupy.empty((N_send_l,), dtype=np.uint64)
+        right_buffer = cupy.empty((N_send_r,), dtype=np.uint64)
+        stay_buffer = cupy.empty((new_Ntot,), dtype=np.uint64)
         # Split the particle array into the 3 buffers on the GPU
         particle_array = getattr( attr_list[i_attr][0], attr_list[i_attr][1] )
         split_particles_to_buffers[dim_grid_1d, dim_block_1d]( particle_array,
@@ -304,9 +306,9 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
         # and fill the sending buffers (if needed for MPI)
         setattr( attr_list[i_attr][0], attr_list[i_attr][1], stay_buffer)
         if left_proc is not None:
-            left_buffer.copy_to_host( uint_send_left[i_attr] )
+            left_buffer.get( out=uint_send_left[i_attr] )
         if right_proc is not None:
-            right_buffer.copy_to_host( uint_send_right[i_attr] )
+            right_buffer.get( out=uint_send_right[i_attr] )
 
     # Change the new total number of particles
     species.Ntot = new_Ntot
@@ -349,20 +351,20 @@ def add_buffers_to_particles( species, float_recv_left, float_recv_right,
     if species.use_cuda:
         shape = (species.Ntot,)
         # Reallocate empty field-on-particle arrays on the GPU
-        species.Ex = cuda.device_array( shape, dtype=np.float64 )
-        species.Ex = cuda.device_array( shape, dtype=np.float64 )
-        species.Ey = cuda.device_array( shape, dtype=np.float64 )
-        species.Ez = cuda.device_array( shape, dtype=np.float64 )
-        species.Bx = cuda.device_array( shape, dtype=np.float64 )
-        species.By = cuda.device_array( shape, dtype=np.float64 )
-        species.Bz = cuda.device_array( shape, dtype=np.float64 )
+        species.Ex = cupy.empty( shape, dtype=np.float64 )
+        species.Ex = cupy.empty( shape, dtype=np.float64 )
+        species.Ey = cupy.empty( shape, dtype=np.float64 )
+        species.Ez = cupy.empty( shape, dtype=np.float64 )
+        species.Bx = cupy.empty( shape, dtype=np.float64 )
+        species.By = cupy.empty( shape, dtype=np.float64 )
+        species.Bz = cupy.empty( shape, dtype=np.float64 )
         # Reallocate empty auxiliary sorting arrays on the GPU
-        species.cell_idx = cuda.device_array( shape, dtype=np.int32 )
-        species.sorted_idx = cuda.device_array( shape, dtype=np.intp )
-        species.sorting_buffer = cuda.device_array( shape, dtype=np.float64 )
+        species.cell_idx = cupy.empty( shape, dtype=np.int32 )
+        species.sorted_idx = cupy.empty( shape, dtype=np.intp )
+        species.sorting_buffer = cupy.empty( shape, dtype=np.float64 )
         if species.n_integer_quantities > 0:
             species.int_sorting_buffer = \
-                cuda.device_array( shape, dtype=np.uint64 )
+                cupy.empty( shape, dtype=np.uint64 )
     else:
         # Reallocate empty field-on-particle arrays on the CPU
         species.Ex = np.empty(species.Ntot, dtype=np.float64)
@@ -459,10 +461,10 @@ def add_buffers_gpu( species, float_recv_left, float_recv_right,
     # Loop through the float quantities
     for i_attr in range( len(attr_list) ):
         # Copy the proper buffers to the GPU
-        left_buffer = cuda.to_device( float_recv_left[i_attr] )
-        right_buffer = cuda.to_device( float_recv_right[i_attr] )
+        left_buffer = cupy.asarray( float_recv_left[i_attr] )
+        right_buffer = cupy.asarray( float_recv_right[i_attr] )
         # Initialize the new particle array
-        particle_array = cuda.device_array( (new_Ntot,), dtype=np.float64)
+        particle_array = cupy.empty( (new_Ntot,), dtype=np.float64)
         # Merge the arrays on the GPU
         stay_buffer = getattr( attr_list[i_attr][0], attr_list[i_attr][1])
         if n_left != 0:
@@ -487,10 +489,10 @@ def add_buffers_gpu( species, float_recv_left, float_recv_right,
     # Loop through the integer quantities
     for i_attr in range( len(attr_list) ):
         # Copy the proper buffers to the GPU
-        left_buffer = cuda.to_device( uint_recv_left[i_attr] )
-        right_buffer = cuda.to_device( uint_recv_right[i_attr] )
+        left_buffer = cupy.asarray( uint_recv_left[i_attr] )
+        right_buffer = cupy.asarray( uint_recv_right[i_attr] )
         # Initialize the new particle array
-        particle_array = cuda.device_array( (new_Ntot,), dtype=np.uint64)
+        particle_array = cupy.empty( (new_Ntot,), dtype=np.uint64)
         # Merge the arrays on the GPU
         stay_buffer = getattr( attr_list[i_attr][0], attr_list[i_attr][1])
         if n_left != 0:

--- a/fbpic/boundaries/pml_damping.py
+++ b/fbpic/boundaries/pml_damping.py
@@ -6,7 +6,9 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the structure that damps the fields in the guard cells.
 """
 import numpy as np
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda
 
@@ -40,7 +42,7 @@ class PMLDamper(object):
 
         # Transfer the damping array to the GPU
         if cuda_installed:
-            self.d_damp_array = cuda.to_device( self.damp_array )
+            self.d_damp_array = cupy.asarray( self.damp_array )
 
 
     def damp_pml_EB( self, interp ):

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -136,6 +136,7 @@ class Fields(object) :
                 'Cuda not available for the fields.\n'
                 'Performing the field operations on the CPU.' )
             self.use_cuda = False
+        self.data_is_on_gpu = False # Data is initialized on CPU
 
         # Register the current correction type
         if current_correction in ['curl-free', 'cross-deposition']:
@@ -219,6 +220,7 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.interp[m].send_fields_to_gpu()
                 self.spect[m].send_fields_to_gpu()
+            self.data_is_on_gpu = True
 
     def receive_fields_from_gpu( self ):
         """
@@ -231,6 +233,7 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.interp[m].receive_fields_from_gpu()
                 self.spect[m].receive_fields_from_gpu()
+            self.data_is_on_gpu = False
 
     def push(self, use_true_rho=False, check_exchanges=False):
         """

--- a/fbpic/fields/interpolation_grid.py
+++ b/fbpic/fields/interpolation_grid.py
@@ -6,9 +6,10 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the InterpolationGrid class.
 """
 import numpy as np
-from numba import cuda
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
     from .cuda_methods import \
@@ -98,7 +99,7 @@ class InterpolationGrid(object) :
 
         # Replace the invvol array by an array on the GPU, when using cuda
         if self.use_cuda :
-            self.d_invvol = cuda.to_device( self.invvol )
+            self.d_invvol = cupy.asarray( self.invvol )
 
     @property
     def z(self):
@@ -117,21 +118,21 @@ class InterpolationGrid(object) :
         After this function is called, the array attributes
         point to GPU arrays.
         """
-        self.Er = cuda.to_device( self.Er )
-        self.Et = cuda.to_device( self.Et )
-        self.Ez = cuda.to_device( self.Ez )
-        self.Br = cuda.to_device( self.Br )
-        self.Bt = cuda.to_device( self.Bt )
-        self.Bz = cuda.to_device( self.Bz )
-        self.Jr = cuda.to_device( self.Jr )
-        self.Jt = cuda.to_device( self.Jt )
-        self.Jz = cuda.to_device( self.Jz )
-        self.rho = cuda.to_device( self.rho )
+        self.Er = cupy.asarray( self.Er )
+        self.Et = cupy.asarray( self.Et )
+        self.Ez = cupy.asarray( self.Ez )
+        self.Br = cupy.asarray( self.Br )
+        self.Bt = cupy.asarray( self.Bt )
+        self.Bz = cupy.asarray( self.Bz )
+        self.Jr = cupy.asarray( self.Jr )
+        self.Jt = cupy.asarray( self.Jt )
+        self.Jz = cupy.asarray( self.Jz )
+        self.rho = cupy.asarray( self.rho )
         if self.use_pml:
-            self.Er_pml = cuda.to_device( self.Er_pml )
-            self.Et_pml = cuda.to_device( self.Et_pml )
-            self.Br_pml = cuda.to_device( self.Br_pml )
-            self.Bt_pml = cuda.to_device( self.Bt_pml )
+            self.Er_pml = cupy.asarray( self.Er_pml )
+            self.Et_pml = cupy.asarray( self.Et_pml )
+            self.Br_pml = cupy.asarray( self.Br_pml )
+            self.Bt_pml = cupy.asarray( self.Bt_pml )
 
     def receive_fields_from_gpu( self ):
         """
@@ -140,21 +141,21 @@ class InterpolationGrid(object) :
         After this function is called, the array attributes
         are accessible by the CPU again.
         """
-        self.Er = self.Er.copy_to_host()
-        self.Et = self.Et.copy_to_host()
-        self.Ez = self.Ez.copy_to_host()
-        self.Br = self.Br.copy_to_host()
-        self.Bt = self.Bt.copy_to_host()
-        self.Bz = self.Bz.copy_to_host()
-        self.Jr = self.Jr.copy_to_host()
-        self.Jt = self.Jt.copy_to_host()
-        self.Jz = self.Jz.copy_to_host()
-        self.rho = self.rho.copy_to_host()
+        self.Er = self.Er.get()
+        self.Et = self.Et.get()
+        self.Ez = self.Ez.get()
+        self.Br = self.Br.get()
+        self.Bt = self.Bt.get()
+        self.Bz = self.Bz.get()
+        self.Jr = self.Jr.get()
+        self.Jt = self.Jt.get()
+        self.Jz = self.Jz.get()
+        self.rho = self.rho.get()
         if self.use_pml:
-            self.Er_pml = self.Er_pml.copy_to_host()
-            self.Et_pml = self.Et_pml.copy_to_host()
-            self.Br_pml = self.Br_pml.copy_to_host()
-            self.Bt_pml = self.Bt_pml.copy_to_host()
+            self.Er_pml = self.Er_pml.get()
+            self.Et_pml = self.Et_pml.get()
+            self.Br_pml = self.Br_pml.get()
+            self.Bt_pml = self.Bt_pml.get()
 
     def erase( self, fieldtype ):
         """

--- a/fbpic/fields/psatd_coefs.py
+++ b/fbpic/fields/psatd_coefs.py
@@ -7,7 +7,9 @@ It defines the PsatdCoeffs class.
 """
 import numpy as np
 from scipy.constants import c, mu_0, epsilon_0
-from numba import cuda
+from fbpic.utils.cuda import cupy_installed
+if cupy_installed:
+    from fbpic.utils.cuda import cupy
 
 
 class PsatdCoeffs(object) :
@@ -162,14 +164,14 @@ class PsatdCoeffs(object) :
 
         # Replace these array by arrays on the GPU, when using cuda
         if use_cuda:
-            self.d_C = cuda.to_device(self.C)
-            self.d_S_w = cuda.to_device(self.S_w)
-            self.d_j_coef = cuda.to_device(self.j_coef)
-            self.d_rho_prev_coef = cuda.to_device(self.rho_prev_coef)
-            self.d_rho_next_coef = cuda.to_device(self.rho_next_coef)
+            self.d_C = cupy.asarray(self.C)
+            self.d_S_w = cupy.asarray(self.S_w)
+            self.d_j_coef = cupy.asarray(self.j_coef)
+            self.d_rho_prev_coef = cupy.asarray(self.rho_prev_coef)
+            self.d_rho_next_coef = cupy.asarray(self.rho_next_coef)
             if self.V is not None:
                 # Variables which are specific to the Galilean/comoving scheme
-                self.d_T_eb = cuda.to_device(self.T_eb)
-                self.d_T_cc = cuda.to_device(self.T_cc)
-                self.d_T_rho = cuda.to_device(self.T_rho)
-                self.d_j_corr_coef = cuda.to_device(self.j_corr_coef)
+                self.d_T_eb = cupy.asarray(self.T_eb)
+                self.d_T_cc = cupy.asarray(self.T_cc)
+                self.d_T_rho = cupy.asarray(self.T_rho)
+                self.d_j_corr_coef = cupy.asarray(self.j_corr_coef)

--- a/fbpic/fields/spectral_grid.py
+++ b/fbpic/fields/spectral_grid.py
@@ -15,10 +15,12 @@ from .numba_methods import numba_push_eb_standard, numba_push_eb_comoving, \
     numba_correct_currents_crossdeposition_comoving, \
     numba_filter_scalar, numba_filter_vector
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
-    from .cuda_methods import cuda, \
+    from .cuda_methods import \
     cuda_correct_currents_curlfree_standard, \
     cuda_correct_currents_crossdeposition_standard, \
     cuda_correct_currents_curlfree_comoving, \
@@ -127,13 +129,13 @@ class SpectralGrid(object) :
 
         # Transfer the auxiliary arrays on the GPU
         if self.use_cuda :
-            self.d_filter_array_z = cuda.to_device( self.filter_array_z )
-            self.d_filter_array_r = cuda.to_device( self.filter_array_r )
-            self.d_kz = cuda.to_device( self.kz )
-            self.d_kr = cuda.to_device( self.kr )
-            self.d_field_shift = cuda.to_device( self.field_shift )
+            self.d_filter_array_z = cupy.asarray( self.filter_array_z )
+            self.d_filter_array_r = cupy.asarray( self.filter_array_r )
+            self.d_kz = cupy.asarray( self.kz )
+            self.d_kr = cupy.asarray( self.kr )
+            self.d_field_shift = cupy.asarray( self.field_shift )
             if current_correction == 'curl-free':
-                self.d_inv_k2 = cuda.to_device( self.inv_k2 )
+                self.d_inv_k2 = cupy.asarray( self.inv_k2 )
 
 
     def send_fields_to_gpu( self ):
@@ -143,26 +145,26 @@ class SpectralGrid(object) :
         After this function is called, the array attributes
         point to GPU arrays.
         """
-        self.Ep = cuda.to_device( self.Ep )
-        self.Em = cuda.to_device( self.Em )
-        self.Ez = cuda.to_device( self.Ez )
-        self.Bp = cuda.to_device( self.Bp )
-        self.Bm = cuda.to_device( self.Bm )
-        self.Bz = cuda.to_device( self.Bz )
-        self.Jp = cuda.to_device( self.Jp )
-        self.Jm = cuda.to_device( self.Jm )
-        self.Jz = cuda.to_device( self.Jz )
-        self.rho_prev = cuda.to_device( self.rho_prev )
-        self.rho_next = cuda.to_device( self.rho_next )
+        self.Ep = cupy.asarray( self.Ep )
+        self.Em = cupy.asarray( self.Em )
+        self.Ez = cupy.asarray( self.Ez )
+        self.Bp = cupy.asarray( self.Bp )
+        self.Bm = cupy.asarray( self.Bm )
+        self.Bz = cupy.asarray( self.Bz )
+        self.Jp = cupy.asarray( self.Jp )
+        self.Jm = cupy.asarray( self.Jm )
+        self.Jz = cupy.asarray( self.Jz )
+        self.rho_prev = cupy.asarray( self.rho_prev )
+        self.rho_next = cupy.asarray( self.rho_next )
         if self.use_pml:
-            self.Ep_pml = cuda.to_device( self.Ep_pml )
-            self.Em_pml = cuda.to_device( self.Em_pml )
-            self.Bp_pml = cuda.to_device( self.Bp_pml )
-            self.Bm_pml = cuda.to_device( self.Bm_pml )
+            self.Ep_pml = cupy.asarray( self.Ep_pml )
+            self.Em_pml = cupy.asarray( self.Em_pml )
+            self.Bp_pml = cupy.asarray( self.Bp_pml )
+            self.Bm_pml = cupy.asarray( self.Bm_pml )
         # Only when using the cross-deposition
         if hasattr( self, 'rho_next_z' ):
-            self.rho_next_z = cuda.to_device( self.rho_next_z )
-            self.rho_next_xy = cuda.to_device( self.rho_next_xy )
+            self.rho_next_z = cupy.asarray( self.rho_next_z )
+            self.rho_next_xy = cupy.asarray( self.rho_next_xy )
 
 
     def receive_fields_from_gpu( self ):
@@ -172,26 +174,26 @@ class SpectralGrid(object) :
         After this function is called, the array attributes
         are accessible by the CPU again.
         """
-        self.Ep = self.Ep.copy_to_host()
-        self.Em = self.Em.copy_to_host()
-        self.Ez = self.Ez.copy_to_host()
-        self.Bp = self.Bp.copy_to_host()
-        self.Bm = self.Bm.copy_to_host()
-        self.Bz = self.Bz.copy_to_host()
-        self.Jp = self.Jp.copy_to_host()
-        self.Jm = self.Jm.copy_to_host()
-        self.Jz = self.Jz.copy_to_host()
+        self.Ep = self.Ep.get()
+        self.Em = self.Em.get()
+        self.Ez = self.Ez.get()
+        self.Bp = self.Bp.get()
+        self.Bm = self.Bm.get()
+        self.Bz = self.Bz.get()
+        self.Jp = self.Jp.get()
+        self.Jm = self.Jm.get()
+        self.Jz = self.Jz.get()
         if self.use_pml:
-            self.Ep_pml = self.Ep_pml.copy_to_host()
-            self.Em_pml = self.Em_pml.copy_to_host()
-            self.Bp_pml = self.Bp_pml.copy_to_host()
-            self.Bm_pml = self.Bm_pml.copy_to_host()
-        self.rho_prev = self.rho_prev.copy_to_host()
-        self.rho_next = self.rho_next.copy_to_host()
+            self.Ep_pml = self.Ep_pml.get()
+            self.Em_pml = self.Em_pml.get()
+            self.Bp_pml = self.Bp_pml.get()
+            self.Bm_pml = self.Bm_pml.get()
+        self.rho_prev = self.rho_prev.get()
+        self.rho_next = self.rho_next.get()
         # Only when using the cross-deposition
         if hasattr( self, 'rho_next_z' ):
-            self.rho_next_z = self.rho_next_z.copy_to_host()
-            self.rho_next_xy = self.rho_next_xy.copy_to_host()
+            self.rho_next_z = self.rho_next_z.get()
+            self.rho_next_xy = self.rho_next_xy.get()
 
 
     def correct_currents (self, dt, ps, current_correction ):

--- a/fbpic/fields/spectral_transform/cuda_methods.py
+++ b/fbpic/fields/spectral_transform/cuda_methods.py
@@ -59,58 +59,6 @@ def cuda_copy_2dR_to_2dC( array_in, array_out ) :
     if (iz < Nz) and (ir < Nr) :
         array_out[iz, ir] = array_in[iz, ir] + 1.j*array_in[iz+Nz, ir]
 
-@cuda.jit
-def cuda_copy_2d_to_1d( array_2d, array_1d ) :
-    """
-    Copy array_2d to array_1d, so that the first axis of array_2d
-    is contiguous in array_1d
-
-    This is typically done before using the cuFFT API,
-    which requires 1d arrays to do FFT in only one dimension.
-
-    Parameters :
-    ------------
-    array_2d : 2darray of complexs
-        Array of shape (Nz, Nr)
-
-    array_1d : 1d array of complexs
-        Array of shape (Nz*Nr,)
-    """
-
-    # Set up cuda grid
-    iz, ir = cuda.grid(2)
-
-    # Copy from array_2d to array_1d
-    if (iz < array_2d.shape[0]) and (ir < array_2d.shape[1]) :
-        i = iz + array_2d.shape[0]*ir
-        array_1d[i] = array_2d[iz, ir]
-
-@cuda.jit
-def cuda_copy_1d_to_2d( array_1d, array_2d ) :
-    """
-    Copy array_1d to array_2d, so that the first axis of array_2d
-    is contiguous in array_1d
-
-    This is typically done after using the cuFFT API,
-    since the the output of cuFFT is a 1d array
-
-    Parameters :
-    ------------
-    array_2d : 2darray of complexs
-        Array of shape (Nz, Nr)
-
-    array_1d : 1d array of complexs
-        Array of shape (Nz*Nr,)
-    """
-
-    # Set up cuda grid
-    iz, ir = cuda.grid(2)
-
-    # Copy from array_1d to array_2d
-    if (iz < array_2d.shape[0]) and (ir < array_2d.shape[1]) :
-        i = iz + array_2d.shape[0]*ir
-        array_2d[iz, ir] = array_1d[i]
-
 # ----------------------------------------------------
 # Functions that combine components in spectral space
 # ----------------------------------------------------

--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -16,7 +16,7 @@ from scipy.special import jn, jn_zeros
 from fbpic.utils.cuda import cuda_installed, cupy_installed
 from .numba_methods import numba_copy_2dC_to_2dR, numba_copy_2dR_to_2dC
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d, cuda_gpu_model
+    from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda_gpu_model
     from .cuda_methods import cuda_copy_2dC_to_2dR, cuda_copy_2dR_to_2dC
 if cupy_installed:
     import cupy
@@ -124,8 +124,8 @@ class DHT(object):
 
         # Copy the matrices to the GPU if needed
         if self.use_cuda:
-            self.d_M = cuda.to_device( self.M )
-            self.d_invM = cuda.to_device( self.invM )
+            self.d_M = cupy.asarray( self.M )
+            self.d_invM = cupy.asarray( self.invM )
 
         # Initialize buffer arrays to store the complex Nz x Nr grid
         # as a real 2Nz x Nr grid, before performing the matrix product
@@ -139,8 +139,8 @@ class DHT(object):
         else:
             # Initialize real buffer arrays on the GPU
             zero_array = np.zeros((2*Nz, Nr), dtype=np.float64)
-            self.d_in = cuda.to_device( zero_array )
-            self.d_out = cuda.to_device( zero_array )
+            self.d_in = cupy.asarray( zero_array )
+            self.d_out = cupy.asarray( zero_array )
             # Initialize cuBLAS
             self.blas = device.get_cublas_handle()
             # Set optimal number of CUDA threads per block
@@ -191,9 +191,9 @@ class DHT(object):
             cuda_copy_2dC_to_2dR[self.dim_grid, self.dim_block]( F, self.d_in )
             # Call cuBLAS gemm kernel
             cublas.dgemm(self.blas, 0, 0, self.Nr, 2*self.Nz, self.Nr,
-                         1, cupy.asarray(self.d_M).data.ptr, self.Nr,
-                            cupy.asarray(self.d_in).data.ptr, self.Nr,
-                         0, cupy.asarray(self.d_out).data.ptr, self.Nr)
+                         1, self.d_M.data.ptr, self.Nr,
+                            self.d_in.data.ptr, self.Nr,
+                         0, self.d_out.data.ptr, self.Nr)
             # Convert F-order, real `d_out` to the C-order, complex `G`
             cuda_copy_2dR_to_2dC[self.dim_grid, self.dim_block]( self.d_out, G )
         else:
@@ -222,9 +222,9 @@ class DHT(object):
             cuda_copy_2dC_to_2dR[self.dim_grid, self.dim_block](G, self.d_in )
             # Call cuBLAS gemm kernel
             cublas.dgemm(self.blas, 0, 0, self.Nr, 2*self.Nz, self.Nr,
-                         1, cupy.asarray(self.d_invM).data.ptr, self.Nr,
-                            cupy.asarray(self.d_in).data.ptr, self.Nr,
-                         0, cupy.asarray(self.d_out).data.ptr, self.Nr)
+                         1, self.d_invM.data.ptr, self.Nr,
+                            self.d_in.data.ptr, self.Nr,
+                         0, self.d_out.data.ptr, self.Nr)
             # Convert the F-order d_out array to the C-order F array
             cuda_copy_2dR_to_2dC[self.dim_grid, self.dim_block]( self.d_out, F )
         else:

--- a/fbpic/fields/spectral_transform/spectral_transformer.py
+++ b/fbpic/fields/spectral_transform/spectral_transformer.py
@@ -12,7 +12,9 @@ from .fourier import FFT
 
 from .numba_methods import numba_rt_to_pm, numba_pm_to_rt
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed, cuda
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
     from .cuda_methods import cuda_rt_to_pm, cuda_pm_to_rt
@@ -72,9 +74,9 @@ class SpectralTransformer(object) :
 
         # Initialize the spectral buffers
         if self.use_cuda:
-            self.spect_buffer_r = cuda.device_array(
+            self.spect_buffer_r = cupy.empty(
                 (Nz, Nr), dtype=np.complex128)
-            self.spect_buffer_t = cuda.device_array(
+            self.spect_buffer_t = cupy.empty(
                 (Nz, Nr), dtype=np.complex128)
         else:
             # Initialize the spectral buffers

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -13,7 +13,9 @@ from fbpic.particles.utilities.utility_methods import weights
 from fbpic.particles.deposition.numba_methods import deposit_field_numba
 
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
@@ -168,10 +170,10 @@ class LaserAntenna( object ):
         self.Jt_buffer = np.empty( (Nm, 2, Nr_grid), dtype='complex' )
         self.Jz_buffer = np.empty( (Nm, 2, Nr_grid), dtype='complex' )
         if cuda_installed:
-            self.d_rho_buffer = cuda.device_array_like( self.rho_buffer )
-            self.d_Jr_buffer = cuda.device_array_like( self.Jr_buffer )
-            self.d_Jt_buffer = cuda.device_array_like( self.Jt_buffer )
-            self.d_Jz_buffer = cuda.device_array_like( self.Jz_buffer )
+            self.d_rho_buffer = cupy.empty_like( self.rho_buffer )
+            self.d_Jr_buffer = cupy.empty_like( self.Jr_buffer )
+            self.d_Jt_buffer = cupy.empty_like( self.Jt_buffer )
+            self.d_Jz_buffer = cupy.empty_like( self.Jz_buffer )
 
     def update_current_rank(self, comm):
         """
@@ -445,7 +447,7 @@ class LaserAntenna( object ):
         else:
             # The large-size array rho is on the GPU
             # Copy the small-size buffer to the GPU
-            cuda.to_device( self.rho_buffer, to=self.d_rho_buffer )
+            cupy.asarray( self.rho_buffer, to=self.d_rho_buffer )
             # On the GPU: add the small-size buffers to the large-size array
             dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( grid[0].Nr, TPB=64 )
             for m in range( Nm ):
@@ -477,9 +479,9 @@ class LaserAntenna( object ):
         else:
             # The large-size arrays for J are on the GPU
             # Copy the small-size buffers to the GPU
-            cuda.to_device( self.Jr_buffer, to=self.d_Jr_buffer )
-            cuda.to_device( self.Jt_buffer, to=self.d_Jt_buffer )
-            cuda.to_device( self.Jz_buffer, to=self.d_Jz_buffer )
+            cupy.asarray( self.Jr_buffer, to=self.d_Jr_buffer )
+            cupy.asarray( self.Jt_buffer, to=self.d_Jt_buffer )
+            cupy.asarray( self.Jz_buffer, to=self.d_Jz_buffer )
             # On the GPU: add the small-size buffers to the large-size array
             dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( grid[0].Nr, TPB=64 )
             for m in range( Nm ):

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -223,21 +223,18 @@ class Simulation(object):
                     'In order to run on GPUs, FBPIC version 0.13 and later \n'
                     'require the `cupy` package.\n'
                     'See the FBPIC documentation in order to install cupy.')
-            elif (cupy_major_version >= 7 and numba_minor_version < 46):
+            elif cupy_major_version < 7:
                 raise RuntimeError(
-                    'You are using cupy version %d.\nFor compatibility, '
-                    'you need to install numba 0.46 or later.\n'
-                    '(Your current version is numba 0.%d.)\n'
-                    'e.g. with `conda uninstall numba; conda install numba`.'
-                    %(cupy_major_version,numba_minor_version))
-            elif (cupy_major_version < 7 and numba_minor_version >= 46):
+                    'In order to run on GPUs, FBPIC version 0.15 and later \n'
+                    'require `cupy` version 7 (or later).\n(The `cupy` version'
+                    ' on your current system is %d.)\n Please install the '
+                    'latest version of `cupy`.' %cupy_major_version)
+            elif numba_minor_version < 46:
                 raise RuntimeError(
-                    'You are using numba version 0.%d.\nFor compatibility, '
-                    'you need to install cupy 7 or later.\n'
-                    '(Your current version is cupy %d.)\n'
-                    'e.g. with `pip install --upgrade cupy-cudaXXX`\n'
-                    'where `XXX` should be replaced by your cuda version.'
-                    %(numba_minor_version,cupy_major_version))
+                    'In order to run on GPUs, FBPIC version 0.15 and later \n'
+                    'require `numba` version 0.46 (or later).\n(The `numba` '
+                    'version on your current system is 0.%d.)\n Please install'
+                    ' the latest version of `numba`.' %numba_minor_version)
         # CPU multi-threading
         self.use_threading = threading_enabled
         if self.use_threading:

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -17,7 +17,9 @@ from scipy.constants import c
 from .field_diag import FieldDiagnostic
 
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
@@ -420,7 +422,7 @@ class LabSnapshot:
         if fld.use_cuda is False:
             self.slice_array = np.empty( data_shape )
         else:
-            self.slice_array = cuda.device_array( data_shape )
+            self.slice_array = cupy.empty( data_shape )
 
     def update_current_output_positions( self, t_boost, inv_gamma, inv_beta ):
         """
@@ -471,7 +473,7 @@ class LabSnapshot:
             self.buffered_slices.append( self.slice_array.copy() )
         # or copy from the GPU
         else:
-            self.buffered_slices.append( self.slice_array.copy_to_host() )
+            self.buffered_slices.append( self.slice_array.get() )
 
     def compact_slices(self):
         """
@@ -752,10 +754,10 @@ if cuda_installed:
         Sz: float
             Interpolation shape factor used at iz
 
-        slice_arr: cuda.device_array
+        slice_arr: cupy.empty
             Array of floats of shape (10, 2*Nm-1, Nr)
 
-        Er, Et, etc...: cuda.device_array
+        Er, Et, etc...: cupy.empty
             Array of complexs of shape (Nz, Nr), for the azimuthal mode m
 
         m: int

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -685,14 +685,14 @@ class ParticleCatcher:
             elif z_cell_curr > Nz:
                 pref_sum_curr = species.Ntot
             else:
-                pref_sum_curr = pref_sum.getitem( z_cell_curr*(Nr+1) - 1 )
+                pref_sum_curr = int(pref_sum[ z_cell_curr*(Nr+1) - 1 ])
             z_cell_prev = iz_prev + pref_sum_shift
             if z_cell_prev <= 0:
                 pref_sum_prev = 0
             elif z_cell_prev > Nz:
                 pref_sum_prev = species.Ntot
             else:
-                pref_sum_prev = pref_sum.getitem( z_cell_prev*(Nr+1) - 1 )
+                pref_sum_prev = int(pref_sum[ z_cell_prev*(Nr+1) - 1 ])
             # Calculate number of particles in this area (N_area)
             N_area = pref_sum_prev - pref_sum_curr
             # Check if there are particles to extract

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -15,9 +15,9 @@ from .particle_diag import ParticleDiagnostic
 from fbpic.utils.mpi import comm
 
 # Check if CUDA is available, then import CUDA
-from fbpic.utils.cuda import cuda_installed
-if cuda_installed:
-        from fbpic.utils.cuda import cuda
+from fbpic.utils.cuda import cupy_installed
+if cupy_installed:
+    import cupy
 
 def set_periodic_checkpoint( sim, period, checkpoint_dir='./checkpoints' ):
     """
@@ -360,8 +360,8 @@ def load_species( species, name, ts, iteration, comm, openpmd_viewer_version ):
     # Sorting arrays
     if species.use_cuda:
         # cell_idx and sorted_idx always stay on GPU
-        species.cell_idx = cuda.device_array( Ntot, dtype=np.int32)
-        species.sorted_idx = cuda.device_array( Ntot, dtype=np.intp)
+        species.cell_idx = cupy.empty( Ntot, dtype=np.int32)
+        species.sorted_idx = cupy.empty( Ntot, dtype=np.intp)
         # sorting buffers are initialized on CPU
         # (because they are swapped with other particle arrays during sorting)
         species.sorting_buffer = np.empty( Ntot, dtype=np.float64)

--- a/fbpic/openpmd_diag/cuda_methods.py
+++ b/fbpic/openpmd_diag/cuda_methods.py
@@ -6,7 +6,7 @@ This files contains cuda methods that are used in the boosted-frame
 diagnostics
 """
 import numpy as np
-from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+from fbpic.utils.cuda import cupy, cuda, cuda_tpb_bpg_1d
 
 def extract_slice_from_gpu( pref_sum_curr, N_area, species ):
     """
@@ -32,34 +32,34 @@ def extract_slice_from_gpu( pref_sum_curr, N_area, species ):
     # Call kernel that extracts particles from GPU
     dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d(N_area)
     # - General particle quantities
-    part_data = cuda.device_array( (8, N_area), dtype=np.float64 )
+    part_data = cupy.empty( (8, N_area), dtype=np.float64 )
     extract_particles_from_gpu[dim_grid_1d, dim_block_1d]( pref_sum_curr,
          species.x, species.y, species.z, species.ux, species.uy, species.uz,
          species.w, species.inv_gamma, part_data )
     # - Optional particle arrays
     if species.tracker is not None:
-        selected_particle_id = cuda.device_array( (N_area,), dtype=np.uint64 )
+        selected_particle_id = cupy.empty( (N_area,), dtype=np.uint64 )
         extract_array_from_gpu[dim_grid_1d, dim_block_1d](
             pref_sum_curr, species.tracker.id, selected_particle_id )
     if species.ionizer is not None:
-        selected_particle_charge = cuda.device_array( (N_area,), dtype=np.uint64 )
+        selected_particle_charge = cupy.empty( (N_area,), dtype=np.uint64 )
         extract_array_from_gpu[dim_grid_1d, dim_block_1d]( pref_sum_curr,
           species.ionizer.ionization_level, selected_particle_charge )
-        selected_particle_weight = cuda.device_array( (N_area,), dtype=np.float64 )
+        selected_particle_weight = cupy.empty( (N_area,), dtype=np.float64 )
         extract_array_from_gpu[dim_grid_1d, dim_block_1d]( pref_sum_curr,
           species.ionizer.w_times_level, selected_particle_weight )
 
     # Copy GPU arrays to the host
-    part_data = part_data.copy_to_host()
+    part_data = part_data.get()
     particle_data = { 'x':part_data[0], 'y':part_data[1], 'z':part_data[2],
         'ux':part_data[3], 'uy':part_data[4], 'uz':part_data[5],
         'w':part_data[6], 'inv_gamma':part_data[7] }
     if species.tracker is not None:
-        particle_data['id'] = selected_particle_id.copy_to_host()
+        particle_data['id'] = selected_particle_id.get()
     if species.ionizer is not None:
-        particle_data['charge'] = selected_particle_charge.copy_to_host()
+        particle_data['charge'] = selected_particle_charge.get()
         # Replace particle weight
-        particle_data['w'] = selected_particle_weight.copy_to_host()
+        particle_data['w'] = selected_particle_weight.get()
 
     # Return the data as dictionary
     return( particle_data )

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -9,7 +9,9 @@ It defines a number of methods that are useful for elementary processes
 import numpy as np
 from fbpic.utils.threading import njit_parallel, prange
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
@@ -22,7 +24,7 @@ def allocate_empty( shape, use_cuda, dtype ):
         # Convert single scalar to tuple
         shape = (shape,)
     if use_cuda:
-        return( cuda.device_array( shape, dtype=dtype ) )
+        return( cupy.empty( shape, dtype=dtype ) )
     else:
         return( np.empty( shape, dtype=dtype ) )
 
@@ -102,12 +104,12 @@ def reallocate_and_copy_old( species, use_cuda, old_Ntot, new_Ntot ):
 
     # Allocate the auxiliary arrays for GPU
     if use_cuda:
-        species.cell_idx = cuda.device_array((new_Ntot,), dtype=np.int32)
-        species.sorted_idx = cuda.device_array((new_Ntot,), dtype=np.intp)
-        species.sorting_buffer = cuda.device_array((new_Ntot,), dtype=np.float64)
+        species.cell_idx = cupy.empty((new_Ntot,), dtype=np.int32)
+        species.sorted_idx = cupy.empty((new_Ntot,), dtype=np.intp)
+        species.sorting_buffer = cupy.empty((new_Ntot,), dtype=np.float64)
         if species.n_integer_quantities > 0:
             species.int_sorting_buffer = \
-                cuda.device_array( (new_Ntot,), dtype=np.uint64 )
+                cupy.empty( (new_Ntot,), dtype=np.uint64 )
 
     # Modify the total number of particles
     species.Ntot = new_Ntot

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -146,6 +146,7 @@ class Particles(object) :
                 'Cuda not available for the particles.\n'
                 'Performing the particle operations on the CPU.')
             self.use_cuda = False
+        self.data_is_on_gpu = False # Data is initialized on the CPU
 
         # Generate evenly-spaced particles
         Ntot, x, y, z, ux, uy, uz, inv_gamma, w = generate_evenly_spaced(
@@ -277,6 +278,9 @@ class Particles(object) :
             if self.ionizer is not None:
                 self.ionizer.send_to_gpu()
 
+            # Modify flag accordingly
+            self.data_is_on_gpu = True
+
     def receive_particles_from_gpu( self ):
         """
         Receive the particles from the GPU.
@@ -315,6 +319,9 @@ class Particles(object) :
             # Copy the ionization data
             if self.ionizer is not None:
                 self.ionizer.receive_from_gpu()
+
+            # Modify flag accordingly
+            self.data_is_on_gpu = False
 
     def generate_continuously_injected_particles( self, time ):
         """

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -28,10 +28,12 @@ from .deposition.threading_methods import \
 # Check if threading is enabled
 from fbpic.utils.threading import nthreads, get_chunk_indices
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     # Load the CUDA methods
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, cuda_gpu_model
+    from fbpic.utils.cuda import cuda_tpb_bpg_1d, cuda_gpu_model
     from .push.cuda_methods import push_p_gpu, push_p_ioniz_gpu, \
                                 push_p_after_plane_gpu, push_x_gpu
     from .deposition.cuda_methods import deposit_rho_gpu_linear, \
@@ -215,9 +217,9 @@ class Particles(object) :
             # Allocate arrays for the particles sorting when using CUDA
             # Most required arrays always stay on GPU
             Nz, Nr = grid_shape
-            self.cell_idx = cuda.device_array( Ntot, dtype=np.int32)
-            self.sorted_idx = cuda.device_array( Ntot, dtype=np.intp)
-            self.prefix_sum = cuda.device_array( Nz*(Nr+1), dtype=np.int32 )
+            self.cell_idx = cupy.empty( Ntot, dtype=np.int32)
+            self.sorted_idx = cupy.empty( Ntot, dtype=np.intp)
+            self.prefix_sum = cupy.empty( Nz*(Nr+1), dtype=np.int32 )
             # sorting buffers are initialized on CPU like other particle arrays
             # (because they are swapped with these arrays during sorting)
             self.sorting_buffer = np.empty( Ntot, dtype=np.float64)
@@ -245,28 +247,28 @@ class Particles(object) :
         if self.use_cuda:
             # Send positions, velocities, inverse gamma and weights
             # to the GPU (CUDA)
-            self.x = cuda.to_device(self.x)
-            self.y = cuda.to_device(self.y)
-            self.z = cuda.to_device(self.z)
-            self.ux = cuda.to_device(self.ux)
-            self.uy = cuda.to_device(self.uy)
-            self.uz = cuda.to_device(self.uz)
-            self.inv_gamma = cuda.to_device(self.inv_gamma)
-            self.w = cuda.to_device(self.w)
+            self.x = cupy.asarray(self.x)
+            self.y = cupy.asarray(self.y)
+            self.z = cupy.asarray(self.z)
+            self.ux = cupy.asarray(self.ux)
+            self.uy = cupy.asarray(self.uy)
+            self.uz = cupy.asarray(self.uz)
+            self.inv_gamma = cupy.asarray(self.inv_gamma)
+            self.w = cupy.asarray(self.w)
 
             # Copy arrays on the GPU for the field
             # gathering and the particle push
-            self.Ex = cuda.to_device(self.Ex)
-            self.Ey = cuda.to_device(self.Ey)
-            self.Ez = cuda.to_device(self.Ez)
-            self.Bx = cuda.to_device(self.Bx)
-            self.By = cuda.to_device(self.By)
-            self.Bz = cuda.to_device(self.Bz)
+            self.Ex = cupy.asarray(self.Ex)
+            self.Ey = cupy.asarray(self.Ey)
+            self.Ez = cupy.asarray(self.Ez)
+            self.Bx = cupy.asarray(self.Bx)
+            self.By = cupy.asarray(self.By)
+            self.Bz = cupy.asarray(self.Bz)
 
             # Copy sorting buffers on the GPU
-            self.sorting_buffer = cuda.to_device(self.sorting_buffer)
+            self.sorting_buffer = cupy.asarray(self.sorting_buffer)
             if self.n_integer_quantities > 0:
-                self.int_sorting_buffer = cuda.to_device(self.int_sorting_buffer)
+                self.int_sorting_buffer = cupy.asarray(self.int_sorting_buffer)
 
             # Copy particle tracker data
             if self.tracker is not None:
@@ -283,29 +285,29 @@ class Particles(object) :
         if self.use_cuda:
             # Copy the positions, velocities, inverse gamma and weights
             # to the GPU (CUDA)
-            self.x = self.x.copy_to_host()
-            self.y = self.y.copy_to_host()
-            self.z = self.z.copy_to_host()
-            self.ux = self.ux.copy_to_host()
-            self.uy = self.uy.copy_to_host()
-            self.uz = self.uz.copy_to_host()
-            self.inv_gamma = self.inv_gamma.copy_to_host()
-            self.w = self.w.copy_to_host()
+            self.x = self.x.get()
+            self.y = self.y.get()
+            self.z = self.z.get()
+            self.ux = self.ux.get()
+            self.uy = self.uy.get()
+            self.uz = self.uz.get()
+            self.inv_gamma = self.inv_gamma.get()
+            self.w = self.w.get()
 
             # Copy arrays on the CPU for the field
             # gathering and the particle push
-            self.Ex = self.Ex.copy_to_host()
-            self.Ey = self.Ey.copy_to_host()
-            self.Ez = self.Ez.copy_to_host()
-            self.Bx = self.Bx.copy_to_host()
-            self.By = self.By.copy_to_host()
-            self.Bz = self.Bz.copy_to_host()
+            self.Ex = self.Ex.get()
+            self.Ey = self.Ey.get()
+            self.Ez = self.Ez.get()
+            self.Bx = self.Bx.get()
+            self.By = self.By.get()
+            self.Bz = self.Bz.get()
 
             # Copy arrays on the CPU
             # that represent the sorting arrays
-            self.sorting_buffer = self.sorting_buffer.copy_to_host()
+            self.sorting_buffer = self.sorting_buffer.get()
             if self.n_integer_quantities > 0:
-                self.int_sorting_buffer = self.int_sorting_buffer.copy_to_host()
+                self.int_sorting_buffer = self.int_sorting_buffer.get()
 
             # Copy particle tracker data
             if self.tracker is not None:

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -45,7 +45,7 @@ if cuda_installed:
         gather_field_gpu_cubic
     from .gathering.cuda_methods_one_mode import erase_eb_cuda, \
         gather_field_gpu_linear_one_mode, gather_field_gpu_cubic_one_mode
-    from .utilities.cuda_sorting import write_sorting_buffer, \
+    from .utilities.cuda_sorting import \
         get_cell_idx_per_particle, sort_particles_per_cell, \
         prefill_prefix_sum, incl_prefix_sum
 
@@ -502,8 +502,6 @@ class Particles(object) :
         arrays. A particle buffer is used to temporarily store
         the rearranged data.
         """
-        # Get the threads per block and the blocks per grid
-        dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( self.Ntot )
         # Iterate over (float) particle attributes
         attr_list = [ (self,'x'), (self,'y'), (self,'z'), \
                         (self,'ux'), (self,'uy'), (self,'uz'), \
@@ -517,8 +515,8 @@ class Particles(object) :
             # Get particle GPU array
             particle_array = getattr( attr[0], attr[1] )
             # Write particle data to particle buffer array while rearranging
-            write_sorting_buffer[dim_grid_1d, dim_block_1d](
-                self.sorted_idx, particle_array, self.sorting_buffer)
+            cupy.take( particle_array, self.sorted_idx,
+                       out=self.sorting_buffer )
             # Assign the particle buffer to
             # the initial particle data array
             setattr( attr[0], attr[1], self.sorting_buffer)
@@ -534,8 +532,8 @@ class Particles(object) :
             # Get particle GPU array
             particle_array = getattr( attr[0], attr[1] )
             # Write particle data to particle buffer array while rearranging
-            write_sorting_buffer[dim_grid_1d, dim_block_1d](
-                self.sorted_idx, particle_array, self.int_sorting_buffer)
+            cupy.take( particle_array, self.sorted_idx,
+                       out=self.int_sorting_buffer )
             # Assign the particle buffer to
             # the initial particle data array
             setattr( attr[0], attr[1], self.int_sorting_buffer)

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -8,7 +8,9 @@ It defines the structure and methods associated with particle tracking.
 import numpy as np
 from numba import cuda
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
 
@@ -54,13 +56,13 @@ class ParticleTracker(object):
         """
         Transfer the tracking data from the CPU to the GPU
         """
-        self.id = cuda.to_device( self.id )
+        self.id = cupy.asarray( self.id )
 
     def receive_from_gpu(self):
         """
         Transfer the tracking data from the GPU to the CPU
         """
-        self.id = self.id.copy_to_host()
+        self.id = self.id.get()
 
     def generate_new_ids( self, N ):
         """

--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -185,26 +185,3 @@ def prefill_prefix_sum(cell_idx, prefix_sum, Ntot):
         else:
             # If this species has no particles, fill all cells with 0
             prefix_sum[i] = 0
-
-@cuda.jit
-def write_sorting_buffer(sorted_idx, val, buf):
-    """
-    Writes the values of a particle array to a buffer,
-    while rearranging them to match the sorted cell index array.
-
-    Parameters
-    ----------
-    sorted_idx : 1darray of integers
-        Represents the original index of the
-        particle before the sorting
-
-    val : 1d array of floats
-        A particle data array
-
-    buf : 1d array of floats
-        A buffer array to temporarily store the
-        sorted particle data array
-    """
-    i = cuda.grid(1)
-    if i < val.shape[0]:
-        buf[i] = val[sorted_idx[i]]

--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -8,9 +8,7 @@ It defines the particle sorting methods on the GPU using CUDA.
 from numba import cuda
 from fbpic.utils.cuda import cupy_installed
 if cupy_installed:
-    import cupy
     from cupy.cuda import thrust
-    cupy_mempool = cupy.get_default_memory_pool()
 import math
 import numpy as np
 
@@ -105,8 +103,8 @@ def sort_particles_per_cell(cell_idx, sorted_idx):
     if Ntot > 0:
         if type(cell_idx) == np.ndarray or  type(sorted_idx) == np.ndarray:
             raise ValueError("Unexpected CPU array")
-        d_cell_idx = cupy.asarray(cell_idx)
-        d_sorted_idx = cupy.asarray(sorted_idx)
+        d_cell_idx = cell_idx
+        d_sorted_idx = sorted_idx
         # `thrust.argsort` will simultaneously:
         # - find the indices `sorted_idx` that sort the initial array cell_idx
         # - sort `cell_idx` in place
@@ -119,7 +117,6 @@ def sort_particles_per_cell(cell_idx, sorted_idx):
         # arrays in its memory pool. For performance reasons, this
         # memory is not automatically released, after `argsort`
         # Here we force `cupy` to release the memory.
-        cupy_mempool.free_all_blocks()
 
 @cuda.jit
 def incl_prefix_sum(cell_idx, prefix_sum):

--- a/replace_script.py
+++ b/replace_script.py
@@ -1,0 +1,76 @@
+import re
+import glob
+
+# Find all source files
+file_list = list(glob.iglob('./fbpic/**/*.py', recursive=True)) + list(glob.iglob('./tests/**/*.py', recursive=True))
+
+# Loop over source files
+for filename in file_list:
+
+    # This file contains copies with pinned memory: handle differently
+    if filename == './fbpic/boundaries/field_buffer_handling.py':
+        continue
+    
+    # Open file
+    print(filename)
+    with open(filename) as f:
+        text = f.read()
+
+    # Remove previous conversion from cuda array to cupy array
+    text = re.sub(r'cupy\.asarray\((.*?)\)', r'\1', text)
+
+    # Replace copies to host by the cupy equivalent (`get`)
+    text = re.sub('\.copy_to_host\(\)', '.get()', text)
+    text = re.sub(r'\.copy_to_host\((\s*)(.*)(\s*)\)', r'.get(\1out=\2\3)', text)
+    
+    # Replace copies to device
+    text = re.sub(r'cuda\.to_device\((.*?)\)', r'cupy.asarray(\1)', text)
+
+    # Replace array allocation
+    text = re.sub(r'cuda\.device_array', r'cupy.empty', text)
+
+    # Remove freeing memory
+    text = re.sub(r'.*cupy_mempool.*\n', r'', text)
+
+    # Replace getitem
+    text = re.sub(r'(\S+)\.getitem\((.*)\)', r'int(\1[\2])', text)
+
+    # Fix import statements
+    if ('cupy.' in text) and re.search('import.*cupy', text) is None:
+        if re.search('if cupy_installed:', text) is not None:
+            text = re.sub(r'if cupy_installed:',
+                   r'if cupy_installed:\n    import cupy', text)
+        elif re.search('\nif cuda_installed:', text) is not None:
+            text = re.sub(r'\nif cuda_installed:',
+                   r'\nif cupy_installed:\n    import cupy\nif cuda_installed:',
+                          text, count=1)
+            text = re.sub(r'import cuda_installed', 'import cupy_installed, cuda_installed', text)
+        elif re.search('from fbpic\.utils\.cuda import (.*)cuda([^_])', text) is not None:
+
+            text = re.sub(r'from fbpic\.utils\.cuda import (.*)cuda([^_])',
+                   r'from fbpic.utils.cuda import \1cupy, cuda\2', text)
+        elif re.search('from numba import cuda', text) is not None:
+            text = re.sub(r'from numba import cuda',
+                          r'from numba import cuda\nfrom fbpic.utils.cuda import cupy_installed\nif cupy_installed:\n    from fbpic.utils.cuda import cupy', text)
+
+    if not 'cuda.' in text:
+        text = re.sub(r'from numba import cuda\n', '', text)
+        text = re.sub(r'import(.*)\, cuda([^_])',
+                      r'import\1\2', text)
+        text = re.sub(r'import(.*) cuda\, ',
+                      r'import\1 ', text)
+
+    # Hand-taylored
+    if filename.endswith('cuda_sorting.py'):
+        text = re.sub(r'.*import cupy\n', '', text)
+    if filename.endswith('compton.py'):
+        text = re.sub(r'from numba import cuda\n', '', text)
+    if filename.endswith('checkpoint_restart.py'):
+        text = re.sub(r'import(.*), cuda_installed', r'import\1', text)
+        text = re.sub(r'if cuda_installed:\n.*\n', r'', text)
+        
+    # Close file
+    with open(filename, 'w') as f:
+        f.write(text)
+
+

--- a/tests/unautomated/test_cuda_transform.py
+++ b/tests/unautomated/test_cuda_transform.py
@@ -13,6 +13,9 @@ $ python tests/test_cuda_transform.py
 import numpy as np
 from fbpic.fields.spectral_transform import SpectralTransformer
 from numba import cuda
+from fbpic.utils.cuda import cupy_installed
+if cupy_installed:
+    from fbpic.utils.cuda import cupy
 import time
 
 if __name__ == '__main__' :
@@ -26,18 +29,18 @@ if __name__ == '__main__' :
     # Initialize the random test_field
     interp_field_r = np.random.rand(Nz, Nr) + 1.j*np.random.rand(Nz, Nr)
     interp_field_t = np.random.rand(Nz, Nr) + 1.j*np.random.rand(Nz, Nr)
-    d_interp_field_r = cuda.to_device( interp_field_r )
-    d_interp_field_t = cuda.to_device( interp_field_t )
+    d_interp_field_r = cupy.asarray( interp_field_r )
+    d_interp_field_t = cupy.asarray( interp_field_t )
     # Initialize the field in spectral space
     spect_field_p = np.empty_like( interp_field_r )
     spect_field_m = np.empty_like( interp_field_t )
-    d_spect_field_p = cuda.to_device( spect_field_p )
-    d_spect_field_m = cuda.to_device( spect_field_m )
+    d_spect_field_p = cupy.asarray( spect_field_p )
+    d_spect_field_m = cupy.asarray( spect_field_m )
     # Initialize the field after back and forth transformation
     back_field_r = np.empty_like( interp_field_r )
     back_field_t = np.empty_like( interp_field_t )
-    d_back_field_r = cuda.to_device( back_field_r )
-    d_back_field_t = cuda.to_device( back_field_t )
+    d_back_field_r = cupy.asarray( back_field_r )
+    d_back_field_t = cupy.asarray( back_field_t )
 
     # ----------------
     # Scalar transform
@@ -71,8 +74,8 @@ if __name__ == '__main__' :
     print( '\n Time taken on the GPU : %.3f ms\n' %(tmin*1e3) )
     
     # Check accuracy
-    check_spect_field_p = d_spect_field_p.copy_to_host()
-    check_back_field_r = d_back_field_r.copy_to_host()
+    check_spect_field_p = d_spect_field_p.get()
+    check_back_field_r = d_back_field_r.get()
     print( 'Max error on forward transform : %e' \
       % abs(spect_field_p - check_spect_field_p).max() )
     print( 'Max error on backward transform : %e\n' \
@@ -116,10 +119,10 @@ if __name__ == '__main__' :
     print( '\n Time taken on the GPU : %.3f ms\n' %(tmin*1e3) )
     
     # Check accuracy
-    check_spect_field_p = d_spect_field_p.copy_to_host()
-    check_spect_field_m = d_spect_field_m.copy_to_host()
-    check_back_field_r = d_back_field_r.copy_to_host()
-    check_back_field_t = d_back_field_t.copy_to_host()
+    check_spect_field_p = d_spect_field_p.get()
+    check_spect_field_m = d_spect_field_m.get()
+    check_back_field_r = d_back_field_r.get()
+    check_back_field_t = d_back_field_t.get()
     print( 'Max error on forward transform : %e' \
       % ( abs(spect_field_p - check_spect_field_p).max() \
       + abs(spect_field_m - check_spect_field_m).max() ) )


### PR DESCRIPTION
# Overview

This branch tries to use `cupy` more extensively, in order to take advantage of:
- faster memory management / deallocation of arrays
- lower kernel launch overhead
compared to `numba.cuda`.

In particular, all of the arrays are now allocated with `cupy` instead of `numba.cuda`.

# List of changes

- All of the device arrays are now `cupy` arrays instead of `numba.cuda` array. In order to change this throughout the code, I wrote, committed and executed a Python script. (see the first two commits)
- On top of this, I tried to reduce kernel load overhead by avoiding some `cuda.numba` functions where possible.
(see the commits "Use cupy.take for particle rearranging", "Use Nd FFT to avoid 2d/1d copies"). There are certain more places where we could do this.
- The last-but-one commit is to avoid errors when the data is on the CPU (e.g. before we call `step`) but we already call `deposit` (e.g. when doing the initial space-charge calculation)

# Caveat

All the tests now pass on GPU, except for the laser antenna tests ; the cde for the laser antenna needs some minor synthactic changes in order to fix this.