### PR TITLE
Added call to clear cupy memory pool for each exchange period

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -18,6 +18,8 @@ if cuda_installed:
     from .utils.cuda import send_data_to_gpu, \
                 receive_data_from_gpu, mpi_select_gpus
     mpi_select_gpus( MPI )
+    if cupy_installed:
+        import cupy
 
 # Import the rest of the requirements
 import sys
@@ -425,6 +427,11 @@ class Simulation(object):
                 # (Since particles have been removed / added to the simulation;
                 # otherwise rho_prev is obtained from the previous iteration.)
                 self.deposit('rho_prev', exchange=(use_true_rho is True))
+
+                # For simulations on GPU, clear the memory pool used by cupy.
+                if self.use_cuda:
+                    mempool = cupy.get_default_memory_pool()
+                    mempool.free_all_blocks()
 
             # For the field diagnostics of the first step: deposit J
             # (Note however that this is not the *corrected* current)


### PR DESCRIPTION
When allocating data on the GPU, cupy by default does not free memory when it is not needed anymore, instead caching the memory so that future allocations become faster. This is expected behaviour and does not lead to out-of-memory crashes since cupy detects when the memory pool is full and clears it when needed. 

However, this leads to the GPU memory filling up even for small simulations, which might be confusing to users. Additionally, it might conflict with other GPU libraries which are not aware of cupy. This PR forces cupy to clear its memory pool at each exchange period to remedy this.