### PR TITLE
Moved cumsum to GPU in Compton kernels

### DIFF
--- a/fbpic/particles/elementary_process/compton/compton.py
+++ b/fbpic/particles/elementary_process/compton/compton.py
@@ -14,8 +14,6 @@ from ..cuda_numba_utils import allocate_empty, reallocate_and_copy_old, \
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
 from fbpic.utils.printing import catch_gpu_memory_error
-if cupy_installed:
-    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
     from numba.cuda.random import create_xoroshiro128p_states

--- a/fbpic/particles/elementary_process/compton/compton.py
+++ b/fbpic/particles/elementary_process/compton/compton.py
@@ -12,7 +12,7 @@ from .numba_methods import get_photon_density_gaussian_numba, \
 from ..cuda_numba_utils import allocate_empty, reallocate_and_copy_old, \
                                 perform_cumsum, generate_new_ids
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 from fbpic.utils.printing import catch_gpu_memory_error
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d

--- a/fbpic/particles/elementary_process/compton/compton.py
+++ b/fbpic/particles/elementary_process/compton/compton.py
@@ -199,13 +199,11 @@ class ComptonScatterer(object):
                 self.ratio_w_electron_photon, photon_n, self.photon_p,
                 self.photon_beta_x, self.photon_beta_y, self.photon_beta_z )
 
-        # Count the total number of new photons (operation always performed
-        # on the CPU, as this is typically difficult on the GPU)
-        if use_cuda:
-            nscatter_per_batch = nscatter_per_batch.get()
-        cumul_nscatter_per_batch = perform_cumsum( nscatter_per_batch )
+        # Count the total number of new photons 
+        cumul_nscatter_per_batch = perform_cumsum( nscatter_per_batch, use_cuda )
+        N_created = int( cumul_nscatter_per_batch[-1] )
         # If no new particle was created, skip the rest of this function
-        if cumul_nscatter_per_batch[-1] == 0:
+        if N_created == 0:
             return
 
         # Reallocate photons species (on CPU or GPU depending on `use_cuda`),
@@ -213,13 +211,12 @@ class ComptonScatterer(object):
         # and copy the old photons to the new arrays
         photons = self.target_species
         old_Ntot = photons.Ntot
-        new_Ntot = old_Ntot + cumul_nscatter_per_batch[-1]
+        new_Ntot = old_Ntot + N_created
         reallocate_and_copy_old( photons, use_cuda, old_Ntot, new_Ntot )
 
         # Create the new photons from ionization (with a random
         # scattering angle) and add recoil momentum to the electrons
         if use_cuda:
-            cumul_nscatter_per_batch = cupy.asarray(cumul_nscatter_per_batch)
             scatter_photons_electrons_cuda[ batch_grid_1d, batch_block_1d ](
                 N_batch, self.batch_size, old_Ntot, elec.Ntot,
                 cumul_nscatter_per_batch, nscatter_per_elec, random_states,

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -28,15 +28,19 @@ def allocate_empty( shape, use_cuda, dtype ):
     else:
         return( np.empty( shape, dtype=dtype ) )
 
-def perform_cumsum( input_array ):
+def perform_cumsum( input_array, use_cuda ):
     """
     Return an array containing the cumulative sum of the 1darray `input_array`
 
     (The returned array has one more element than `input_array`; its first
     element is 0 and its last element is the total sum of `input_array`)
     """
-    cumulative_array = np.zeros( len(input_array)+1, dtype=np.int64 )
-    np.cumsum( input_array, out=cumulative_array[1:] )
+    if use_cuda:
+        cumulative_array = cupy.zeros( len(input_array)+1, dtype=cupy.int64 )
+        cupy.cumsum( input_array, out=cumulative_array[1:] )
+    else:
+        cumulative_array = np.zeros( len(input_array)+1, dtype=np.int64 )
+        np.cumsum( input_array, out=cumulative_array[1:] )
     return( cumulative_array )
 
 def perform_cumsum_2d( input_array, use_cuda ):


### PR DESCRIPTION
This moves the calculation of the cumsum to the GPU in the Compton scattering module, analogously to the ionization module.