### PR TITLE
Move the cumsum in the ionization kernels to the GPU

### DIFF
--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -39,7 +39,7 @@ def perform_cumsum( input_array ):
     np.cumsum( input_array, out=cumulative_array[1:] )
     return( cumulative_array )
 
-def perform_cumsum_2d( input_array ):
+def perform_cumsum_2d( input_array, use_cuda ):
     """
     Return an array containing the cumulative sum of the 2darray `input_array`,
     where the cumsum is taken along the last axis.
@@ -49,8 +49,12 @@ def perform_cumsum_2d( input_array ):
     total sum of `input_array`)
     """
     new_shape = (input_array.shape[0], input_array.shape[1]+1)
-    cumulative_array = np.zeros( new_shape, dtype=np.int64 )
-    np.cumsum( input_array, out=cumulative_array[:,1:], axis=-1 )
+    if use_cuda:
+        cumulative_array = cupy.zeros( new_shape, dtype=cupy.int64 )
+        cupy.cumsum( input_array, out=cumulative_array[:,1:], axis=-1 )
+    else:
+        cumulative_array = np.zeros( new_shape, dtype=np.int64 )
+        np.cumsum( input_array, out=cumulative_array[:,1:], axis=-1 )
     return( cumulative_array )
 
 def reallocate_and_copy_old( species, use_cuda, old_Ntot, new_Ntot ):

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -47,6 +47,8 @@ def perform_cumsum_2d( input_array, use_cuda ):
     (The returned array has one more element than `input_array` along the
     last axis; its first element is 0 and its last element is the
     total sum of `input_array`)
+
+    If needed, the calculation is performed on the GPU.
     """
     new_shape = (input_array.shape[0], input_array.shape[1]+1)
     if use_cuda:

--- a/fbpic/particles/elementary_process/ionization/ionizer.py
+++ b/fbpic/particles/elementary_process/ionization/ionizer.py
@@ -267,10 +267,7 @@ class Ionizer(object):
                 ion.ux, ion.uy, ion.uz, ion.Ex, ion.Ey, ion.Ez,
                 ion.Bx, ion.By, ion.Bz, ion.w, self.w_times_level )
 
-        # Count the total number of new electrons (operation always performed
-        # on the CPU, as this is typically difficult on the GPU)
-        #if use_cuda:
-        #    n_ionized = n_ionized.get()
+        # Count the total number of new electrons 
         cumulative_n_ionized = perform_cumsum_2d( n_ionized, use_cuda )
         # If no new particle was created, skip the rest of this function
         if use_cuda:
@@ -279,10 +276,6 @@ class Ionizer(object):
         else:
             if np.all( cumulative_n_ionized[:,-1] == 0 ):
                 return
-        # Copy the cumulated number of electrons back on GPU
-        # (Keep a copy on the CPU)
-        #if use_cuda:
-        #    d_cumulative_n_ionized = cupy.asarray( cumulative_n_ionized )
 
         # Loop over the electron species associated to each level
         # (when store_electrons_per_level is False, there is a single species)
@@ -292,6 +285,7 @@ class Ionizer(object):
         assert len(self.target_species) == n_levels
         for i_level, elec in enumerate(self.target_species):
             old_Ntot = elec.Ntot
+            # Cast to int transfers the data from the GPU if needed
             new_Ntot = old_Ntot + int( cumulative_n_ionized[i_level,-1] )
             reallocate_and_copy_old( elec, use_cuda, old_Ntot, new_Ntot )
             # Create the new electrons from ionization (one thread per batch)


### PR DESCRIPTION
This PR moves the cumsum calculated after the particle ionization to the GPU using `cupy.cumsum`. This helps reduce overhead since much less data needs to be copied from device to host and back.