### PR TITLE
For GPU: check cupy, numba and Python version.

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -20,6 +20,7 @@ if cuda_installed:
     mpi_select_gpus( MPI )
 
 # Import the rest of the requirements
+import sys
 import warnings
 import numba
 import numpy as np
@@ -216,28 +217,30 @@ class Simulation(object):
                 'Cuda not available for the simulation.\n'
                 'Performing the simulation on CPU.' )
             self.use_cuda = False
-        # Check that cupy and numba have the right version
+        # Check that cupy, numba and Python have the right version
         if self.use_cuda:
             if not cupy_installed:
                 raise RuntimeError(
                     'In order to run on GPUs, FBPIC version 0.13 and later \n'
                     'require the `cupy` package.\n'
                     'See the FBPIC documentation in order to install cupy.')
-            elif (cupy_major_version >= 7 and numba_minor_version < 46):
+            elif cupy_major_version < 7:
                 raise RuntimeError(
-                    'You are using cupy version %d.\nFor compatibility, '
-                    'you need to install numba 0.46 or later.\n'
-                    '(Your current version is numba 0.%d.)\n'
-                    'e.g. with `conda uninstall numba; conda install numba`.'
-                    %(cupy_major_version,numba_minor_version))
-            elif (cupy_major_version < 7 and numba_minor_version >= 46):
+                    'In order to run on GPUs, FBPIC version 0.16 and later \n'
+                    'requires `cupy` version 7 (or later).\n(The `cupy` version'
+                    ' on your current system is %d.)\nPlease install the '
+                    'latest version of `cupy`.' %cupy_major_version)
+            elif numba_minor_version < 46:
                 raise RuntimeError(
-                    'You are using numba version 0.%d.\nFor compatibility, '
-                    'you need to install cupy 7 or later.\n'
-                    '(Your current version is cupy %d.)\n'
-                    'e.g. with `pip install --upgrade cupy-cudaXXX`\n'
-                    'where `XXX` should be replaced by your cuda version.'
-                    %(numba_minor_version,cupy_major_version))
+                    'In order to run on GPUs, FBPIC version 0.16 and later \n'
+                    'requires `numba` version 0.46 (or later).\n(The `numba` '
+                    'version on your current system is 0.%d.)\nPlease install'
+                    ' the latest version of `numba`.' %numba_minor_version)
+            elif sys.version_info.major < 3:
+                raise RuntimeError(
+                    'In order to run on GPUs, FBPIC version 0.16 and later \n'
+                    'requires Python 3.\n(The Python version on your current '
+                    'system is Python 2.)\nPlease install Python 3.')
         # CPU multi-threading
         self.use_threading = threading_enabled
         if self.use_threading:


### PR DESCRIPTION
In previous versions of FBPIC, we were allowing `numba<= 0.45` on GPU - provided that `cupy<=6` was also installed. 

However, now that GPU arrays are `cupy` arrays, this is no longer possible. This is because passing `cupy` arrays of size 0 to a `numba.cuda` kernel (which happens e.g. when a given species has 0 macroparticles in FBPIC) causes the code to crash, with `cupy<=6`. (See [this issue](https://github.com/numba/numba/issues/4140) for more details.)

Note that this is still the case with the new decorator (PR #431), since we still pass cupy arrays (potentially of size 0) to `numba`'s `specialize` function - which is enough to cause the above-mentioned crash.

As a result, we now need `cupy>=7`, which in turn imposes `numba>=0.46` and Python 3 (when running on GPU).
