### PR TITLE
Use a custom decorator to compile CUDA kernels to cupy

### DIFF
--- a/fbpic/boundaries/cuda_methods.py
+++ b/fbpic/boundaries/cuda_methods.py
@@ -6,8 +6,9 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines a set of generic functions that operate on a GPU.
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 
-@cuda.jit
+@compile_cupy
 def copy_vec_to_gpu_buffer( vec_buffer_l, vec_buffer_r,
                             grid_r, grid_t, grid_z, m,
                             copy_left, copy_right, nz_start, nz_end ):
@@ -68,7 +69,7 @@ def copy_vec_to_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 vec_buffer_r[3*m+2, iz, ir] = grid_z[ iz_right, ir ]
 
 
-@cuda.jit
+@compile_cupy
 def copy_pml_to_gpu_buffer( vec_buffer_l, vec_buffer_r,
                             grid_r, grid_t, grid_z, pml_r, pml_t, m,
                             copy_left, copy_right, nz_start, nz_end ):
@@ -137,7 +138,7 @@ def copy_pml_to_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 vec_buffer_r[5*m+4, iz, ir] = pml_t[ iz_right, ir ]
 
 
-@cuda.jit
+@compile_cupy
 def copy_scal_to_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                              copy_left, copy_right, nz_start, nz_end ):
     """
@@ -192,7 +193,7 @@ def copy_scal_to_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                 scal_buffer_r[m, iz, ir] = grid[ iz_right, ir ]
 
 
-@cuda.jit
+@compile_cupy
 def replace_vec_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                                  grid_r, grid_t, grid_z, m,
                                  copy_left, copy_right, nz_start, nz_end ):
@@ -250,7 +251,7 @@ def replace_vec_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 grid_t[ iz_right, ir ] = vec_buffer_r[3*m+1, iz, ir]
                 grid_z[ iz_right, ir ] = vec_buffer_r[3*m+2, iz, ir]
 
-@cuda.jit
+@compile_cupy
 def replace_pml_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                                  grid_r, grid_t, grid_z, pml_r, pml_t, m,
                                  copy_left, copy_right, nz_start, nz_end ):
@@ -316,7 +317,7 @@ def replace_pml_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 pml_r[ iz_right, ir ] = vec_buffer_r[5*m+3, iz, ir]
                 pml_t[ iz_right, ir ] = vec_buffer_r[5*m+4, iz, ir]
 
-@cuda.jit
+@compile_cupy
 def replace_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                                  copy_left, copy_right, nz_start, nz_end ):
     """
@@ -369,7 +370,7 @@ def replace_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                 grid[ iz_right, ir ] = scal_buffer_r[m, iz, ir]
 
 
-@cuda.jit
+@compile_cupy
 def add_vec_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                              grid_r, grid_t, grid_z, m,
                              copy_left, copy_right, nz_start, nz_end ):
@@ -427,7 +428,7 @@ def add_vec_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 grid_t[ iz_right, ir ] += vec_buffer_r[3*m+1, iz, ir]
                 grid_z[ iz_right, ir ] += vec_buffer_r[3*m+2, iz, ir]
 
-@cuda.jit
+@compile_cupy
 def add_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                               copy_left, copy_right, nz_start, nz_end ):
     """
@@ -481,7 +482,7 @@ def add_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
 
 # CUDA damping kernels:
 # --------------------
-@cuda.jit
+@compile_cupy
 def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
     """
     Multiply the E and B fields in the left guard cells
@@ -520,7 +521,7 @@ def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
             Bt[iz, ir] *= damp_factor_left
             Bz[iz, ir] *= damp_factor_left
 
-@cuda.jit
+@compile_cupy
 def cuda_damp_EB_left_pml( Er_pml, Et_pml, Br_pml, Bt_pml, damp_array, nd ):
     """
     Multiply the E and B fields in the left guard cells
@@ -557,7 +558,7 @@ def cuda_damp_EB_left_pml( Er_pml, Et_pml, Br_pml, Bt_pml, damp_array, nd ):
             Br_pml[iz, ir] *= damp_factor_left
             Bt_pml[iz, ir] *= damp_factor_left
 
-@cuda.jit
+@compile_cupy
 def cuda_damp_EB_right( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
     """
     Multiply the E and B fields in the right guard cells
@@ -598,7 +599,7 @@ def cuda_damp_EB_right( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
             Bz[iz_right, ir] *= damp_factor_right
 
 
-@cuda.jit
+@compile_cupy
 def cuda_damp_EB_right_pml( Er_pml, Et_pml, Br_pml, Bt_pml, damp_array, nd ):
     """
     Multiply the E and B fields in the right guard cells

--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -9,7 +9,7 @@ from fbpic.utils.threading import njit_parallel, prange
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d, compile_cupy
 
 class MovingWindow(object):
     """
@@ -240,7 +240,7 @@ def shift_spect_array_cpu( field_array, shift_factor, n_move ):
 
 if cuda_installed:
 
-    @cuda.jit
+    @compile_cupy
     def shift_spect_array_gpu( field_array, shift_factor, n_move ):
         """
         Shift the field 'field_array' by n_move cells on the GPU.

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -13,7 +13,7 @@ from fbpic.utils.printing import catch_gpu_memory_error
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 def remove_outside_particles(species, fld, n_guard, left_proc, right_proc):
     """
@@ -560,7 +560,7 @@ def shift_particles_periodic_numba( z, zmin, zmax ):
 # -------------
 if cuda_installed:
 
-    @cuda.jit
+    @compile_cupy
     def split_particles_to_buffers( particle_array, left_buffer,
                     stay_buffer, right_buffer, i_min, i_max ):
         """
@@ -607,7 +607,7 @@ if cuda_installed:
             if (n_right != 0):
                 right_buffer[i-i_max] = particle_array[i]
 
-    @cuda.jit
+    @compile_cupy
     def copy_particles( N_elements, source_array, source_start,
                                     target_array, target_start ):
         """
@@ -634,7 +634,7 @@ if cuda_installed:
             target_array[i+target_start] = source_array[i+source_start]
 
 
-    @cuda.jit
+    @compile_cupy
     def shift_particles_periodic_cuda( z, zmin, zmax ):
         """
         Shift the particle positions by an integer number of box length,

--- a/fbpic/boundaries/pml_damping.py
+++ b/fbpic/boundaries/pml_damping.py
@@ -10,7 +10,7 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda
+    from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda, compile_cupy
 
 class PMLDamper(object):
     """
@@ -108,7 +108,7 @@ def generate_pml_damp_array( n_pml, cdt_over_dr ):
 
 
 if cuda_installed:
-    @cuda.jit
+    @compile_cupy
     def cuda_damp_pml_EB( Et, Et_pml, Ez, Bt, Bt_pml, Bz,
                       damp_array, n_pml ) :
         """

--- a/fbpic/fields/cuda_methods.py
+++ b/fbpic/fields/cuda_methods.py
@@ -6,6 +6,7 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the optimized fields methods that use cuda on a GPU
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 from scipy.constants import c, epsilon_0, mu_0
 c2 = c**2
 
@@ -13,7 +14,7 @@ c2 = c**2
 # Erasing functions
 # ------------------
 
-@cuda.jit
+@compile_cupy
 def cuda_erase_scalar( array ):
     """
     Set input array to 0
@@ -35,7 +36,7 @@ def cuda_erase_scalar( array ):
     if (iz < array.shape[0]) and (ir < array.shape[1]):
         array[iz, ir] = 0
 
-@cuda.jit
+@compile_cupy
 def cuda_erase_vector( array_r, array_t, array_z ):
     """
     Set the input arrays to 0
@@ -63,7 +64,7 @@ def cuda_erase_vector( array_r, array_t, array_z ):
 # Divide by volume functions
 # ---------------------------
 
-@cuda.jit
+@compile_cupy
 def cuda_divide_scalar_by_volume( array, invvol ):
     """
     Multiply the input array by the corresponding invvol
@@ -87,7 +88,7 @@ def cuda_divide_scalar_by_volume( array, invvol ):
         array[iz, ir] = array[iz, ir] * invvol[ir]
 
 
-@cuda.jit
+@compile_cupy
 def cuda_divide_vector_by_volume( array_r, array_t, array_z, invvol ):
     """
     Multiply the input arrays by the corresponding invvol
@@ -116,7 +117,7 @@ def cuda_divide_vector_by_volume( array_r, array_t, array_z, invvol ):
 # Methods of the SpectralGrid object
 # -----------------------------------
 
-@cuda.jit
+@compile_cupy
 def cuda_correct_currents_curlfree_standard( rho_prev, rho_next, Jp, Jm, Jz,
                             kz, kr, inv_k2, inv_dt, Nz, Nr ):
     """
@@ -139,7 +140,7 @@ def cuda_correct_currents_curlfree_standard( rho_prev, rho_next, Jp, Jm, Jz,
         Jm[iz, ir] += -0.5 * kr[iz, ir] * F
         Jz[iz, ir] += -1.j * kz[iz, ir] * F
 
-@cuda.jit
+@compile_cupy
 def cuda_correct_currents_crossdeposition_standard( rho_prev, rho_next,
         rho_next_z, rho_next_xy, Jp, Jm, Jz, kz, kr, inv_dt, Nz, Nr ):
     """
@@ -169,7 +170,7 @@ def cuda_correct_currents_crossdeposition_standard( rho_prev, rho_next,
             inv_kz = 1./kz[iz, ir]
             Jz[iz, ir] += 1.j * Dz * inv_kz
 
-@cuda.jit
+@compile_cupy
 def cuda_correct_currents_curlfree_comoving( rho_prev, rho_next, Jp, Jm, Jz,
                             kz, kr, inv_k2,
                             j_corr_coef, T_eb, T_cc,
@@ -195,7 +196,7 @@ def cuda_correct_currents_curlfree_comoving( rho_prev, rho_next, Jp, Jm, Jz,
         Jm[iz, ir] += -0.5 * kr[iz, ir] * F
         Jz[iz, ir] += -1.j * kz[iz, ir] * F
 
-@cuda.jit
+@compile_cupy
 def cuda_correct_currents_crossdeposition_comoving(
         rho_prev, rho_next, rho_next_z, rho_next_xy, Jp, Jm, Jz,
         kz, kr, j_corr_coef, T_eb, T_cc, inv_dt, Nz, Nr ) :
@@ -230,7 +231,7 @@ def cuda_correct_currents_crossdeposition_comoving(
             Jz[iz, ir] += 1.j * Dz * inv_kz
 
 
-@cuda.jit
+@compile_cupy
 def cuda_push_eb_standard( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                        rho_prev, rho_next,
                        rho_prev_coef, rho_next_coef, j_coef,
@@ -300,7 +301,7 @@ def cuda_push_eb_standard( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                         + 1.j*kr[iz, ir]*Jm[iz, ir] )
 
 
-@cuda.jit
+@compile_cupy
 def cuda_push_eb_pml_standard( Ep_pml, Em_pml, Bp_pml, Bm_pml,
                         Ez, Bz, C, S_w, kr, kz, Nz, Nr):
     """
@@ -329,7 +330,7 @@ def cuda_push_eb_pml_standard( Ep_pml, Em_pml, Bp_pml, Bm_pml,
             - S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Ez[iz, ir] )
 
 
-@cuda.jit
+@compile_cupy
 def cuda_push_eb_comoving( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                        rho_prev, rho_next,
                        rho_prev_coef, rho_next_coef, j_coef,
@@ -410,7 +411,7 @@ def cuda_push_eb_comoving( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                         + 1.j*kr[iz, ir]*Jm[iz, ir] )
 
 
-@cuda.jit
+@compile_cupy
 def cuda_push_eb_pml_comoving( Ep_pml, Em_pml, Bp_pml, Bm_pml,
                         Ez, Bz, C, S_w, T_eb, kr, kz, Nz, Nr):
     """
@@ -438,7 +439,7 @@ def cuda_push_eb_pml_comoving( Ep_pml, Em_pml, Bp_pml, Bm_pml,
             - T_eb[iz, ir]*S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Ez[iz, ir] )
 
 
-@cuda.jit
+@compile_cupy
 def cuda_push_rho( rho_prev, rho_next, Nz, Nr ) :
     """
     Transfer the values of rho_next to rho_prev,
@@ -462,7 +463,7 @@ def cuda_push_rho( rho_prev, rho_next, Nz, Nr ) :
         rho_prev[iz, ir] = rho_next[iz, ir]
         rho_next[iz, ir] = 0.
 
-@cuda.jit
+@compile_cupy
 def cuda_filter_scalar( field, Nz, Nr, filter_array_z, filter_array_r ) :
     """
     Multiply the input field by the filter_array
@@ -487,7 +488,7 @@ def cuda_filter_scalar( field, Nz, Nr, filter_array_z, filter_array_r ) :
 
         field[iz, ir] = filter_array_z[iz]*filter_array_r[ir]*field[iz, ir]
 
-@cuda.jit
+@compile_cupy
 def cuda_filter_vector( fieldr, fieldt, fieldz, Nz, Nr,
                         filter_array_z, filter_array_r ):
     """

--- a/fbpic/fields/spectral_transform/cuda_methods.py
+++ b/fbpic/fields/spectral_transform/cuda_methods.py
@@ -7,12 +7,13 @@ It defines a set of functions that are useful when converting the
 fields from interpolation grid to the spectral grid and vice-versa
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 
 # ------------------
 # Copying functions
 # ------------------
 
-@cuda.jit
+@compile_cupy
 def cuda_copy_2dC_to_2dR( array_in, array_out ) :
     """
     Store the complex Nz x Nr array `array_in`
@@ -36,7 +37,7 @@ def cuda_copy_2dC_to_2dR( array_in, array_out ) :
         array_out[iz, ir] = array_in[iz, ir].real
         array_out[iz+Nz, ir] = array_in[iz, ir].imag
 
-@cuda.jit
+@compile_cupy
 def cuda_copy_2dR_to_2dC( array_in, array_out ) :
     """
     Reconstruct the complex Nz x Nr array `array_out`,
@@ -59,7 +60,7 @@ def cuda_copy_2dR_to_2dC( array_in, array_out ) :
     if (iz < Nz) and (ir < Nr) :
         array_out[iz, ir] = array_in[iz, ir] + 1.j*array_in[iz+Nz, ir]
 
-@cuda.jit
+@compile_cupy
 def cuda_copy_2d_to_1d( array_2d, array_1d ) :
     """
     Copy array_2d to array_1d, so that the first axis of array_2d
@@ -85,7 +86,7 @@ def cuda_copy_2d_to_1d( array_2d, array_1d ) :
         i = iz + array_2d.shape[0]*ir
         array_1d[i] = array_2d[iz, ir]
 
-@cuda.jit
+@compile_cupy
 def cuda_copy_1d_to_2d( array_1d, array_2d ) :
     """
     Copy array_1d to array_2d, so that the first axis of array_2d
@@ -115,7 +116,7 @@ def cuda_copy_1d_to_2d( array_1d, array_2d ) :
 # Functions that combine components in spectral space
 # ----------------------------------------------------
 
-@cuda.jit
+@compile_cupy
 def cuda_rt_to_pm( buffer_r, buffer_t, buffer_p, buffer_m ) :
     """
     Combine the arrays buffer_r and buffer_t to produce the
@@ -136,7 +137,7 @@ def cuda_rt_to_pm( buffer_r, buffer_t, buffer_p, buffer_m ) :
         buffer_m[iz, ir] = 0.5*( value_r + 1.j*value_t )
 
 
-@cuda.jit
+@compile_cupy
 def cuda_pm_to_rt( buffer_p, buffer_m, buffer_r, buffer_t ) :
     """
     Combine the arrays buffer_p and buffer_m to produce the

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -491,7 +491,7 @@ class LaserAntenna( object ):
 
 if cuda_installed:
 
-    @cuda.jit()
+    @compile_cupy
     def add_rho_to_gpu_array( iz_min, rho_buffer, rho, m ):
         """
         Add the small-size array rho_buffer into the full-size array rho
@@ -520,7 +520,7 @@ if cuda_installed:
             rho[iz_min, ir] += rho_buffer[m, 0, ir]
             rho[iz_min+1, ir] += rho_buffer[m, 1, ir]
 
-    @cuda.jit()
+    @compile_cupy
     def add_J_to_gpu_array( iz_min, Jr_buffer, Jt_buffer,
                             Jz_buffer, Jr, Jt, Jz, m ):
         """

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -17,7 +17,7 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 class LaserAntenna( object ):
     """

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -21,7 +21,7 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 class BackTransformedFieldDiagnostic(FieldDiagnostic):
     """
@@ -736,7 +736,7 @@ class SliceHandler:
 
 if cuda_installed:
 
-    @cuda.jit
+    @compile_cupy
     def extract_slice_cuda( Nr, iz, Sz, slice_arr,
         Er, Et, Ez, Br, Bt, Bz, Jr, Jt, Jz, rho, m ):
         """

--- a/fbpic/openpmd_diag/cuda_methods.py
+++ b/fbpic/openpmd_diag/cuda_methods.py
@@ -6,7 +6,7 @@ This files contains cuda methods that are used in the boosted-frame
 diagnostics
 """
 import numpy as np
-from fbpic.utils.cuda import cupy, cuda, cuda_tpb_bpg_1d
+from fbpic.utils.cuda import cupy, cuda, cuda_tpb_bpg_1d, compile_cupy
 
 def extract_slice_from_gpu( pref_sum_curr, N_area, species ):
     """
@@ -64,7 +64,7 @@ def extract_slice_from_gpu( pref_sum_curr, N_area, species ):
     # Return the data as dictionary
     return( particle_data )
 
-@cuda.jit()
+@compile_cupy
 def extract_particles_from_gpu( part_idx_start, x, y, z, ux, uy, uz, w,
                                 inv_gamma, selected ):
     """
@@ -102,7 +102,7 @@ def extract_particles_from_gpu( part_idx_start, x, y, z, ux, uy, uz, w,
         selected[6, i] = w[ptcl_idx]
         selected[7, i] = inv_gamma[ptcl_idx]
 
-@cuda.jit()
+@compile_cupy
 def extract_array_from_gpu( part_idx_start, array, selected ):
     """
     Extract a selection of particles from the GPU and

--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -7,6 +7,7 @@ It defines the deposition methods for rho and J for linear and cubic
 order shapes on the GPU using CUDA.
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 import math
 from scipy.constants import c
 import numpy as np
@@ -81,7 +82,7 @@ def r_shape_cubic(cell_position, index):
 # Field deposition - linear - rho
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_rho_gpu_linear(x, y, z, w, q,
                            invdz, zmin, Nz,
                            invdr, rmin, Nr,
@@ -246,7 +247,7 @@ def deposit_rho_gpu_linear(x, y, z, w, q,
 # Field deposition - linear - J
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_J_gpu_linear(x, y, z, w, q,
                          ux, uy, uz, inv_gamma,
                          invdz, zmin, Nz,
@@ -501,7 +502,7 @@ def deposit_J_gpu_linear(x, y, z, w, q,
 # Field deposition - cubic - rho
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_rho_gpu_cubic(x, y, z, w, q,
                           invdz, zmin, Nz,
                           invdr, rmin, Nr,
@@ -777,7 +778,7 @@ def deposit_rho_gpu_cubic(x, y, z, w, q,
 # Field deposition - cubic - J
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_J_gpu_cubic(x, y, z, w, q,
                         ux, uy, uz, inv_gamma,
                         invdz, zmin, Nz,

--- a/fbpic/particles/deposition/cuda_methods_one_mode.py
+++ b/fbpic/particles/deposition/cuda_methods_one_mode.py
@@ -7,6 +7,7 @@ It defines the deposition methods for rho and J for linear and cubic
 order shapes on the GPU using CUDA, for one azimuthal mode only
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 import math
 from scipy.constants import c
 import numpy as np
@@ -82,7 +83,7 @@ def r_shape_cubic(cell_position, index):
 # Field deposition - linear - rho
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_rho_gpu_linear_one_mode(x, y, z, w, q,
                            invdz, zmin, Nz,
                            invdr, rmin, Nr,
@@ -236,7 +237,7 @@ def deposit_rho_gpu_linear_one_mode(x, y, z, w, q,
 # Field deposition - linear - J
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_J_gpu_linear_one_mode(x, y, z, w, q,
                          ux, uy, uz, inv_gamma,
                          invdz, zmin, Nz,
@@ -448,7 +449,7 @@ def deposit_J_gpu_linear_one_mode(x, y, z, w, q,
 # Field deposition - cubic - rho
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_rho_gpu_cubic_one_mode(x, y, z, w, q,
                           invdz, zmin, Nz,
                           invdr, rmin, Nr,
@@ -663,7 +664,7 @@ def deposit_rho_gpu_cubic_one_mode(x, y, z, w, q,
 # Field deposition - cubic - J
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_J_gpu_cubic_one_mode(x, y, z, w, q,
                         ux, uy, uz, inv_gamma,
                         invdz, zmin, Nz,

--- a/fbpic/particles/elementary_process/compton/cuda_methods.py
+++ b/fbpic/particles/elementary_process/compton/cuda_methods.py
@@ -7,6 +7,7 @@ It defines cuda methods that are used in Compton scattering (on GPU).
 """
 import math
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 from numba.cuda.random import xoroshiro128p_uniform_float64
 # Import the inline functions
 from .inline_functions import lorentz_transform, get_scattering_probability, \
@@ -18,7 +19,7 @@ get_scattering_probability = cuda.jit( get_scattering_probability,
 get_photon_density_gaussian = cuda.jit( get_photon_density_gaussian,
                                             device=True, inline=True )
 
-@cuda.jit
+@compile_cupy
 def get_photon_density_gaussian_cuda( photon_n, elec_Ntot,
     elec_x, elec_y, elec_z, ct, photon_n_lab_max, inv_laser_waist2,
     inv_laser_ctau2, laser_initial_z0, gamma_boost, beta_boost ):

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -13,7 +13,7 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 def allocate_empty( shape, use_cuda, dtype ):
     """
@@ -140,7 +140,7 @@ def copy_particle_data_numba( Ntot, old_array, new_array ):
     return( new_array )
 
 if cuda_installed:
-    @cuda.jit()
+    @compile_cupy
     def copy_particle_data_cuda( Ntot, old_array, new_array ):
         """
         Copy the `Ntot` elements of `old_array` into `new_array`, on GPU

--- a/fbpic/particles/elementary_process/ionization/cuda_methods.py
+++ b/fbpic/particles/elementary_process/ionization/cuda_methods.py
@@ -8,6 +8,7 @@ It defines cuda methods that are used in particle ionization.
 Apart from synthactic details, this file is very close to numba_methods.py
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 from scipy.constants import c
 # Import inline functions
 from .inline_functions import get_ionization_probability, \
@@ -20,7 +21,7 @@ get_E_amplitude = cuda.jit( get_E_amplitude,
 copy_ionized_electrons_batch = cuda.jit( copy_ionized_electrons_batch,
                                             device=True, inline=True )
 
-@cuda.jit()
+@compile_cupy
 def ionize_ions_cuda( N_batch, batch_size, Ntot,
     level_start, level_max, n_levels,
     n_ionized, ionized_from, ionization_level, random_draw,
@@ -83,7 +84,7 @@ def ionize_ions_cuda( N_batch, batch_size, Ntot,
             else:
                 ionized_from[ip] = -1
 
-@cuda.jit()
+@compile_cupy
 def copy_ionized_electrons_cuda(
     N_batch, batch_size, elec_old_Ntot, ion_Ntot,
     cumulative_n_ionized, ionized_from,

--- a/fbpic/particles/gathering/cuda_methods.py
+++ b/fbpic/particles/gathering/cuda_methods.py
@@ -7,6 +7,7 @@ It defines the field gathering methods linear and cubic order shapes
 on the GPU using CUDA.
 """
 from numba import cuda, float64, int64
+from fbpic.utils.cuda import compile_cupy
 import math
 # Import inline functions
 from .inline_functions import \
@@ -21,7 +22,7 @@ add_cubic_gather_for_mode = cuda.jit( add_cubic_gather_for_mode,
 # Field gathering linear
 # -----------------------
 
-@cuda.jit
+@compile_cupy
 def gather_field_gpu_linear(x, y, z,
                     rmax_gather,
                     invdz, zmin, Nz,
@@ -204,7 +205,7 @@ def gather_field_gpu_linear(x, y, z,
 # Field gathering cubic
 # -----------------------
 
-@cuda.jit
+@compile_cupy
 def gather_field_gpu_cubic(x, y, z,
                     rmax_gather,
                     invdz, zmin, Nz,

--- a/fbpic/particles/gathering/cuda_methods_one_mode.py
+++ b/fbpic/particles/gathering/cuda_methods_one_mode.py
@@ -7,6 +7,7 @@ It defines the field gathering methods linear and cubic order shapes
 on the GPU using CUDA, for one azimuthal mode at a time
 """
 from numba import cuda, float64, int64
+from fbpic.utils.cuda import compile_cupy
 import math
 # Import inline functions
 from .inline_functions import \
@@ -17,7 +18,7 @@ add_linear_gather_for_mode = cuda.jit( add_linear_gather_for_mode,
 add_cubic_gather_for_mode = cuda.jit( add_cubic_gather_for_mode,
                                         device=True, inline=True )
 
-@cuda.jit
+@compile_cupy
 def erase_eb_cuda( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
     """
     Reset the arrays of fields (i.e. set them to 0)
@@ -41,7 +42,7 @@ def erase_eb_cuda( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
 # Field gathering linear
 # -----------------------
 
-@cuda.jit
+@compile_cupy
 def gather_field_gpu_linear_one_mode(x, y, z,
                     rmax_gather,
                     invdz, zmin, Nz,
@@ -211,7 +212,7 @@ def gather_field_gpu_linear_one_mode(x, y, z,
 # Field gathering cubic
 # -----------------------
 
-@cuda.jit
+@compile_cupy
 def gather_field_gpu_cubic_one_mode(x, y, z,
                     rmax_gather,
                     invdz, zmin, Nz,

--- a/fbpic/particles/push/cuda_methods.py
+++ b/fbpic/particles/push/cuda_methods.py
@@ -7,12 +7,13 @@ It defines the particle push methods on the GPU using CUDA.
 """
 from scipy.constants import c, e
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 # Import inline function
 from .inline_functions import push_p_vay
 # Compile the inline function for GPU
 push_p_vay = cuda.jit( push_p_vay, device=True, inline=True )
 
-@cuda.jit
+@compile_cupy
 def push_x_gpu( x, y, z, ux, uy, uz, inv_gamma, dt,
                 x_push, y_push, z_push ) :
     """
@@ -50,7 +51,7 @@ def push_x_gpu( x, y, z, ux, uy, uz, inv_gamma, dt,
         y[i] += cdt*y_push*inv_g*uy[i]
         z[i] += cdt*z_push*inv_g*uz[i]
 
-@cuda.jit
+@compile_cupy
 def push_p_gpu( ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz,
                 q, m, Ntot, dt ) :
@@ -98,7 +99,7 @@ def push_p_gpu( ux, uy, uz, inv_gamma,
             Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip], econst, bconst)
 
 
-@cuda.jit
+@compile_cupy
 def push_p_after_plane_gpu( z, z_plane, ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz, q, m, Ntot, dt ) :
     """
@@ -130,7 +131,7 @@ def push_p_after_plane_gpu( z, z_plane, ux, uy, uz, inv_gamma,
             Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip], econst, bconst)
 
 
-@cuda.jit
+@compile_cupy
 def push_p_ioniz_gpu( ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz,
                 m, Ntot, dt, ionization_level ) :

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -12,7 +12,7 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda_tpb_bpg_1d
+    from fbpic.utils.cuda import cuda_tpb_bpg_1d, compile_cupy
 
 class ParticleTracker(object):
     """
@@ -134,7 +134,7 @@ class ParticleTracker(object):
 
 if cuda_installed:
 
-    @cuda.jit()
+    @compile_cupy
     def generate_ids_gpu( id_array, i_start, i_end,
                             next_attributed_id, id_step ):
         """

--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -6,7 +6,7 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the particle sorting methods on the GPU using CUDA.
 """
 from numba import cuda
-from fbpic.utils.cuda import cupy_installed
+from fbpic.utils.cuda import cupy_installed, compile_cupy
 if cupy_installed:
     from cupy.cuda import thrust
 import math
@@ -16,7 +16,7 @@ import numpy as np
 # Sorting utilities - get_cell_idx / sort / prefix_sum
 # -----------------------------------------------------
 
-@cuda.jit
+@compile_cupy
 def get_cell_idx_per_particle(cell_idx, sorted_idx,
                               x, y, z,
                               invdz, zmin, Nz,
@@ -118,7 +118,7 @@ def sort_particles_per_cell(cell_idx, sorted_idx):
         # memory is not automatically released, after `argsort`
         # Here we force `cupy` to release the memory.
 
-@cuda.jit
+@compile_cupy
 def incl_prefix_sum(cell_idx, prefix_sum):
     """
     Perform an inclusive parallel prefix sum on the sorted
@@ -151,7 +151,7 @@ def incl_prefix_sum(cell_idx, prefix_sum):
             ci += 1
 
 
-@cuda.jit
+@compile_cupy
 def prefill_prefix_sum(cell_idx, prefix_sum, Ntot):
     """
     Prefill the prefix sum array so that:
@@ -186,7 +186,7 @@ def prefill_prefix_sum(cell_idx, prefix_sum, Ntot):
             # If this species has no particles, fill all cells with 0
             prefix_sum[i] = 0
 
-@cuda.jit
+@compile_cupy
 def write_sorting_buffer(sorted_idx, val, buf):
     """
     Writes the values of a particle array to a buffer,

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -189,3 +189,160 @@ def mpi_select_gpus(mpi):
         if rank%n_gpus == i_gpu:
             cuda.select_device(i_gpu)
         mpi.COMM_WORLD.barrier()
+
+
+# -----------------------------------------------------
+# CUDA kernel decorator
+# -----------------------------------------------------
+
+if cupy_installed:
+    
+    def get_args_hash(args):
+        """
+        Computes a hash from the argument types of a kernel call.
+        This takes into account both data types as well as (for arrays) the
+        number of dimensions.
+        Parameters :
+        ------------
+        args: A list of arguments (scalars or Cupy arrays).
+        Returns :
+        ------------
+        hash: Hash value as an int.
+        """
+        types = []
+
+        # Loop over the arguments
+        for a in args:
+            # For array arguments: save the data type and the number of
+            # dimensions
+            if isinstance(a, cupy.ndarray):
+                types.append(a.dtype)
+                types.append(a.ndim)
+
+            # For scalar arguments: save only the data type
+            else:
+                types.append(type(a))
+
+        # Use the built-in Python hash function to compute the hash
+        return hash(tuple(types))
+
+    class compile_cupy(object):
+        """
+        This class defines a custom function decorator which compiles python
+        functions into GPU CUDA kernels. It uses the Just-in-time compilation
+        from Numba (cuda.jit) to compile the kernels into PTX code, then 
+        transfers this code to a Cupy RawKernel. It then implements a wrapper
+        to call this Cupy kernel with Cupy arrays as arguments. Also, it checks
+        the provided arguments for their types and, if needed, compiles the
+        same kernel multiple times for different data types.
+        This way, the better call time, reduced API overhead and faster memory
+        allocation of Cupy can be combined with the Just-in-time compilation
+        features of Numba.
+        The decorator is designed to mimic the Numba @cuda.jit decorator and
+        the resulting kernels are called the same way, with the syntax
+            kernel[blocks_per_grid, threads_per_block]( arguments )
+        """
+
+        def __init__(self, func):
+            """
+            Constructor of the decorator class.
+            Parameters :
+            ------------
+            func: The python function the decorator is applied to, which will
+                be compiled into a CUDA kernel.
+            """
+
+            self.python_func = func
+            self.kernel_dict = {}
+
+        def __getitem__(self, bt):
+            """
+            Called when the kernel is called with square brackets, e.g.
+                 kernel[blocks_per_grid, threads_per_block]
+            
+            This is used to mimic the Numba behaviour.
+            Parameters :
+            ------------
+            bt: A 2-tuple (blocks_per_grid, threads_per_block) giving the
+                thread and block size on the GPU. 
+                Both blocks_per_grid and threads_per_block should themselves
+                be tuples, even in the 1D case.
+            Returns :
+            ------------
+            call_kernel: A wrapper function which represents the kernel
+                specialized to the specified thread and block size, and
+                which can then be called with the kernel arguments.
+            """
+
+            def call_kernel(*args):
+                """
+                Wrapper function for the actual kernel call. Checks if a
+                kernel for the specified argument types is already compiled,
+                and compiles one if needed. Then calls the kernel.
+                 Parameters :
+                ------------
+                args: List of the kernel arguments. They should all be either
+                scalar values (float, int, complex, bool) or Cupy arrays.
+                """
+
+                # Calculate a hash from the argument types to check whether a 
+                # compatible kernel is already compiled.
+                hash = get_args_hash(args)
+
+                if hash not in self.kernel_dict:
+
+                    # Compile a Numba kernel for the specified arguments
+                    # using cuda.jit
+                    numba_kernel = cuda.jit()(self.python_func) \
+                        .specialize(*args)
+
+                    # Create a Cupy kernel module and load the PTX code of the
+                    # numba kernel
+                    module = cupy.cuda.function.Module()
+                    module.load(bytes(numba_kernel.ptx, 'UTF-8'))
+
+                    # Cache the resulting Cupy kernel in a dictionary using
+                    # the hash
+                    self.kernel_dict[hash] = module.get_function(
+                        numba_kernel.entry_name)
+
+                # Prepare the arguments for the Cupy kernel.
+                # Because of the way Numba JIT compilation works, the
+                # resulting kernels expect multiple arguments for each array.
+                kernel_args = []
+
+                # Loop over the given arguments
+                for a in args:
+
+                    # Check whether the argument is an array and requires
+                    # multiple kernel arguments.
+                    if isinstance(a, cupy.ndarray):
+
+                        # Append all required arguments to the list, in order:
+                        # - Two zeroes (corresponding to null pointers in C)
+                        # - The total size of the array
+                        # - The size in bytes of the array datatype
+                        # - The array itself
+                        # - The shape of the array, as single integers
+                        # - The strides of the array, as single integers
+                        # Note that due to the latter two entries, the actual
+                        # number of arguments per array depends on the number
+                        # of array dimensions.
+                        kernel_args.extend(
+                            [0, 0, a.size, a.dtype.itemsize, a,
+                                *a.shape, *a.strides])
+                    else:
+
+                        # For scalar arguments, simply append the
+                        # argument itself.
+                        kernel_args.append(a)
+
+                # Call the actual kernel from the cache.
+                # The arguments of the call are:
+                # - Blocks per grid (tuple)
+                # - Threads per blocks (tuple)
+                # - The prepared list of kernel arguments
+                self.kernel_dict[hash](bt[0], bt[1], kernel_args)
+
+            # __getitem__ returns the created wrapper method.
+            return call_kernel

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -274,6 +274,17 @@ if cupy_installed:
                 which can then be called with the kernel arguments.
             """
 
+            blocks_per_grid = bt[0]
+            threads_per_block = bt[1]
+
+            # Cast the thread and block size to tuples if neccessary
+            # since Cupy does not accept them as simple numbers
+            if not isinstance(blocks_per_grid, tuple):
+                blocks_per_grid = (blocks_per_grid, )
+            
+            if not isinstance(threads_per_block, tuple):
+                threads_per_block = (threads_per_block, )
+
             def call_kernel(*args):
                 """
                 Wrapper function for the actual kernel call. Checks if a
@@ -342,7 +353,8 @@ if cupy_installed:
                 # - Blocks per grid (tuple)
                 # - Threads per blocks (tuple)
                 # - The prepared list of kernel arguments
-                self.kernel_dict[hash](bt[0], bt[1], kernel_args)
+                self.kernel_dict[hash](blocks_per_grid, threads_per_block,
+                    kernel_args)
 
             # __getitem__ returns the created wrapper method.
             return call_kernel

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -340,8 +340,9 @@ if cupy_installed:
                         # number of arguments per array depends on the number
                         # of array dimensions.
                         kernel_args.extend(
-                            [0, 0, a.size, a.dtype.itemsize, a,
-                                *a.shape, *a.strides])
+                            [0, 0, a.size, a.dtype.itemsize, a])
+                        kernel_args.extend(a.shape)
+                        kernel_args.extend(a.strides)
                     else:
 
                         # For scalar arguments, simply append the


### PR DESCRIPTION
This pull request implements a custom decorator mimicking Numba's `@cuda.jit` which compiles python functions to CUDA kernels. It uses the Numba JIT compilation to produce PTX code, which is then passed to Cupy to create a RawKernel. This way, the smaller API overhead from Cupy is utilized while retaining the flexibility of Numba JIT compilation.