### PR TITLE
Implement context manager to move data to GPU

### DIFF
--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -136,6 +136,7 @@ class Fields(object) :
                 'Cuda not available for the fields.\n'
                 'Performing the field operations on the CPU.' )
             self.use_cuda = False
+        self.data_is_on_gpu = False # Data is initialized on CPU
 
         # Register the current correction type
         if current_correction in ['curl-free', 'cross-deposition']:
@@ -219,6 +220,7 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.interp[m].send_fields_to_gpu()
                 self.spect[m].send_fields_to_gpu()
+            self.data_is_on_gpu = True
 
     def receive_fields_from_gpu( self ):
         """
@@ -231,6 +233,7 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.interp[m].receive_fields_from_gpu()
                 self.spect[m].receive_fields_from_gpu()
+            self.data_is_on_gpu = False
 
     def push(self, use_true_rho=False, check_exchanges=False):
         """

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -11,6 +11,7 @@ from fbpic.fields import Fields
 from fbpic.particles.elementary_process.cuda_numba_utils import \
     reallocate_and_copy_old
 from fbpic.particles.injection import BallisticBeforePlane
+from fbpic.utils.cuda import GpuMemoryManager
 import warnings
 
 
@@ -835,10 +836,12 @@ def get_space_charge_fields( sim, ptcl, direction='forward' ):
         gamma = w_gamma_sum/w_sum
 
     # Project the charge and currents onto the local subdomain
-    sim.deposit( 'rho', exchange=True, species_list=[ptcl],
-                    update_spectral=False )
-    sim.deposit( 'J', exchange=True, species_list=[ptcl],
-                    update_spectral=False )
+    # (Move data to GPU if needed, for this step)
+    with GpuMemoryManager(sim):
+        sim.deposit( 'rho', exchange=True, species_list=[ptcl],
+                        update_spectral=False )
+        sim.deposit( 'J', exchange=True, species_list=[ptcl],
+                        update_spectral=False )
 
     # Create a global field object across all subdomains, and copy the sources
     # (Space-charge calculation is a global operation)

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -146,6 +146,7 @@ class Particles(object) :
                 'Cuda not available for the particles.\n'
                 'Performing the particle operations on the CPU.')
             self.use_cuda = False
+        self.data_is_on_gpu = False # Data is initialized on the CPU
 
         # Generate evenly-spaced particles
         Ntot, x, y, z, ux, uy, uz, inv_gamma, w = generate_evenly_spaced(
@@ -277,6 +278,9 @@ class Particles(object) :
             if self.ionizer is not None:
                 self.ionizer.send_to_gpu()
 
+            # Modify flag accordingly
+            self.data_is_on_gpu = True
+
     def receive_particles_from_gpu( self ):
         """
         Receive the particles from the GPU.
@@ -315,6 +319,9 @@ class Particles(object) :
             # Copy the ionization data
             if self.ionizer is not None:
                 self.ionizer.receive_from_gpu()
+
+            # Modify flag accordingly
+            self.data_is_on_gpu = False
 
     def generate_continuously_injected_particles( self, time ):
         """

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -125,6 +125,52 @@ def receive_data_from_gpu(simulation):
     # Receive fields from the GPU (if CUDA is used)
     simulation.fld.receive_fields_from_gpu()
 
+class GpuMemoryManager(object):
+    """
+    Context manager that temporarily moves the simulation data to the GPU,
+    if the data is originally on the CPU when entering the context manager
+    """
+
+    def __init__(self, simulation):
+        """
+        Initialize the context manager
+
+        Parameters:
+        -----------
+        simulation: object
+            A simulation object that contains the particle
+            (ptcl) and field object (fld)
+        """
+        # Check whether the data is initially on the CPU or GPU
+        self.fields_were_on_gpu = simulation.fld.data_is_on_gpu
+        self.species_were_on_gpu = [ species.data_is_on_gpu \
+                                     for species in simulation.ptcl ]
+        # Keep a reference to the simulation
+        self.sim = simulation
+
+    def __enter__(self):
+        """
+        Move the data to the GPU (if it was originally on the CPU)
+        """
+        if self.sim.use_cuda:
+            if not self.fields_were_on_gpu:
+                self.sim.fld.send_fields_to_gpu()
+            for i, species in enumerate(self.sim.ptcl):
+                if not self.species_were_on_gpu[i]:
+                    species.send_particles_to_gpu()
+
+    def __exit__(self, type, value, traceback):
+        """
+        Move the data back to the CPU (if it was originally on the CPU)
+        """
+        if self.sim.use_cuda:
+            if not self.fields_were_on_gpu:
+                self.sim.fld.receive_fields_from_gpu()
+            for i, species in enumerate(self.sim.ptcl):
+                if not self.species_were_on_gpu[i]:
+                    species.receive_particles_from_gpu()
+
+
 # -----------------------------------------------------
 # CUDA mpi management
 # -----------------------------------------------------

--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -121,6 +121,7 @@ import numpy as np
 from scipy.constants import c, e, m_e, epsilon_0
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
+from fbpic.utils.cuda import GpuMemoryManager
 from fbpic.fields import Fields
 
 # Parameters
@@ -188,8 +189,10 @@ def simulate_periodic_plasma_wave( particle_shape, show=False ):
 
     # Save the initial density in spectral space, and consider it
     # to be the density of the (uninitialized) ions
-    sim.deposit('rho_prev', exchange=True)
-    sim.fld.spect2interp('rho_prev')
+    # (Move the simulation to GPU if needed, for this step)
+    with GpuMemoryManager(sim):
+        sim.deposit('rho_prev', exchange=True)
+        sim.fld.spect2interp('rho_prev')
     rho_ions = [ ]
     for m in range(len(sim.fld.interp)):
         rho_ions.append( -sim.fld.interp[m].rho.copy() )


### PR DESCRIPTION
This is a PR that **prepares** the code for a switch of some functionalities from `numba.cuda` to `cupy`.

More specifically, in FBPIC, we sometimes pass CPU (`numpy`) arrays to `numba.cuda` kernels. This essentially happens when we call `deposit` outside of the main PIC loop. (e.g. when computing the initial space-charge fields). In this case, the code calls the `numba.cuda` kernels for charge/current deposition, but the arrays are still on the CPU, because the execution has not gone through the set of `send_to_gpu` functions that are the beginning of the main PIC loop.

In this case, `numba.cuda` kernels are quite forgiving, as they then automatically copy the `numpy` arrays to GPU before the kernel and back to CPU after the kernel.
However, this will not be the case with `cupy` kernels: instead (from experience) the code crashes when passing `numpy` array to `cupy` kernel.

In order to avoid this issue in upcoming PRs with more `cupy` kernels, this PR creates a context manager that moves the simulation data to GPU (and back) if it is originally on CPU. This context manager is used for `deposit`, in this PR, but could also be used in other parts of the code if the need arises.

To keep track of whether the data is on CPU or GPU at any point in time, new boolean flags `data_is_on_gpu` have been added to the `Particles` and `Fields` class. These flags are of course updated when calling `send_to_gpu` and `receive_from_gpu`