### PR TITLE
Use `cupy` more extensively

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -18,7 +18,9 @@ from .pml_damping import PMLDamper
 from .particle_buffer_handling import remove_outside_particles, \
      add_buffers_to_particles, shift_particles_periodic_subdomain
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d
     from .cuda_methods import cuda_damp_EB_left, cuda_damp_EB_right, \
@@ -320,13 +322,13 @@ class BoundaryCommunicator(object):
                 self.left_damp = self.generate_damp_array(
                     self.n_guard, self.nz_damp, self.n_inject )
                 if cuda_installed:
-                    self.d_left_damp = cuda.to_device( self.left_damp )
+                    self.d_left_damp = cupy.asarray( self.left_damp )
             if self.right_proc is None:
                 # Create the damping arrays for right proc
                 self.right_damp = self.generate_damp_array(
                     self.n_guard, self.nz_damp, self.n_inject )
                 if cuda_installed:
-                    self.d_right_damp = cuda.to_device( self.right_damp )
+                    self.d_right_damp = cupy.asarray( self.right_damp )
 
         # Create damping object for the PML
         self.use_pml = (boundaries['r'] == "open")

--- a/fbpic/boundaries/cuda_methods.py
+++ b/fbpic/boundaries/cuda_methods.py
@@ -6,8 +6,9 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines a set of generic functions that operate on a GPU.
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 
-@cuda.jit
+@compile_cupy
 def copy_vec_to_gpu_buffer( vec_buffer_l, vec_buffer_r,
                             grid_r, grid_t, grid_z, m,
                             copy_left, copy_right, nz_start, nz_end ):
@@ -68,7 +69,7 @@ def copy_vec_to_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 vec_buffer_r[3*m+2, iz, ir] = grid_z[ iz_right, ir ]
 
 
-@cuda.jit
+@compile_cupy
 def copy_pml_to_gpu_buffer( vec_buffer_l, vec_buffer_r,
                             grid_r, grid_t, grid_z, pml_r, pml_t, m,
                             copy_left, copy_right, nz_start, nz_end ):
@@ -137,7 +138,7 @@ def copy_pml_to_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 vec_buffer_r[5*m+4, iz, ir] = pml_t[ iz_right, ir ]
 
 
-@cuda.jit
+@compile_cupy
 def copy_scal_to_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                              copy_left, copy_right, nz_start, nz_end ):
     """
@@ -192,7 +193,7 @@ def copy_scal_to_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                 scal_buffer_r[m, iz, ir] = grid[ iz_right, ir ]
 
 
-@cuda.jit
+@compile_cupy
 def replace_vec_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                                  grid_r, grid_t, grid_z, m,
                                  copy_left, copy_right, nz_start, nz_end ):
@@ -250,7 +251,7 @@ def replace_vec_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 grid_t[ iz_right, ir ] = vec_buffer_r[3*m+1, iz, ir]
                 grid_z[ iz_right, ir ] = vec_buffer_r[3*m+2, iz, ir]
 
-@cuda.jit
+@compile_cupy
 def replace_pml_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                                  grid_r, grid_t, grid_z, pml_r, pml_t, m,
                                  copy_left, copy_right, nz_start, nz_end ):
@@ -316,7 +317,7 @@ def replace_pml_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 pml_r[ iz_right, ir ] = vec_buffer_r[5*m+3, iz, ir]
                 pml_t[ iz_right, ir ] = vec_buffer_r[5*m+4, iz, ir]
 
-@cuda.jit
+@compile_cupy
 def replace_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                                  copy_left, copy_right, nz_start, nz_end ):
     """
@@ -369,7 +370,7 @@ def replace_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                 grid[ iz_right, ir ] = scal_buffer_r[m, iz, ir]
 
 
-@cuda.jit
+@compile_cupy
 def add_vec_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                              grid_r, grid_t, grid_z, m,
                              copy_left, copy_right, nz_start, nz_end ):
@@ -427,7 +428,7 @@ def add_vec_from_gpu_buffer( vec_buffer_l, vec_buffer_r,
                 grid_t[ iz_right, ir ] += vec_buffer_r[3*m+1, iz, ir]
                 grid_z[ iz_right, ir ] += vec_buffer_r[3*m+2, iz, ir]
 
-@cuda.jit
+@compile_cupy
 def add_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
                               copy_left, copy_right, nz_start, nz_end ):
     """
@@ -481,7 +482,7 @@ def add_scal_from_gpu_buffer( scal_buffer_l, scal_buffer_r, grid, m,
 
 # CUDA damping kernels:
 # --------------------
-@cuda.jit
+@compile_cupy
 def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
     """
     Multiply the E and B fields in the left guard cells
@@ -520,7 +521,7 @@ def cuda_damp_EB_left( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
             Bt[iz, ir] *= damp_factor_left
             Bz[iz, ir] *= damp_factor_left
 
-@cuda.jit
+@compile_cupy
 def cuda_damp_EB_left_pml( Er_pml, Et_pml, Br_pml, Bt_pml, damp_array, nd ):
     """
     Multiply the E and B fields in the left guard cells
@@ -557,7 +558,7 @@ def cuda_damp_EB_left_pml( Er_pml, Et_pml, Br_pml, Bt_pml, damp_array, nd ):
             Br_pml[iz, ir] *= damp_factor_left
             Bt_pml[iz, ir] *= damp_factor_left
 
-@cuda.jit
+@compile_cupy
 def cuda_damp_EB_right( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
     """
     Multiply the E and B fields in the right guard cells
@@ -598,7 +599,7 @@ def cuda_damp_EB_right( Er, Et, Ez, Br, Bt, Bz, damp_array, nd ):
             Bz[iz_right, ir] *= damp_factor_right
 
 
-@cuda.jit
+@compile_cupy
 def cuda_damp_EB_right_pml( Er_pml, Et_pml, Br_pml, Bt_pml, damp_array, nd ):
     """
     Multiply the E and B fields in the right guard cells

--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -7,7 +7,9 @@ It defines the structure necessary to handle mpi buffers for the fields
 """
 import numpy as np
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d
     from .cuda_methods import \
@@ -100,13 +102,13 @@ class BufferHandler(object):
 
         # Allocate buffers on the GPU, for the different exchange types
         if cuda_installed:
-            self.d_send_l = { key: cuda.to_device(value) for key, value in \
+            self.d_send_l = { key: cupy.asarray(value) for key, value in \
                                 self.send_l.items() }
-            self.d_send_r = { key: cuda.to_device(value) for key, value in \
+            self.d_send_r = { key: cupy.asarray(value) for key, value in \
                                 self.send_r.items() }
-            self.d_recv_l = { key: cuda.to_device(value) for key, value in \
+            self.d_recv_l = { key: cupy.asarray(value) for key, value in \
                                 self.recv_l.items() }
-            self.d_recv_r = { key: cuda.to_device(value) for key, value in \
+            self.d_recv_r = { key: cupy.asarray(value) for key, value in \
                                 self.recv_r.items() }
 
 
@@ -216,21 +218,21 @@ class BufferHandler(object):
                 # copy the GPU buffers to the sending CPU buffers
                 if not gpudirect:
                     if copy_left:
-                        self.d_send_l[exchange_type].copy_to_host(
-                            self.send_l[exchange_type] )
+                        self.d_send_l[exchange_type].get(
+                            out=self.send_l[exchange_type] )
                     if copy_right:
-                        self.d_send_r[exchange_type].copy_to_host(
-                            self.send_r[exchange_type] )
+                        self.d_send_r[exchange_type].get(
+                            out=self.send_r[exchange_type] )
 
             elif after_receiving:
                 # If GPUDirect with CUDA-aware MPI is not used,
                 # copy the CPU receiving buffers to the GPU buffers
                 if not gpudirect:
                     if copy_left:
-                        self.d_recv_l[exchange_type].copy_to_device(
+                        self.d_recv_l[exchange_type].set(
                             self.recv_l[exchange_type] )
                     if copy_right:
-                        self.d_recv_r[exchange_type].copy_to_device(
+                        self.d_recv_r[exchange_type].set(
                             self.recv_r[exchange_type] )
                 if method == 'replace':
                     # Replace the guard cells of the domain with the buffers
@@ -432,21 +434,21 @@ class BufferHandler(object):
                 # copy the GPU buffers to the sending CPU buffers
                 if not gpudirect:
                     if copy_left:
-                        self.d_send_l[exchange_type].copy_to_host(
-                            self.send_l[exchange_type] )
+                        self.d_send_l[exchange_type].get(
+                            out=self.send_l[exchange_type] )
                     if copy_right:
-                        self.d_send_r[exchange_type].copy_to_host(
-                            self.send_r[exchange_type] )
+                        self.d_send_r[exchange_type].get(
+                            out=self.send_r[exchange_type] )
 
             elif after_receiving:
                 # If GPUDirect with CUDA-aware MPI is not used,
                 # copy the CPU receiving buffers to the GPU buffers
                 if not gpudirect:
                     if copy_left:
-                        self.d_recv_l[exchange_type].copy_to_device(
+                        self.d_recv_l[exchange_type].set(
                             self.recv_l[exchange_type] )
                     if copy_right:
-                        self.d_recv_r[exchange_type].copy_to_device(
+                        self.d_recv_r[exchange_type].set(
                             self.recv_r[exchange_type] )
                 if method == 'replace':
                     # Replace the guard cells of the domain with the buffers

--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -9,7 +9,7 @@ from fbpic.utils.threading import njit_parallel, prange
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d, compile_cupy
 
 class MovingWindow(object):
     """
@@ -240,7 +240,7 @@ def shift_spect_array_cpu( field_array, shift_factor, n_move ):
 
 if cuda_installed:
 
-    @cuda.jit
+    @compile_cupy
     def shift_spect_array_gpu( field_array, shift_factor, n_move ):
         """
         Shift the field 'field_array' by n_move cells on the GPU.

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -13,7 +13,7 @@ from fbpic.utils.printing import catch_gpu_memory_error
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 def remove_outside_particles(species, fld, n_guard, left_proc, right_proc):
     """
@@ -560,7 +560,7 @@ def shift_particles_periodic_numba( z, zmin, zmax ):
 # -------------
 if cuda_installed:
 
-    @cuda.jit
+    @compile_cupy
     def split_particles_to_buffers( particle_array, left_buffer,
                     stay_buffer, right_buffer, i_min, i_max ):
         """
@@ -607,7 +607,7 @@ if cuda_installed:
             if (n_right != 0):
                 right_buffer[i-i_max] = particle_array[i]
 
-    @cuda.jit
+    @compile_cupy
     def copy_particles( N_elements, source_array, source_start,
                                     target_array, target_start ):
         """
@@ -634,7 +634,7 @@ if cuda_installed:
             target_array[i+target_start] = source_array[i+source_start]
 
 
-    @cuda.jit
+    @compile_cupy
     def shift_particles_periodic_cuda( z, zmin, zmax ):
         """
         Shift the particle positions by an integer number of box length,

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -8,8 +8,10 @@ It defines the structure necessary to handle mpi buffers for the particles
 import numpy as np
 import numba
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
 from fbpic.utils.printing import catch_gpu_memory_error
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
@@ -224,10 +226,10 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     # Reminder: prefix_sum[i] is the cumulative sum of the number of particles
     # in cells 0 to i (where cell i is included)
     if iz_min*(Nr+1) - 1 >= 0:
-        i_min = prefix_sum.getitem( iz_min*(Nr+1) - 1 )
+        i_min = int(prefix_sum[ iz_min*(Nr+1) - 1 ])
     else:
         i_min = 0
-    i_max = prefix_sum.getitem( iz_max*(Nr+1) - 1 )
+    i_max = int(prefix_sum[ iz_max*(Nr+1) - 1 ])
 
     # Total number of particles in each particle group
     N_send_l = i_min
@@ -263,9 +265,9 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     for i_attr in range(n_float):
         # Initialize 3 buffer arrays on the GPU (need to be initialized
         # inside the loop, as `copy_to_host` invalidates these arrays)
-        left_buffer = cuda.device_array((N_send_l,), dtype=np.float64)
-        right_buffer = cuda.device_array((N_send_r,), dtype=np.float64)
-        stay_buffer = cuda.device_array((new_Ntot,), dtype=np.float64)
+        left_buffer = cupy.empty((N_send_l,), dtype=np.float64)
+        right_buffer = cupy.empty((N_send_r,), dtype=np.float64)
+        stay_buffer = cupy.empty((new_Ntot,), dtype=np.float64)
         # Check that the buffers are still on GPU
         # (safeguard against automatic memory management)
         assert type(left_buffer) != np.ndarray
@@ -279,9 +281,9 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
         # and fill the sending buffers (if needed for MPI)
         setattr( attr_list[i_attr][0], attr_list[i_attr][1], stay_buffer)
         if left_proc is not None:
-            left_buffer.copy_to_host( float_send_left[i_attr] )
+            left_buffer.get( out=float_send_left[i_attr] )
         if right_proc is not None:
-            right_buffer.copy_to_host( float_send_right[i_attr] )
+            right_buffer.get( out=float_send_right[i_attr] )
 
     # Integer quantities:
     if n_int > 0:
@@ -293,9 +295,9 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
     for i_attr in range(n_int):
         # Initialize 3 buffer arrays on the GPU (need to be initialized
         # inside the loop, as `copy_to_host` invalidates these arrays)
-        left_buffer = cuda.device_array((N_send_l,), dtype=np.uint64)
-        right_buffer = cuda.device_array((N_send_r,), dtype=np.uint64)
-        stay_buffer = cuda.device_array((new_Ntot,), dtype=np.uint64)
+        left_buffer = cupy.empty((N_send_l,), dtype=np.uint64)
+        right_buffer = cupy.empty((N_send_r,), dtype=np.uint64)
+        stay_buffer = cupy.empty((new_Ntot,), dtype=np.uint64)
         # Split the particle array into the 3 buffers on the GPU
         particle_array = getattr( attr_list[i_attr][0], attr_list[i_attr][1] )
         split_particles_to_buffers[dim_grid_1d, dim_block_1d]( particle_array,
@@ -304,9 +306,9 @@ def remove_particles_gpu(species, fld, n_guard, left_proc, right_proc):
         # and fill the sending buffers (if needed for MPI)
         setattr( attr_list[i_attr][0], attr_list[i_attr][1], stay_buffer)
         if left_proc is not None:
-            left_buffer.copy_to_host( uint_send_left[i_attr] )
+            left_buffer.get( out=uint_send_left[i_attr] )
         if right_proc is not None:
-            right_buffer.copy_to_host( uint_send_right[i_attr] )
+            right_buffer.get( out=uint_send_right[i_attr] )
 
     # Change the new total number of particles
     species.Ntot = new_Ntot
@@ -349,20 +351,20 @@ def add_buffers_to_particles( species, float_recv_left, float_recv_right,
     if species.use_cuda:
         shape = (species.Ntot,)
         # Reallocate empty field-on-particle arrays on the GPU
-        species.Ex = cuda.device_array( shape, dtype=np.float64 )
-        species.Ex = cuda.device_array( shape, dtype=np.float64 )
-        species.Ey = cuda.device_array( shape, dtype=np.float64 )
-        species.Ez = cuda.device_array( shape, dtype=np.float64 )
-        species.Bx = cuda.device_array( shape, dtype=np.float64 )
-        species.By = cuda.device_array( shape, dtype=np.float64 )
-        species.Bz = cuda.device_array( shape, dtype=np.float64 )
+        species.Ex = cupy.empty( shape, dtype=np.float64 )
+        species.Ex = cupy.empty( shape, dtype=np.float64 )
+        species.Ey = cupy.empty( shape, dtype=np.float64 )
+        species.Ez = cupy.empty( shape, dtype=np.float64 )
+        species.Bx = cupy.empty( shape, dtype=np.float64 )
+        species.By = cupy.empty( shape, dtype=np.float64 )
+        species.Bz = cupy.empty( shape, dtype=np.float64 )
         # Reallocate empty auxiliary sorting arrays on the GPU
-        species.cell_idx = cuda.device_array( shape, dtype=np.int32 )
-        species.sorted_idx = cuda.device_array( shape, dtype=np.intp )
-        species.sorting_buffer = cuda.device_array( shape, dtype=np.float64 )
+        species.cell_idx = cupy.empty( shape, dtype=np.int32 )
+        species.sorted_idx = cupy.empty( shape, dtype=np.intp )
+        species.sorting_buffer = cupy.empty( shape, dtype=np.float64 )
         if species.n_integer_quantities > 0:
             species.int_sorting_buffer = \
-                cuda.device_array( shape, dtype=np.uint64 )
+                cupy.empty( shape, dtype=np.uint64 )
     else:
         # Reallocate empty field-on-particle arrays on the CPU
         species.Ex = np.empty(species.Ntot, dtype=np.float64)
@@ -459,10 +461,10 @@ def add_buffers_gpu( species, float_recv_left, float_recv_right,
     # Loop through the float quantities
     for i_attr in range( len(attr_list) ):
         # Copy the proper buffers to the GPU
-        left_buffer = cuda.to_device( float_recv_left[i_attr] )
-        right_buffer = cuda.to_device( float_recv_right[i_attr] )
+        left_buffer = cupy.asarray( float_recv_left[i_attr] )
+        right_buffer = cupy.asarray( float_recv_right[i_attr] )
         # Initialize the new particle array
-        particle_array = cuda.device_array( (new_Ntot,), dtype=np.float64)
+        particle_array = cupy.empty( (new_Ntot,), dtype=np.float64)
         # Merge the arrays on the GPU
         stay_buffer = getattr( attr_list[i_attr][0], attr_list[i_attr][1])
         if n_left != 0:
@@ -487,10 +489,10 @@ def add_buffers_gpu( species, float_recv_left, float_recv_right,
     # Loop through the integer quantities
     for i_attr in range( len(attr_list) ):
         # Copy the proper buffers to the GPU
-        left_buffer = cuda.to_device( uint_recv_left[i_attr] )
-        right_buffer = cuda.to_device( uint_recv_right[i_attr] )
+        left_buffer = cupy.asarray( uint_recv_left[i_attr] )
+        right_buffer = cupy.asarray( uint_recv_right[i_attr] )
         # Initialize the new particle array
-        particle_array = cuda.device_array( (new_Ntot,), dtype=np.uint64)
+        particle_array = cupy.empty( (new_Ntot,), dtype=np.uint64)
         # Merge the arrays on the GPU
         stay_buffer = getattr( attr_list[i_attr][0], attr_list[i_attr][1])
         if n_left != 0:

--- a/fbpic/boundaries/pml_damping.py
+++ b/fbpic/boundaries/pml_damping.py
@@ -6,7 +6,9 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the structure that damps the fields in the guard cells.
 """
 import numpy as np
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda
 
@@ -40,7 +42,7 @@ class PMLDamper(object):
 
         # Transfer the damping array to the GPU
         if cuda_installed:
-            self.d_damp_array = cuda.to_device( self.damp_array )
+            self.d_damp_array = cupy.asarray( self.damp_array )
 
 
     def damp_pml_EB( self, interp ):

--- a/fbpic/boundaries/pml_damping.py
+++ b/fbpic/boundaries/pml_damping.py
@@ -10,7 +10,7 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda
+    from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda, compile_cupy
 
 class PMLDamper(object):
     """
@@ -108,7 +108,7 @@ def generate_pml_damp_array( n_pml, cdt_over_dr ):
 
 
 if cuda_installed:
-    @cuda.jit
+    @compile_cupy
     def cuda_damp_pml_EB( Et, Et_pml, Ez, Bt, Bt_pml, Bz,
                       damp_array, n_pml ) :
         """

--- a/fbpic/fields/cuda_methods.py
+++ b/fbpic/fields/cuda_methods.py
@@ -6,6 +6,7 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the optimized fields methods that use cuda on a GPU
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 from scipy.constants import c, epsilon_0, mu_0
 c2 = c**2
 
@@ -13,7 +14,7 @@ c2 = c**2
 # Erasing functions
 # ------------------
 
-@cuda.jit
+@compile_cupy
 def cuda_erase_scalar( array ):
     """
     Set input array to 0
@@ -35,7 +36,7 @@ def cuda_erase_scalar( array ):
     if (iz < array.shape[0]) and (ir < array.shape[1]):
         array[iz, ir] = 0
 
-@cuda.jit
+@compile_cupy
 def cuda_erase_vector( array_r, array_t, array_z ):
     """
     Set the input arrays to 0
@@ -63,7 +64,7 @@ def cuda_erase_vector( array_r, array_t, array_z ):
 # Divide by volume functions
 # ---------------------------
 
-@cuda.jit
+@compile_cupy
 def cuda_divide_scalar_by_volume( array, invvol ):
     """
     Multiply the input array by the corresponding invvol
@@ -87,7 +88,7 @@ def cuda_divide_scalar_by_volume( array, invvol ):
         array[iz, ir] = array[iz, ir] * invvol[ir]
 
 
-@cuda.jit
+@compile_cupy
 def cuda_divide_vector_by_volume( array_r, array_t, array_z, invvol ):
     """
     Multiply the input arrays by the corresponding invvol
@@ -116,7 +117,7 @@ def cuda_divide_vector_by_volume( array_r, array_t, array_z, invvol ):
 # Methods of the SpectralGrid object
 # -----------------------------------
 
-@cuda.jit
+@compile_cupy
 def cuda_correct_currents_curlfree_standard( rho_prev, rho_next, Jp, Jm, Jz,
                             kz, kr, inv_k2, inv_dt, Nz, Nr ):
     """
@@ -139,7 +140,7 @@ def cuda_correct_currents_curlfree_standard( rho_prev, rho_next, Jp, Jm, Jz,
         Jm[iz, ir] += -0.5 * kr[iz, ir] * F
         Jz[iz, ir] += -1.j * kz[iz, ir] * F
 
-@cuda.jit
+@compile_cupy
 def cuda_correct_currents_crossdeposition_standard( rho_prev, rho_next,
         rho_next_z, rho_next_xy, Jp, Jm, Jz, kz, kr, inv_dt, Nz, Nr ):
     """
@@ -169,7 +170,7 @@ def cuda_correct_currents_crossdeposition_standard( rho_prev, rho_next,
             inv_kz = 1./kz[iz, ir]
             Jz[iz, ir] += 1.j * Dz * inv_kz
 
-@cuda.jit
+@compile_cupy
 def cuda_correct_currents_curlfree_comoving( rho_prev, rho_next, Jp, Jm, Jz,
                             kz, kr, inv_k2,
                             j_corr_coef, T_eb, T_cc,
@@ -195,7 +196,7 @@ def cuda_correct_currents_curlfree_comoving( rho_prev, rho_next, Jp, Jm, Jz,
         Jm[iz, ir] += -0.5 * kr[iz, ir] * F
         Jz[iz, ir] += -1.j * kz[iz, ir] * F
 
-@cuda.jit
+@compile_cupy
 def cuda_correct_currents_crossdeposition_comoving(
         rho_prev, rho_next, rho_next_z, rho_next_xy, Jp, Jm, Jz,
         kz, kr, j_corr_coef, T_eb, T_cc, inv_dt, Nz, Nr ) :
@@ -230,7 +231,7 @@ def cuda_correct_currents_crossdeposition_comoving(
             Jz[iz, ir] += 1.j * Dz * inv_kz
 
 
-@cuda.jit
+@compile_cupy
 def cuda_push_eb_standard( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                        rho_prev, rho_next,
                        rho_prev_coef, rho_next_coef, j_coef,
@@ -300,7 +301,7 @@ def cuda_push_eb_standard( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                         + 1.j*kr[iz, ir]*Jm[iz, ir] )
 
 
-@cuda.jit
+@compile_cupy
 def cuda_push_eb_pml_standard( Ep_pml, Em_pml, Bp_pml, Bm_pml,
                         Ez, Bz, C, S_w, kr, kz, Nz, Nr):
     """
@@ -329,7 +330,7 @@ def cuda_push_eb_pml_standard( Ep_pml, Em_pml, Bp_pml, Bm_pml,
             - S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Ez[iz, ir] )
 
 
-@cuda.jit
+@compile_cupy
 def cuda_push_eb_comoving( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                        rho_prev, rho_next,
                        rho_prev_coef, rho_next_coef, j_coef,
@@ -410,7 +411,7 @@ def cuda_push_eb_comoving( Ep, Em, Ez, Bp, Bm, Bz, Jp, Jm, Jz,
                         + 1.j*kr[iz, ir]*Jm[iz, ir] )
 
 
-@cuda.jit
+@compile_cupy
 def cuda_push_eb_pml_comoving( Ep_pml, Em_pml, Bp_pml, Bm_pml,
                         Ez, Bz, C, S_w, T_eb, kr, kz, Nz, Nr):
     """
@@ -438,7 +439,7 @@ def cuda_push_eb_pml_comoving( Ep_pml, Em_pml, Bp_pml, Bm_pml,
             - T_eb[iz, ir]*S_w[iz, ir]*( -1.j*0.5*kr[iz, ir]*Ez[iz, ir] )
 
 
-@cuda.jit
+@compile_cupy
 def cuda_push_rho( rho_prev, rho_next, Nz, Nr ) :
     """
     Transfer the values of rho_next to rho_prev,
@@ -462,7 +463,7 @@ def cuda_push_rho( rho_prev, rho_next, Nz, Nr ) :
         rho_prev[iz, ir] = rho_next[iz, ir]
         rho_next[iz, ir] = 0.
 
-@cuda.jit
+@compile_cupy
 def cuda_filter_scalar( field, Nz, Nr, filter_array_z, filter_array_r ) :
     """
     Multiply the input field by the filter_array
@@ -487,7 +488,7 @@ def cuda_filter_scalar( field, Nz, Nr, filter_array_z, filter_array_r ) :
 
         field[iz, ir] = filter_array_z[iz]*filter_array_r[ir]*field[iz, ir]
 
-@cuda.jit
+@compile_cupy
 def cuda_filter_vector( fieldr, fieldt, fieldz, Nz, Nr,
                         filter_array_z, filter_array_r ):
     """

--- a/fbpic/fields/fields.py
+++ b/fbpic/fields/fields.py
@@ -136,6 +136,7 @@ class Fields(object) :
                 'Cuda not available for the fields.\n'
                 'Performing the field operations on the CPU.' )
             self.use_cuda = False
+        self.data_is_on_gpu = False # Data is initialized on CPU
 
         # Register the current correction type
         if current_correction in ['curl-free', 'cross-deposition']:
@@ -219,6 +220,7 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.interp[m].send_fields_to_gpu()
                 self.spect[m].send_fields_to_gpu()
+            self.data_is_on_gpu = True
 
     def receive_fields_from_gpu( self ):
         """
@@ -231,6 +233,7 @@ class Fields(object) :
             for m in range(self.Nm) :
                 self.interp[m].receive_fields_from_gpu()
                 self.spect[m].receive_fields_from_gpu()
+            self.data_is_on_gpu = False
 
     def push(self, use_true_rho=False, check_exchanges=False):
         """

--- a/fbpic/fields/interpolation_grid.py
+++ b/fbpic/fields/interpolation_grid.py
@@ -6,9 +6,10 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the InterpolationGrid class.
 """
 import numpy as np
-from numba import cuda
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
     from .cuda_methods import \
@@ -98,7 +99,7 @@ class InterpolationGrid(object) :
 
         # Replace the invvol array by an array on the GPU, when using cuda
         if self.use_cuda :
-            self.d_invvol = cuda.to_device( self.invvol )
+            self.d_invvol = cupy.asarray( self.invvol )
 
     @property
     def z(self):
@@ -117,21 +118,21 @@ class InterpolationGrid(object) :
         After this function is called, the array attributes
         point to GPU arrays.
         """
-        self.Er = cuda.to_device( self.Er )
-        self.Et = cuda.to_device( self.Et )
-        self.Ez = cuda.to_device( self.Ez )
-        self.Br = cuda.to_device( self.Br )
-        self.Bt = cuda.to_device( self.Bt )
-        self.Bz = cuda.to_device( self.Bz )
-        self.Jr = cuda.to_device( self.Jr )
-        self.Jt = cuda.to_device( self.Jt )
-        self.Jz = cuda.to_device( self.Jz )
-        self.rho = cuda.to_device( self.rho )
+        self.Er = cupy.asarray( self.Er )
+        self.Et = cupy.asarray( self.Et )
+        self.Ez = cupy.asarray( self.Ez )
+        self.Br = cupy.asarray( self.Br )
+        self.Bt = cupy.asarray( self.Bt )
+        self.Bz = cupy.asarray( self.Bz )
+        self.Jr = cupy.asarray( self.Jr )
+        self.Jt = cupy.asarray( self.Jt )
+        self.Jz = cupy.asarray( self.Jz )
+        self.rho = cupy.asarray( self.rho )
         if self.use_pml:
-            self.Er_pml = cuda.to_device( self.Er_pml )
-            self.Et_pml = cuda.to_device( self.Et_pml )
-            self.Br_pml = cuda.to_device( self.Br_pml )
-            self.Bt_pml = cuda.to_device( self.Bt_pml )
+            self.Er_pml = cupy.asarray( self.Er_pml )
+            self.Et_pml = cupy.asarray( self.Et_pml )
+            self.Br_pml = cupy.asarray( self.Br_pml )
+            self.Bt_pml = cupy.asarray( self.Bt_pml )
 
     def receive_fields_from_gpu( self ):
         """
@@ -140,21 +141,21 @@ class InterpolationGrid(object) :
         After this function is called, the array attributes
         are accessible by the CPU again.
         """
-        self.Er = self.Er.copy_to_host()
-        self.Et = self.Et.copy_to_host()
-        self.Ez = self.Ez.copy_to_host()
-        self.Br = self.Br.copy_to_host()
-        self.Bt = self.Bt.copy_to_host()
-        self.Bz = self.Bz.copy_to_host()
-        self.Jr = self.Jr.copy_to_host()
-        self.Jt = self.Jt.copy_to_host()
-        self.Jz = self.Jz.copy_to_host()
-        self.rho = self.rho.copy_to_host()
+        self.Er = self.Er.get()
+        self.Et = self.Et.get()
+        self.Ez = self.Ez.get()
+        self.Br = self.Br.get()
+        self.Bt = self.Bt.get()
+        self.Bz = self.Bz.get()
+        self.Jr = self.Jr.get()
+        self.Jt = self.Jt.get()
+        self.Jz = self.Jz.get()
+        self.rho = self.rho.get()
         if self.use_pml:
-            self.Er_pml = self.Er_pml.copy_to_host()
-            self.Et_pml = self.Et_pml.copy_to_host()
-            self.Br_pml = self.Br_pml.copy_to_host()
-            self.Bt_pml = self.Bt_pml.copy_to_host()
+            self.Er_pml = self.Er_pml.get()
+            self.Et_pml = self.Et_pml.get()
+            self.Br_pml = self.Br_pml.get()
+            self.Bt_pml = self.Bt_pml.get()
 
     def erase( self, fieldtype ):
         """

--- a/fbpic/fields/psatd_coefs.py
+++ b/fbpic/fields/psatd_coefs.py
@@ -7,7 +7,9 @@ It defines the PsatdCoeffs class.
 """
 import numpy as np
 from scipy.constants import c, mu_0, epsilon_0
-from numba import cuda
+from fbpic.utils.cuda import cupy_installed
+if cupy_installed:
+    from fbpic.utils.cuda import cupy
 
 
 class PsatdCoeffs(object) :
@@ -162,14 +164,14 @@ class PsatdCoeffs(object) :
 
         # Replace these array by arrays on the GPU, when using cuda
         if use_cuda:
-            self.d_C = cuda.to_device(self.C)
-            self.d_S_w = cuda.to_device(self.S_w)
-            self.d_j_coef = cuda.to_device(self.j_coef)
-            self.d_rho_prev_coef = cuda.to_device(self.rho_prev_coef)
-            self.d_rho_next_coef = cuda.to_device(self.rho_next_coef)
+            self.d_C = cupy.asarray(self.C)
+            self.d_S_w = cupy.asarray(self.S_w)
+            self.d_j_coef = cupy.asarray(self.j_coef)
+            self.d_rho_prev_coef = cupy.asarray(self.rho_prev_coef)
+            self.d_rho_next_coef = cupy.asarray(self.rho_next_coef)
             if self.V is not None:
                 # Variables which are specific to the Galilean/comoving scheme
-                self.d_T_eb = cuda.to_device(self.T_eb)
-                self.d_T_cc = cuda.to_device(self.T_cc)
-                self.d_T_rho = cuda.to_device(self.T_rho)
-                self.d_j_corr_coef = cuda.to_device(self.j_corr_coef)
+                self.d_T_eb = cupy.asarray(self.T_eb)
+                self.d_T_cc = cupy.asarray(self.T_cc)
+                self.d_T_rho = cupy.asarray(self.T_rho)
+                self.d_j_corr_coef = cupy.asarray(self.j_corr_coef)

--- a/fbpic/fields/spectral_grid.py
+++ b/fbpic/fields/spectral_grid.py
@@ -15,10 +15,12 @@ from .numba_methods import numba_push_eb_standard, numba_push_eb_comoving, \
     numba_correct_currents_crossdeposition_comoving, \
     numba_filter_scalar, numba_filter_vector
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
-    from .cuda_methods import cuda, \
+    from .cuda_methods import \
     cuda_correct_currents_curlfree_standard, \
     cuda_correct_currents_crossdeposition_standard, \
     cuda_correct_currents_curlfree_comoving, \
@@ -127,13 +129,13 @@ class SpectralGrid(object) :
 
         # Transfer the auxiliary arrays on the GPU
         if self.use_cuda :
-            self.d_filter_array_z = cuda.to_device( self.filter_array_z )
-            self.d_filter_array_r = cuda.to_device( self.filter_array_r )
-            self.d_kz = cuda.to_device( self.kz )
-            self.d_kr = cuda.to_device( self.kr )
-            self.d_field_shift = cuda.to_device( self.field_shift )
+            self.d_filter_array_z = cupy.asarray( self.filter_array_z )
+            self.d_filter_array_r = cupy.asarray( self.filter_array_r )
+            self.d_kz = cupy.asarray( self.kz )
+            self.d_kr = cupy.asarray( self.kr )
+            self.d_field_shift = cupy.asarray( self.field_shift )
             if current_correction == 'curl-free':
-                self.d_inv_k2 = cuda.to_device( self.inv_k2 )
+                self.d_inv_k2 = cupy.asarray( self.inv_k2 )
 
 
     def send_fields_to_gpu( self ):
@@ -143,26 +145,26 @@ class SpectralGrid(object) :
         After this function is called, the array attributes
         point to GPU arrays.
         """
-        self.Ep = cuda.to_device( self.Ep )
-        self.Em = cuda.to_device( self.Em )
-        self.Ez = cuda.to_device( self.Ez )
-        self.Bp = cuda.to_device( self.Bp )
-        self.Bm = cuda.to_device( self.Bm )
-        self.Bz = cuda.to_device( self.Bz )
-        self.Jp = cuda.to_device( self.Jp )
-        self.Jm = cuda.to_device( self.Jm )
-        self.Jz = cuda.to_device( self.Jz )
-        self.rho_prev = cuda.to_device( self.rho_prev )
-        self.rho_next = cuda.to_device( self.rho_next )
+        self.Ep = cupy.asarray( self.Ep )
+        self.Em = cupy.asarray( self.Em )
+        self.Ez = cupy.asarray( self.Ez )
+        self.Bp = cupy.asarray( self.Bp )
+        self.Bm = cupy.asarray( self.Bm )
+        self.Bz = cupy.asarray( self.Bz )
+        self.Jp = cupy.asarray( self.Jp )
+        self.Jm = cupy.asarray( self.Jm )
+        self.Jz = cupy.asarray( self.Jz )
+        self.rho_prev = cupy.asarray( self.rho_prev )
+        self.rho_next = cupy.asarray( self.rho_next )
         if self.use_pml:
-            self.Ep_pml = cuda.to_device( self.Ep_pml )
-            self.Em_pml = cuda.to_device( self.Em_pml )
-            self.Bp_pml = cuda.to_device( self.Bp_pml )
-            self.Bm_pml = cuda.to_device( self.Bm_pml )
+            self.Ep_pml = cupy.asarray( self.Ep_pml )
+            self.Em_pml = cupy.asarray( self.Em_pml )
+            self.Bp_pml = cupy.asarray( self.Bp_pml )
+            self.Bm_pml = cupy.asarray( self.Bm_pml )
         # Only when using the cross-deposition
         if hasattr( self, 'rho_next_z' ):
-            self.rho_next_z = cuda.to_device( self.rho_next_z )
-            self.rho_next_xy = cuda.to_device( self.rho_next_xy )
+            self.rho_next_z = cupy.asarray( self.rho_next_z )
+            self.rho_next_xy = cupy.asarray( self.rho_next_xy )
 
 
     def receive_fields_from_gpu( self ):
@@ -172,26 +174,26 @@ class SpectralGrid(object) :
         After this function is called, the array attributes
         are accessible by the CPU again.
         """
-        self.Ep = self.Ep.copy_to_host()
-        self.Em = self.Em.copy_to_host()
-        self.Ez = self.Ez.copy_to_host()
-        self.Bp = self.Bp.copy_to_host()
-        self.Bm = self.Bm.copy_to_host()
-        self.Bz = self.Bz.copy_to_host()
-        self.Jp = self.Jp.copy_to_host()
-        self.Jm = self.Jm.copy_to_host()
-        self.Jz = self.Jz.copy_to_host()
+        self.Ep = self.Ep.get()
+        self.Em = self.Em.get()
+        self.Ez = self.Ez.get()
+        self.Bp = self.Bp.get()
+        self.Bm = self.Bm.get()
+        self.Bz = self.Bz.get()
+        self.Jp = self.Jp.get()
+        self.Jm = self.Jm.get()
+        self.Jz = self.Jz.get()
         if self.use_pml:
-            self.Ep_pml = self.Ep_pml.copy_to_host()
-            self.Em_pml = self.Em_pml.copy_to_host()
-            self.Bp_pml = self.Bp_pml.copy_to_host()
-            self.Bm_pml = self.Bm_pml.copy_to_host()
-        self.rho_prev = self.rho_prev.copy_to_host()
-        self.rho_next = self.rho_next.copy_to_host()
+            self.Ep_pml = self.Ep_pml.get()
+            self.Em_pml = self.Em_pml.get()
+            self.Bp_pml = self.Bp_pml.get()
+            self.Bm_pml = self.Bm_pml.get()
+        self.rho_prev = self.rho_prev.get()
+        self.rho_next = self.rho_next.get()
         # Only when using the cross-deposition
         if hasattr( self, 'rho_next_z' ):
-            self.rho_next_z = self.rho_next_z.copy_to_host()
-            self.rho_next_xy = self.rho_next_xy.copy_to_host()
+            self.rho_next_z = self.rho_next_z.get()
+            self.rho_next_xy = self.rho_next_xy.get()
 
 
     def correct_currents (self, dt, ps, current_correction ):

--- a/fbpic/fields/spectral_transform/cuda_methods.py
+++ b/fbpic/fields/spectral_transform/cuda_methods.py
@@ -7,12 +7,13 @@ It defines a set of functions that are useful when converting the
 fields from interpolation grid to the spectral grid and vice-versa
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 
 # ------------------
 # Copying functions
 # ------------------
 
-@cuda.jit
+@compile_cupy
 def cuda_copy_2dC_to_2dR( array_in, array_out ) :
     """
     Store the complex Nz x Nr array `array_in`
@@ -36,7 +37,7 @@ def cuda_copy_2dC_to_2dR( array_in, array_out ) :
         array_out[iz, ir] = array_in[iz, ir].real
         array_out[iz+Nz, ir] = array_in[iz, ir].imag
 
-@cuda.jit
+@compile_cupy
 def cuda_copy_2dR_to_2dC( array_in, array_out ) :
     """
     Reconstruct the complex Nz x Nr array `array_out`,
@@ -59,7 +60,7 @@ def cuda_copy_2dR_to_2dC( array_in, array_out ) :
     if (iz < Nz) and (ir < Nr) :
         array_out[iz, ir] = array_in[iz, ir] + 1.j*array_in[iz+Nz, ir]
 
-@cuda.jit
+@compile_cupy
 def cuda_copy_2d_to_1d( array_2d, array_1d ) :
     """
     Copy array_2d to array_1d, so that the first axis of array_2d
@@ -85,7 +86,7 @@ def cuda_copy_2d_to_1d( array_2d, array_1d ) :
         i = iz + array_2d.shape[0]*ir
         array_1d[i] = array_2d[iz, ir]
 
-@cuda.jit
+@compile_cupy
 def cuda_copy_1d_to_2d( array_1d, array_2d ) :
     """
     Copy array_1d to array_2d, so that the first axis of array_2d
@@ -115,7 +116,7 @@ def cuda_copy_1d_to_2d( array_1d, array_2d ) :
 # Functions that combine components in spectral space
 # ----------------------------------------------------
 
-@cuda.jit
+@compile_cupy
 def cuda_rt_to_pm( buffer_r, buffer_t, buffer_p, buffer_m ) :
     """
     Combine the arrays buffer_r and buffer_t to produce the
@@ -136,7 +137,7 @@ def cuda_rt_to_pm( buffer_r, buffer_t, buffer_p, buffer_m ) :
         buffer_m[iz, ir] = 0.5*( value_r + 1.j*value_t )
 
 
-@cuda.jit
+@compile_cupy
 def cuda_pm_to_rt( buffer_p, buffer_m, buffer_r, buffer_t ) :
     """
     Combine the arrays buffer_p and buffer_m to produce the

--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -16,7 +16,7 @@ from scipy.special import jn, jn_zeros
 from fbpic.utils.cuda import cuda_installed, cupy_installed
 from .numba_methods import numba_copy_2dC_to_2dR, numba_copy_2dR_to_2dC
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d, cuda_gpu_model
+    from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda_gpu_model
     from .cuda_methods import cuda_copy_2dC_to_2dR, cuda_copy_2dR_to_2dC
 if cupy_installed:
     import cupy
@@ -124,8 +124,8 @@ class DHT(object):
 
         # Copy the matrices to the GPU if needed
         if self.use_cuda:
-            self.d_M = cuda.to_device( self.M )
-            self.d_invM = cuda.to_device( self.invM )
+            self.d_M = cupy.asarray( self.M )
+            self.d_invM = cupy.asarray( self.invM )
 
         # Initialize buffer arrays to store the complex Nz x Nr grid
         # as a real 2Nz x Nr grid, before performing the matrix product
@@ -139,8 +139,8 @@ class DHT(object):
         else:
             # Initialize real buffer arrays on the GPU
             zero_array = np.zeros((2*Nz, Nr), dtype=np.float64)
-            self.d_in = cuda.to_device( zero_array )
-            self.d_out = cuda.to_device( zero_array )
+            self.d_in = cupy.asarray( zero_array )
+            self.d_out = cupy.asarray( zero_array )
             # Initialize cuBLAS
             self.blas = device.get_cublas_handle()
             # Set optimal number of CUDA threads per block
@@ -191,9 +191,9 @@ class DHT(object):
             cuda_copy_2dC_to_2dR[self.dim_grid, self.dim_block]( F, self.d_in )
             # Call cuBLAS gemm kernel
             cublas.dgemm(self.blas, 0, 0, self.Nr, 2*self.Nz, self.Nr,
-                         1, cupy.asarray(self.d_M).data.ptr, self.Nr,
-                            cupy.asarray(self.d_in).data.ptr, self.Nr,
-                         0, cupy.asarray(self.d_out).data.ptr, self.Nr)
+                         1, self.d_M.data.ptr, self.Nr,
+                            self.d_in.data.ptr, self.Nr,
+                         0, self.d_out.data.ptr, self.Nr)
             # Convert F-order, real `d_out` to the C-order, complex `G`
             cuda_copy_2dR_to_2dC[self.dim_grid, self.dim_block]( self.d_out, G )
         else:
@@ -222,9 +222,9 @@ class DHT(object):
             cuda_copy_2dC_to_2dR[self.dim_grid, self.dim_block](G, self.d_in )
             # Call cuBLAS gemm kernel
             cublas.dgemm(self.blas, 0, 0, self.Nr, 2*self.Nz, self.Nr,
-                         1, cupy.asarray(self.d_invM).data.ptr, self.Nr,
-                            cupy.asarray(self.d_in).data.ptr, self.Nr,
-                         0, cupy.asarray(self.d_out).data.ptr, self.Nr)
+                         1, self.d_invM.data.ptr, self.Nr,
+                            self.d_in.data.ptr, self.Nr,
+                         0, self.d_out.data.ptr, self.Nr)
             # Convert the F-order d_out array to the C-order F array
             cuda_copy_2dR_to_2dC[self.dim_grid, self.dim_block]( self.d_out, F )
         else:

--- a/fbpic/fields/spectral_transform/spectral_transformer.py
+++ b/fbpic/fields/spectral_transform/spectral_transformer.py
@@ -12,7 +12,9 @@ from .fourier import FFT
 
 from .numba_methods import numba_rt_to_pm, numba_pm_to_rt
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed, cuda
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
     from .cuda_methods import cuda_rt_to_pm, cuda_pm_to_rt
@@ -72,9 +74,9 @@ class SpectralTransformer(object) :
 
         # Initialize the spectral buffers
         if self.use_cuda:
-            self.spect_buffer_r = cuda.device_array(
+            self.spect_buffer_r = cupy.empty(
                 (Nz, Nr), dtype=np.complex128)
-            self.spect_buffer_t = cuda.device_array(
+            self.spect_buffer_t = cupy.empty(
                 (Nz, Nr), dtype=np.complex128)
         else:
             # Initialize the spectral buffers

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -11,6 +11,7 @@ from fbpic.fields import Fields
 from fbpic.particles.elementary_process.cuda_numba_utils import \
     reallocate_and_copy_old
 from fbpic.particles.injection import BallisticBeforePlane
+from fbpic.utils.cuda import GpuMemoryManager
 import warnings
 
 
@@ -835,10 +836,12 @@ def get_space_charge_fields( sim, ptcl, direction='forward' ):
         gamma = w_gamma_sum/w_sum
 
     # Project the charge and currents onto the local subdomain
-    sim.deposit( 'rho', exchange=True, species_list=[ptcl],
-                    update_spectral=False )
-    sim.deposit( 'J', exchange=True, species_list=[ptcl],
-                    update_spectral=False )
+    # (Move data to GPU if needed, for this step)
+    with GpuMemoryManager(sim):
+        sim.deposit( 'rho', exchange=True, species_list=[ptcl],
+                        update_spectral=False )
+        sim.deposit( 'J', exchange=True, species_list=[ptcl],
+                        update_spectral=False )
 
     # Create a global field object across all subdomains, and copy the sources
     # (Space-charge calculation is a global operation)

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -13,7 +13,9 @@ from fbpic.particles.utilities.utility_methods import weights
 from fbpic.particles.deposition.numba_methods import deposit_field_numba
 
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
@@ -168,10 +170,10 @@ class LaserAntenna( object ):
         self.Jt_buffer = np.empty( (Nm, 2, Nr_grid), dtype='complex' )
         self.Jz_buffer = np.empty( (Nm, 2, Nr_grid), dtype='complex' )
         if cuda_installed:
-            self.d_rho_buffer = cuda.device_array_like( self.rho_buffer )
-            self.d_Jr_buffer = cuda.device_array_like( self.Jr_buffer )
-            self.d_Jt_buffer = cuda.device_array_like( self.Jt_buffer )
-            self.d_Jz_buffer = cuda.device_array_like( self.Jz_buffer )
+            self.d_rho_buffer = cupy.asarray( self.rho_buffer )
+            self.d_Jr_buffer = cupy.asarray( self.Jr_buffer )
+            self.d_Jt_buffer = cupy.asarray( self.Jt_buffer )
+            self.d_Jz_buffer = cupy.asarray( self.Jz_buffer )
 
     def update_current_rank(self, comm):
         """
@@ -445,7 +447,7 @@ class LaserAntenna( object ):
         else:
             # The large-size array rho is on the GPU
             # Copy the small-size buffer to the GPU
-            cuda.to_device( self.rho_buffer, to=self.d_rho_buffer )
+            self.d_rho_buffer.set( self.rho_buffer)
             # On the GPU: add the small-size buffers to the large-size array
             dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( grid[0].Nr, TPB=64 )
             for m in range( Nm ):
@@ -477,9 +479,9 @@ class LaserAntenna( object ):
         else:
             # The large-size arrays for J are on the GPU
             # Copy the small-size buffers to the GPU
-            cuda.to_device( self.Jr_buffer, to=self.d_Jr_buffer )
-            cuda.to_device( self.Jt_buffer, to=self.d_Jt_buffer )
-            cuda.to_device( self.Jz_buffer, to=self.d_Jz_buffer )
+            self.d_Jr_buffer.set( self.Jr_buffer)
+            self.d_Jt_buffer.set( self.Jt_buffer)
+            self.d_Jz_buffer.set( self.Jz_buffer)
             # On the GPU: add the small-size buffers to the large-size array
             dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( grid[0].Nr, TPB=64 )
             for m in range( Nm ):

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -17,7 +17,7 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 class LaserAntenna( object ):
     """
@@ -491,7 +491,7 @@ class LaserAntenna( object ):
 
 if cuda_installed:
 
-    @cuda.jit()
+    @compile_cupy
     def add_rho_to_gpu_array( iz_min, rho_buffer, rho, m ):
         """
         Add the small-size array rho_buffer into the full-size array rho
@@ -520,7 +520,7 @@ if cuda_installed:
             rho[iz_min, ir] += rho_buffer[m, 0, ir]
             rho[iz_min+1, ir] += rho_buffer[m, 1, ir]
 
-    @cuda.jit()
+    @compile_cupy
     def add_J_to_gpu_array( iz_min, Jr_buffer, Jt_buffer,
                             Jz_buffer, Jr, Jt, Jz, m ):
         """

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -20,6 +20,7 @@ if cuda_installed:
     mpi_select_gpus( MPI )
 
 # Import the rest of the requirements
+import sys
 import warnings
 import numba
 import numpy as np
@@ -216,28 +217,30 @@ class Simulation(object):
                 'Cuda not available for the simulation.\n'
                 'Performing the simulation on CPU.' )
             self.use_cuda = False
-        # Check that cupy and numba have the right version
+        # Check that cupy, numba and Python have the right version
         if self.use_cuda:
             if not cupy_installed:
                 raise RuntimeError(
                     'In order to run on GPUs, FBPIC version 0.13 and later \n'
                     'require the `cupy` package.\n'
                     'See the FBPIC documentation in order to install cupy.')
-            elif (cupy_major_version >= 7 and numba_minor_version < 46):
+            elif cupy_major_version < 7:
                 raise RuntimeError(
-                    'You are using cupy version %d.\nFor compatibility, '
-                    'you need to install numba 0.46 or later.\n'
-                    '(Your current version is numba 0.%d.)\n'
-                    'e.g. with `conda uninstall numba; conda install numba`.'
-                    %(cupy_major_version,numba_minor_version))
-            elif (cupy_major_version < 7 and numba_minor_version >= 46):
+                    'In order to run on GPUs, FBPIC version 0.16 and later \n'
+                    'requires `cupy` version 7 (or later).\n(The `cupy` version'
+                    ' on your current system is %d.)\nPlease install the '
+                    'latest version of `cupy`.' %cupy_major_version)
+            elif numba_minor_version < 46:
                 raise RuntimeError(
-                    'You are using numba version 0.%d.\nFor compatibility, '
-                    'you need to install cupy 7 or later.\n'
-                    '(Your current version is cupy %d.)\n'
-                    'e.g. with `pip install --upgrade cupy-cudaXXX`\n'
-                    'where `XXX` should be replaced by your cuda version.'
-                    %(numba_minor_version,cupy_major_version))
+                    'In order to run on GPUs, FBPIC version 0.16 and later \n'
+                    'requires `numba` version 0.46 (or later).\n(The `numba` '
+                    'version on your current system is 0.%d.)\nPlease install'
+                    ' the latest version of `numba`.' %numba_minor_version)
+            elif sys.version_info.major < 3:
+                raise RuntimeError(
+                    'In order to run on GPUs, FBPIC version 0.16 and later \n'
+                    'requires Python 3.\n(The Python version on your current '
+                    'system is Python 2.)\nPlease install Python 3.')
         # CPU multi-threading
         self.use_threading = threading_enabled
         if self.use_threading:

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -18,6 +18,8 @@ if cuda_installed:
     from .utils.cuda import send_data_to_gpu, \
                 receive_data_from_gpu, mpi_select_gpus
     mpi_select_gpus( MPI )
+    if cupy_installed:
+        import cupy
 
 # Import the rest of the requirements
 import sys
@@ -425,6 +427,11 @@ class Simulation(object):
                 # (Since particles have been removed / added to the simulation;
                 # otherwise rho_prev is obtained from the previous iteration.)
                 self.deposit('rho_prev', exchange=(use_true_rho is True))
+
+                # For simulations on GPU, clear the memory pool used by cupy.
+                if self.use_cuda:
+                    mempool = cupy.get_default_memory_pool()
+                    mempool.free_all_blocks()
 
             # For the field diagnostics of the first step: deposit J
             # (Note however that this is not the *corrected* current)

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -21,7 +21,7 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 class BackTransformedFieldDiagnostic(FieldDiagnostic):
     """
@@ -736,7 +736,7 @@ class SliceHandler:
 
 if cuda_installed:
 
-    @cuda.jit
+    @compile_cupy
     def extract_slice_cuda( Nr, iz, Sz, slice_arr,
         Er, Et, Ez, Br, Bt, Bz, Jr, Jt, Jz, rho, m ):
         """

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -17,7 +17,9 @@ from scipy.constants import c
 from .field_diag import FieldDiagnostic
 
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
@@ -420,7 +422,7 @@ class LabSnapshot:
         if fld.use_cuda is False:
             self.slice_array = np.empty( data_shape )
         else:
-            self.slice_array = cuda.device_array( data_shape )
+            self.slice_array = cupy.empty( data_shape )
 
     def update_current_output_positions( self, t_boost, inv_gamma, inv_beta ):
         """
@@ -471,7 +473,7 @@ class LabSnapshot:
             self.buffered_slices.append( self.slice_array.copy() )
         # or copy from the GPU
         else:
-            self.buffered_slices.append( self.slice_array.copy_to_host() )
+            self.buffered_slices.append( self.slice_array.get() )
 
     def compact_slices(self):
         """
@@ -752,10 +754,10 @@ if cuda_installed:
         Sz: float
             Interpolation shape factor used at iz
 
-        slice_arr: cuda.device_array
+        slice_arr: cupy.empty
             Array of floats of shape (10, 2*Nm-1, Nr)
 
-        Er, Et, etc...: cuda.device_array
+        Er, Et, etc...: cupy.empty
             Array of complexs of shape (Nz, Nr), for the azimuthal mode m
 
         m: int

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -685,14 +685,14 @@ class ParticleCatcher:
             elif z_cell_curr > Nz:
                 pref_sum_curr = species.Ntot
             else:
-                pref_sum_curr = pref_sum.getitem( z_cell_curr*(Nr+1) - 1 )
+                pref_sum_curr = int(pref_sum[ z_cell_curr*(Nr+1) - 1 ])
             z_cell_prev = iz_prev + pref_sum_shift
             if z_cell_prev <= 0:
                 pref_sum_prev = 0
             elif z_cell_prev > Nz:
                 pref_sum_prev = species.Ntot
             else:
-                pref_sum_prev = pref_sum.getitem( z_cell_prev*(Nr+1) - 1 )
+                pref_sum_prev = int(pref_sum[ z_cell_prev*(Nr+1) - 1 ])
             # Calculate number of particles in this area (N_area)
             N_area = pref_sum_prev - pref_sum_curr
             # Check if there are particles to extract

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -15,9 +15,9 @@ from .particle_diag import ParticleDiagnostic
 from fbpic.utils.mpi import comm
 
 # Check if CUDA is available, then import CUDA
-from fbpic.utils.cuda import cuda_installed
-if cuda_installed:
-        from fbpic.utils.cuda import cuda
+from fbpic.utils.cuda import cupy_installed
+if cupy_installed:
+    import cupy
 
 def set_periodic_checkpoint( sim, period, checkpoint_dir='./checkpoints' ):
     """
@@ -360,8 +360,8 @@ def load_species( species, name, ts, iteration, comm, openpmd_viewer_version ):
     # Sorting arrays
     if species.use_cuda:
         # cell_idx and sorted_idx always stay on GPU
-        species.cell_idx = cuda.device_array( Ntot, dtype=np.int32)
-        species.sorted_idx = cuda.device_array( Ntot, dtype=np.intp)
+        species.cell_idx = cupy.empty( Ntot, dtype=np.int32)
+        species.sorted_idx = cupy.empty( Ntot, dtype=np.intp)
         # sorting buffers are initialized on CPU
         # (because they are swapped with other particle arrays during sorting)
         species.sorting_buffer = np.empty( Ntot, dtype=np.float64)

--- a/fbpic/openpmd_diag/cuda_methods.py
+++ b/fbpic/openpmd_diag/cuda_methods.py
@@ -6,7 +6,7 @@ This files contains cuda methods that are used in the boosted-frame
 diagnostics
 """
 import numpy as np
-from fbpic.utils.cuda import cupy, cuda, cuda_tpb_bpg_1d
+from fbpic.utils.cuda import cupy, cuda, cuda_tpb_bpg_1d, compile_cupy
 
 def extract_slice_from_gpu( pref_sum_curr, N_area, species ):
     """
@@ -64,7 +64,7 @@ def extract_slice_from_gpu( pref_sum_curr, N_area, species ):
     # Return the data as dictionary
     return( particle_data )
 
-@cuda.jit()
+@compile_cupy
 def extract_particles_from_gpu( part_idx_start, x, y, z, ux, uy, uz, w,
                                 inv_gamma, selected ):
     """
@@ -102,7 +102,7 @@ def extract_particles_from_gpu( part_idx_start, x, y, z, ux, uy, uz, w,
         selected[6, i] = w[ptcl_idx]
         selected[7, i] = inv_gamma[ptcl_idx]
 
-@cuda.jit()
+@compile_cupy
 def extract_array_from_gpu( part_idx_start, array, selected ):
     """
     Extract a selection of particles from the GPU and

--- a/fbpic/openpmd_diag/cuda_methods.py
+++ b/fbpic/openpmd_diag/cuda_methods.py
@@ -6,7 +6,7 @@ This files contains cuda methods that are used in the boosted-frame
 diagnostics
 """
 import numpy as np
-from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+from fbpic.utils.cuda import cupy, cuda, cuda_tpb_bpg_1d
 
 def extract_slice_from_gpu( pref_sum_curr, N_area, species ):
     """
@@ -32,34 +32,34 @@ def extract_slice_from_gpu( pref_sum_curr, N_area, species ):
     # Call kernel that extracts particles from GPU
     dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d(N_area)
     # - General particle quantities
-    part_data = cuda.device_array( (8, N_area), dtype=np.float64 )
+    part_data = cupy.empty( (8, N_area), dtype=np.float64 )
     extract_particles_from_gpu[dim_grid_1d, dim_block_1d]( pref_sum_curr,
          species.x, species.y, species.z, species.ux, species.uy, species.uz,
          species.w, species.inv_gamma, part_data )
     # - Optional particle arrays
     if species.tracker is not None:
-        selected_particle_id = cuda.device_array( (N_area,), dtype=np.uint64 )
+        selected_particle_id = cupy.empty( (N_area,), dtype=np.uint64 )
         extract_array_from_gpu[dim_grid_1d, dim_block_1d](
             pref_sum_curr, species.tracker.id, selected_particle_id )
     if species.ionizer is not None:
-        selected_particle_charge = cuda.device_array( (N_area,), dtype=np.uint64 )
+        selected_particle_charge = cupy.empty( (N_area,), dtype=np.uint64 )
         extract_array_from_gpu[dim_grid_1d, dim_block_1d]( pref_sum_curr,
           species.ionizer.ionization_level, selected_particle_charge )
-        selected_particle_weight = cuda.device_array( (N_area,), dtype=np.float64 )
+        selected_particle_weight = cupy.empty( (N_area,), dtype=np.float64 )
         extract_array_from_gpu[dim_grid_1d, dim_block_1d]( pref_sum_curr,
           species.ionizer.w_times_level, selected_particle_weight )
 
     # Copy GPU arrays to the host
-    part_data = part_data.copy_to_host()
+    part_data = part_data.get()
     particle_data = { 'x':part_data[0], 'y':part_data[1], 'z':part_data[2],
         'ux':part_data[3], 'uy':part_data[4], 'uz':part_data[5],
         'w':part_data[6], 'inv_gamma':part_data[7] }
     if species.tracker is not None:
-        particle_data['id'] = selected_particle_id.copy_to_host()
+        particle_data['id'] = selected_particle_id.get()
     if species.ionizer is not None:
-        particle_data['charge'] = selected_particle_charge.copy_to_host()
+        particle_data['charge'] = selected_particle_charge.get()
         # Replace particle weight
-        particle_data['w'] = selected_particle_weight.copy_to_host()
+        particle_data['w'] = selected_particle_weight.get()
 
     # Return the data as dictionary
     return( particle_data )

--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -7,6 +7,7 @@ It defines the deposition methods for rho and J for linear and cubic
 order shapes on the GPU using CUDA.
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 import math
 from scipy.constants import c
 import numpy as np
@@ -81,7 +82,7 @@ def r_shape_cubic(cell_position, index):
 # Field deposition - linear - rho
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_rho_gpu_linear(x, y, z, w, q,
                            invdz, zmin, Nz,
                            invdr, rmin, Nr,
@@ -246,7 +247,7 @@ def deposit_rho_gpu_linear(x, y, z, w, q,
 # Field deposition - linear - J
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_J_gpu_linear(x, y, z, w, q,
                          ux, uy, uz, inv_gamma,
                          invdz, zmin, Nz,
@@ -501,7 +502,7 @@ def deposit_J_gpu_linear(x, y, z, w, q,
 # Field deposition - cubic - rho
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_rho_gpu_cubic(x, y, z, w, q,
                           invdz, zmin, Nz,
                           invdr, rmin, Nr,
@@ -777,7 +778,7 @@ def deposit_rho_gpu_cubic(x, y, z, w, q,
 # Field deposition - cubic - J
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_J_gpu_cubic(x, y, z, w, q,
                         ux, uy, uz, inv_gamma,
                         invdz, zmin, Nz,

--- a/fbpic/particles/deposition/cuda_methods_one_mode.py
+++ b/fbpic/particles/deposition/cuda_methods_one_mode.py
@@ -7,6 +7,7 @@ It defines the deposition methods for rho and J for linear and cubic
 order shapes on the GPU using CUDA, for one azimuthal mode only
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 import math
 from scipy.constants import c
 import numpy as np
@@ -82,7 +83,7 @@ def r_shape_cubic(cell_position, index):
 # Field deposition - linear - rho
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_rho_gpu_linear_one_mode(x, y, z, w, q,
                            invdz, zmin, Nz,
                            invdr, rmin, Nr,
@@ -236,7 +237,7 @@ def deposit_rho_gpu_linear_one_mode(x, y, z, w, q,
 # Field deposition - linear - J
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_J_gpu_linear_one_mode(x, y, z, w, q,
                          ux, uy, uz, inv_gamma,
                          invdz, zmin, Nz,
@@ -448,7 +449,7 @@ def deposit_J_gpu_linear_one_mode(x, y, z, w, q,
 # Field deposition - cubic - rho
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_rho_gpu_cubic_one_mode(x, y, z, w, q,
                           invdz, zmin, Nz,
                           invdr, rmin, Nr,
@@ -663,7 +664,7 @@ def deposit_rho_gpu_cubic_one_mode(x, y, z, w, q,
 # Field deposition - cubic - J
 # -------------------------------
 
-@cuda.jit
+@compile_cupy
 def deposit_J_gpu_cubic_one_mode(x, y, z, w, q,
                         ux, uy, uz, inv_gamma,
                         invdz, zmin, Nz,

--- a/fbpic/particles/elementary_process/compton/compton.py
+++ b/fbpic/particles/elementary_process/compton/compton.py
@@ -12,10 +12,8 @@ from .numba_methods import get_photon_density_gaussian_numba, \
 from ..cuda_numba_utils import allocate_empty, reallocate_and_copy_old, \
                                 perform_cumsum, generate_new_ids
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 from fbpic.utils.printing import catch_gpu_memory_error
-if cupy_installed:
-    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
     from numba.cuda.random import create_xoroshiro128p_states
@@ -199,13 +197,11 @@ class ComptonScatterer(object):
                 self.ratio_w_electron_photon, photon_n, self.photon_p,
                 self.photon_beta_x, self.photon_beta_y, self.photon_beta_z )
 
-        # Count the total number of new photons (operation always performed
-        # on the CPU, as this is typically difficult on the GPU)
-        if use_cuda:
-            nscatter_per_batch = nscatter_per_batch.get()
-        cumul_nscatter_per_batch = perform_cumsum( nscatter_per_batch )
+        # Count the total number of new photons 
+        cumul_nscatter_per_batch = perform_cumsum( nscatter_per_batch, use_cuda )
+        N_created = int( cumul_nscatter_per_batch[-1] )
         # If no new particle was created, skip the rest of this function
-        if cumul_nscatter_per_batch[-1] == 0:
+        if N_created == 0:
             return
 
         # Reallocate photons species (on CPU or GPU depending on `use_cuda`),
@@ -213,13 +209,12 @@ class ComptonScatterer(object):
         # and copy the old photons to the new arrays
         photons = self.target_species
         old_Ntot = photons.Ntot
-        new_Ntot = old_Ntot + cumul_nscatter_per_batch[-1]
+        new_Ntot = old_Ntot + N_created
         reallocate_and_copy_old( photons, use_cuda, old_Ntot, new_Ntot )
 
         # Create the new photons from ionization (with a random
         # scattering angle) and add recoil momentum to the electrons
         if use_cuda:
-            cumul_nscatter_per_batch = cupy.asarray(cumul_nscatter_per_batch)
             scatter_photons_electrons_cuda[ batch_grid_1d, batch_block_1d ](
                 N_batch, self.batch_size, old_Ntot, elec.Ntot,
                 cumul_nscatter_per_batch, nscatter_per_elec, random_states,

--- a/fbpic/particles/elementary_process/compton/cuda_methods.py
+++ b/fbpic/particles/elementary_process/compton/cuda_methods.py
@@ -7,6 +7,7 @@ It defines cuda methods that are used in Compton scattering (on GPU).
 """
 import math
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 from numba.cuda.random import xoroshiro128p_uniform_float64
 # Import the inline functions
 from .inline_functions import lorentz_transform, get_scattering_probability, \
@@ -18,7 +19,7 @@ get_scattering_probability = cuda.jit( get_scattering_probability,
 get_photon_density_gaussian = cuda.jit( get_photon_density_gaussian,
                                             device=True, inline=True )
 
-@cuda.jit
+@compile_cupy
 def get_photon_density_gaussian_cuda( photon_n, elec_Ntot,
     elec_x, elec_y, elec_z, ct, photon_n_lab_max, inv_laser_waist2,
     inv_laser_ctau2, laser_initial_z0, gamma_boost, beta_boost ):

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -13,7 +13,7 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 def allocate_empty( shape, use_cuda, dtype ):
     """
@@ -140,7 +140,7 @@ def copy_particle_data_numba( Ntot, old_array, new_array ):
     return( new_array )
 
 if cuda_installed:
-    @cuda.jit()
+    @compile_cupy
     def copy_particle_data_cuda( Ntot, old_array, new_array ):
         """
         Copy the `Ntot` elements of `old_array` into `new_array`, on GPU

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -9,7 +9,9 @@ It defines a number of methods that are useful for elementary processes
 import numpy as np
 from fbpic.utils.threading import njit_parallel, prange
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
 
@@ -22,7 +24,7 @@ def allocate_empty( shape, use_cuda, dtype ):
         # Convert single scalar to tuple
         shape = (shape,)
     if use_cuda:
-        return( cuda.device_array( shape, dtype=dtype ) )
+        return( cupy.empty( shape, dtype=dtype ) )
     else:
         return( np.empty( shape, dtype=dtype ) )
 
@@ -102,12 +104,12 @@ def reallocate_and_copy_old( species, use_cuda, old_Ntot, new_Ntot ):
 
     # Allocate the auxiliary arrays for GPU
     if use_cuda:
-        species.cell_idx = cuda.device_array((new_Ntot,), dtype=np.int32)
-        species.sorted_idx = cuda.device_array((new_Ntot,), dtype=np.intp)
-        species.sorting_buffer = cuda.device_array((new_Ntot,), dtype=np.float64)
+        species.cell_idx = cupy.empty((new_Ntot,), dtype=np.int32)
+        species.sorted_idx = cupy.empty((new_Ntot,), dtype=np.intp)
+        species.sorting_buffer = cupy.empty((new_Ntot,), dtype=np.float64)
         if species.n_integer_quantities > 0:
             species.int_sorting_buffer = \
-                cuda.device_array( (new_Ntot,), dtype=np.uint64 )
+                cupy.empty( (new_Ntot,), dtype=np.uint64 )
 
     # Modify the total number of particles
     species.Ntot = new_Ntot

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -39,7 +39,7 @@ def perform_cumsum( input_array ):
     np.cumsum( input_array, out=cumulative_array[1:] )
     return( cumulative_array )
 
-def perform_cumsum_2d( input_array ):
+def perform_cumsum_2d( input_array, use_cuda ):
     """
     Return an array containing the cumulative sum of the 2darray `input_array`,
     where the cumsum is taken along the last axis.
@@ -47,10 +47,16 @@ def perform_cumsum_2d( input_array ):
     (The returned array has one more element than `input_array` along the
     last axis; its first element is 0 and its last element is the
     total sum of `input_array`)
+
+    If needed, the calculation is performed on the GPU.
     """
     new_shape = (input_array.shape[0], input_array.shape[1]+1)
-    cumulative_array = np.zeros( new_shape, dtype=np.int64 )
-    np.cumsum( input_array, out=cumulative_array[:,1:], axis=-1 )
+    if use_cuda:
+        cumulative_array = cupy.zeros( new_shape, dtype=cupy.int64 )
+        cupy.cumsum( input_array, out=cumulative_array[:,1:], axis=-1 )
+    else:
+        cumulative_array = np.zeros( new_shape, dtype=np.int64 )
+        np.cumsum( input_array, out=cumulative_array[:,1:], axis=-1 )
     return( cumulative_array )
 
 def reallocate_and_copy_old( species, use_cuda, old_Ntot, new_Ntot ):

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -28,15 +28,19 @@ def allocate_empty( shape, use_cuda, dtype ):
     else:
         return( np.empty( shape, dtype=dtype ) )
 
-def perform_cumsum( input_array ):
+def perform_cumsum( input_array, use_cuda ):
     """
     Return an array containing the cumulative sum of the 1darray `input_array`
 
     (The returned array has one more element than `input_array`; its first
     element is 0 and its last element is the total sum of `input_array`)
     """
-    cumulative_array = np.zeros( len(input_array)+1, dtype=np.int64 )
-    np.cumsum( input_array, out=cumulative_array[1:] )
+    if use_cuda:
+        cumulative_array = cupy.zeros( len(input_array)+1, dtype=cupy.int64 )
+        cupy.cumsum( input_array, out=cumulative_array[1:] )
+    else:
+        cumulative_array = np.zeros( len(input_array)+1, dtype=np.int64 )
+        np.cumsum( input_array, out=cumulative_array[1:] )
     return( cumulative_array )
 
 def perform_cumsum_2d( input_array, use_cuda ):

--- a/fbpic/particles/elementary_process/ionization/cuda_methods.py
+++ b/fbpic/particles/elementary_process/ionization/cuda_methods.py
@@ -8,6 +8,7 @@ It defines cuda methods that are used in particle ionization.
 Apart from synthactic details, this file is very close to numba_methods.py
 """
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 from scipy.constants import c
 # Import inline functions
 from .inline_functions import get_ionization_probability, \
@@ -20,7 +21,7 @@ get_E_amplitude = cuda.jit( get_E_amplitude,
 copy_ionized_electrons_batch = cuda.jit( copy_ionized_electrons_batch,
                                             device=True, inline=True )
 
-@cuda.jit()
+@compile_cupy
 def ionize_ions_cuda( N_batch, batch_size, Ntot,
     level_start, level_max, n_levels,
     n_ionized, ionized_from, ionization_level, random_draw,
@@ -83,7 +84,7 @@ def ionize_ions_cuda( N_batch, batch_size, Ntot,
             else:
                 ionized_from[ip] = -1
 
-@cuda.jit()
+@compile_cupy
 def copy_ionized_electrons_cuda(
     N_batch, batch_size, elec_old_Ntot, ion_Ntot,
     cumulative_n_ionized, ionized_from,

--- a/fbpic/particles/elementary_process/ionization/ionizer.py
+++ b/fbpic/particles/elementary_process/ionization/ionizer.py
@@ -267,18 +267,15 @@ class Ionizer(object):
                 ion.ux, ion.uy, ion.uz, ion.Ex, ion.Ey, ion.Ez,
                 ion.Bx, ion.By, ion.Bz, ion.w, self.w_times_level )
 
-        # Count the total number of new electrons (operation always performed
-        # on the CPU, as this is typically difficult on the GPU)
-        if use_cuda:
-            n_ionized = n_ionized.get()
-        cumulative_n_ionized = perform_cumsum_2d( n_ionized )
+        # Count the total number of new electrons 
+        cumulative_n_ionized = perform_cumsum_2d( n_ionized, use_cuda )
         # If no new particle was created, skip the rest of this function
-        if np.all( cumulative_n_ionized[:,-1] == 0 ):
-            return
-        # Copy the cumulated number of electrons back on GPU
-        # (Keep a copy on the CPU)
         if use_cuda:
-            d_cumulative_n_ionized = cupy.asarray( cumulative_n_ionized )
+            if cupy.all( cumulative_n_ionized[:,-1] == 0 ):
+                return
+        else:
+            if np.all( cumulative_n_ionized[:,-1] == 0 ):
+                return
 
         # Loop over the electron species associated to each level
         # (when store_electrons_per_level is False, there is a single species)
@@ -288,13 +285,14 @@ class Ionizer(object):
         assert len(self.target_species) == n_levels
         for i_level, elec in enumerate(self.target_species):
             old_Ntot = elec.Ntot
-            new_Ntot = old_Ntot + cumulative_n_ionized[i_level,-1]
+            # Cast to int transfers the data from the GPU if needed
+            new_Ntot = old_Ntot + int( cumulative_n_ionized[i_level,-1] )
             reallocate_and_copy_old( elec, use_cuda, old_Ntot, new_Ntot )
             # Create the new electrons from ionization (one thread per batch)
             if use_cuda:
                 copy_ionized_electrons_cuda[ batch_grid_1d, batch_block_1d ](
                     N_batch, self.batch_size, old_Ntot, ion.Ntot,
-                    d_cumulative_n_ionized, ionized_from,
+                    cumulative_n_ionized, ionized_from,
                     i_level, self.store_electrons_per_level,
                     elec.x, elec.y, elec.z, elec.inv_gamma,
                     elec.ux, elec.uy, elec.uz, elec.w,

--- a/fbpic/particles/gathering/cuda_methods.py
+++ b/fbpic/particles/gathering/cuda_methods.py
@@ -7,6 +7,7 @@ It defines the field gathering methods linear and cubic order shapes
 on the GPU using CUDA.
 """
 from numba import cuda, float64, int64
+from fbpic.utils.cuda import compile_cupy
 import math
 # Import inline functions
 from .inline_functions import \
@@ -21,7 +22,7 @@ add_cubic_gather_for_mode = cuda.jit( add_cubic_gather_for_mode,
 # Field gathering linear
 # -----------------------
 
-@cuda.jit
+@compile_cupy
 def gather_field_gpu_linear(x, y, z,
                     rmax_gather,
                     invdz, zmin, Nz,
@@ -204,7 +205,7 @@ def gather_field_gpu_linear(x, y, z,
 # Field gathering cubic
 # -----------------------
 
-@cuda.jit
+@compile_cupy
 def gather_field_gpu_cubic(x, y, z,
                     rmax_gather,
                     invdz, zmin, Nz,

--- a/fbpic/particles/gathering/cuda_methods_one_mode.py
+++ b/fbpic/particles/gathering/cuda_methods_one_mode.py
@@ -7,6 +7,7 @@ It defines the field gathering methods linear and cubic order shapes
 on the GPU using CUDA, for one azimuthal mode at a time
 """
 from numba import cuda, float64, int64
+from fbpic.utils.cuda import compile_cupy
 import math
 # Import inline functions
 from .inline_functions import \
@@ -17,7 +18,7 @@ add_linear_gather_for_mode = cuda.jit( add_linear_gather_for_mode,
 add_cubic_gather_for_mode = cuda.jit( add_cubic_gather_for_mode,
                                         device=True, inline=True )
 
-@cuda.jit
+@compile_cupy
 def erase_eb_cuda( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
     """
     Reset the arrays of fields (i.e. set them to 0)
@@ -41,7 +42,7 @@ def erase_eb_cuda( Ex, Ey, Ez, Bx, By, Bz, Ntot ):
 # Field gathering linear
 # -----------------------
 
-@cuda.jit
+@compile_cupy
 def gather_field_gpu_linear_one_mode(x, y, z,
                     rmax_gather,
                     invdz, zmin, Nz,
@@ -211,7 +212,7 @@ def gather_field_gpu_linear_one_mode(x, y, z,
 # Field gathering cubic
 # -----------------------
 
-@cuda.jit
+@compile_cupy
 def gather_field_gpu_cubic_one_mode(x, y, z,
                     rmax_gather,
                     invdz, zmin, Nz,

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -146,6 +146,7 @@ class Particles(object) :
                 'Cuda not available for the particles.\n'
                 'Performing the particle operations on the CPU.')
             self.use_cuda = False
+        self.data_is_on_gpu = False # Data is initialized on the CPU
 
         # Generate evenly-spaced particles
         Ntot, x, y, z, ux, uy, uz, inv_gamma, w = generate_evenly_spaced(
@@ -277,6 +278,9 @@ class Particles(object) :
             if self.ionizer is not None:
                 self.ionizer.send_to_gpu()
 
+            # Modify flag accordingly
+            self.data_is_on_gpu = True
+
     def receive_particles_from_gpu( self ):
         """
         Receive the particles from the GPU.
@@ -315,6 +319,9 @@ class Particles(object) :
             # Copy the ionization data
             if self.ionizer is not None:
                 self.ionizer.receive_from_gpu()
+
+            # Modify flag accordingly
+            self.data_is_on_gpu = False
 
     def generate_continuously_injected_particles( self, time ):
         """

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -28,10 +28,12 @@ from .deposition.threading_methods import \
 # Check if threading is enabled
 from fbpic.utils.threading import nthreads, get_chunk_indices
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     # Load the CUDA methods
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, cuda_gpu_model
+    from fbpic.utils.cuda import cuda_tpb_bpg_1d, cuda_gpu_model
     from .push.cuda_methods import push_p_gpu, push_p_ioniz_gpu, \
                                 push_p_after_plane_gpu, push_x_gpu
     from .deposition.cuda_methods import deposit_rho_gpu_linear, \
@@ -215,9 +217,9 @@ class Particles(object) :
             # Allocate arrays for the particles sorting when using CUDA
             # Most required arrays always stay on GPU
             Nz, Nr = grid_shape
-            self.cell_idx = cuda.device_array( Ntot, dtype=np.int32)
-            self.sorted_idx = cuda.device_array( Ntot, dtype=np.intp)
-            self.prefix_sum = cuda.device_array( Nz*(Nr+1), dtype=np.int32 )
+            self.cell_idx = cupy.empty( Ntot, dtype=np.int32)
+            self.sorted_idx = cupy.empty( Ntot, dtype=np.intp)
+            self.prefix_sum = cupy.empty( Nz*(Nr+1), dtype=np.int32 )
             # sorting buffers are initialized on CPU like other particle arrays
             # (because they are swapped with these arrays during sorting)
             self.sorting_buffer = np.empty( Ntot, dtype=np.float64)
@@ -245,28 +247,28 @@ class Particles(object) :
         if self.use_cuda:
             # Send positions, velocities, inverse gamma and weights
             # to the GPU (CUDA)
-            self.x = cuda.to_device(self.x)
-            self.y = cuda.to_device(self.y)
-            self.z = cuda.to_device(self.z)
-            self.ux = cuda.to_device(self.ux)
-            self.uy = cuda.to_device(self.uy)
-            self.uz = cuda.to_device(self.uz)
-            self.inv_gamma = cuda.to_device(self.inv_gamma)
-            self.w = cuda.to_device(self.w)
+            self.x = cupy.asarray(self.x)
+            self.y = cupy.asarray(self.y)
+            self.z = cupy.asarray(self.z)
+            self.ux = cupy.asarray(self.ux)
+            self.uy = cupy.asarray(self.uy)
+            self.uz = cupy.asarray(self.uz)
+            self.inv_gamma = cupy.asarray(self.inv_gamma)
+            self.w = cupy.asarray(self.w)
 
             # Copy arrays on the GPU for the field
             # gathering and the particle push
-            self.Ex = cuda.to_device(self.Ex)
-            self.Ey = cuda.to_device(self.Ey)
-            self.Ez = cuda.to_device(self.Ez)
-            self.Bx = cuda.to_device(self.Bx)
-            self.By = cuda.to_device(self.By)
-            self.Bz = cuda.to_device(self.Bz)
+            self.Ex = cupy.asarray(self.Ex)
+            self.Ey = cupy.asarray(self.Ey)
+            self.Ez = cupy.asarray(self.Ez)
+            self.Bx = cupy.asarray(self.Bx)
+            self.By = cupy.asarray(self.By)
+            self.Bz = cupy.asarray(self.Bz)
 
             # Copy sorting buffers on the GPU
-            self.sorting_buffer = cuda.to_device(self.sorting_buffer)
+            self.sorting_buffer = cupy.asarray(self.sorting_buffer)
             if self.n_integer_quantities > 0:
-                self.int_sorting_buffer = cuda.to_device(self.int_sorting_buffer)
+                self.int_sorting_buffer = cupy.asarray(self.int_sorting_buffer)
 
             # Copy particle tracker data
             if self.tracker is not None:
@@ -283,29 +285,29 @@ class Particles(object) :
         if self.use_cuda:
             # Copy the positions, velocities, inverse gamma and weights
             # to the GPU (CUDA)
-            self.x = self.x.copy_to_host()
-            self.y = self.y.copy_to_host()
-            self.z = self.z.copy_to_host()
-            self.ux = self.ux.copy_to_host()
-            self.uy = self.uy.copy_to_host()
-            self.uz = self.uz.copy_to_host()
-            self.inv_gamma = self.inv_gamma.copy_to_host()
-            self.w = self.w.copy_to_host()
+            self.x = self.x.get()
+            self.y = self.y.get()
+            self.z = self.z.get()
+            self.ux = self.ux.get()
+            self.uy = self.uy.get()
+            self.uz = self.uz.get()
+            self.inv_gamma = self.inv_gamma.get()
+            self.w = self.w.get()
 
             # Copy arrays on the CPU for the field
             # gathering and the particle push
-            self.Ex = self.Ex.copy_to_host()
-            self.Ey = self.Ey.copy_to_host()
-            self.Ez = self.Ez.copy_to_host()
-            self.Bx = self.Bx.copy_to_host()
-            self.By = self.By.copy_to_host()
-            self.Bz = self.Bz.copy_to_host()
+            self.Ex = self.Ex.get()
+            self.Ey = self.Ey.get()
+            self.Ez = self.Ez.get()
+            self.Bx = self.Bx.get()
+            self.By = self.By.get()
+            self.Bz = self.Bz.get()
 
             # Copy arrays on the CPU
             # that represent the sorting arrays
-            self.sorting_buffer = self.sorting_buffer.copy_to_host()
+            self.sorting_buffer = self.sorting_buffer.get()
             if self.n_integer_quantities > 0:
-                self.int_sorting_buffer = self.int_sorting_buffer.copy_to_host()
+                self.int_sorting_buffer = self.int_sorting_buffer.get()
 
             # Copy particle tracker data
             if self.tracker is not None:

--- a/fbpic/particles/push/cuda_methods.py
+++ b/fbpic/particles/push/cuda_methods.py
@@ -7,12 +7,13 @@ It defines the particle push methods on the GPU using CUDA.
 """
 from scipy.constants import c, e
 from numba import cuda
+from fbpic.utils.cuda import compile_cupy
 # Import inline function
 from .inline_functions import push_p_vay
 # Compile the inline function for GPU
 push_p_vay = cuda.jit( push_p_vay, device=True, inline=True )
 
-@cuda.jit
+@compile_cupy
 def push_x_gpu( x, y, z, ux, uy, uz, inv_gamma, dt,
                 x_push, y_push, z_push ) :
     """
@@ -50,7 +51,7 @@ def push_x_gpu( x, y, z, ux, uy, uz, inv_gamma, dt,
         y[i] += cdt*y_push*inv_g*uy[i]
         z[i] += cdt*z_push*inv_g*uz[i]
 
-@cuda.jit
+@compile_cupy
 def push_p_gpu( ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz,
                 q, m, Ntot, dt ) :
@@ -98,7 +99,7 @@ def push_p_gpu( ux, uy, uz, inv_gamma,
             Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip], econst, bconst)
 
 
-@cuda.jit
+@compile_cupy
 def push_p_after_plane_gpu( z, z_plane, ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz, q, m, Ntot, dt ) :
     """
@@ -130,7 +131,7 @@ def push_p_after_plane_gpu( z, z_plane, ux, uy, uz, inv_gamma,
             Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip], econst, bconst)
 
 
-@cuda.jit
+@compile_cupy
 def push_p_ioniz_gpu( ux, uy, uz, inv_gamma,
                 Ex, Ey, Ez, Bx, By, Bz,
                 m, Ntot, dt, ionization_level ) :

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -12,7 +12,7 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda_tpb_bpg_1d
+    from fbpic.utils.cuda import cuda_tpb_bpg_1d, compile_cupy
 
 class ParticleTracker(object):
     """
@@ -134,7 +134,7 @@ class ParticleTracker(object):
 
 if cuda_installed:
 
-    @cuda.jit()
+    @compile_cupy
     def generate_ids_gpu( id_array, i_start, i_end,
                             next_attributed_id, id_step ):
         """

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -8,7 +8,9 @@ It defines the structure and methods associated with particle tracking.
 import numpy as np
 from numba import cuda
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cupy_installed, cuda_installed
+if cupy_installed:
+    import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
 
@@ -54,13 +56,13 @@ class ParticleTracker(object):
         """
         Transfer the tracking data from the CPU to the GPU
         """
-        self.id = cuda.to_device( self.id )
+        self.id = cupy.asarray( self.id )
 
     def receive_from_gpu(self):
         """
         Transfer the tracking data from the GPU to the CPU
         """
-        self.id = self.id.copy_to_host()
+        self.id = self.id.get()
 
     def generate_new_ids( self, N ):
         """

--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -6,7 +6,7 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the particle sorting methods on the GPU using CUDA.
 """
 from numba import cuda
-from fbpic.utils.cuda import cupy_installed
+from fbpic.utils.cuda import cupy_installed, compile_cupy
 if cupy_installed:
     from cupy.cuda import thrust
 import math
@@ -16,7 +16,7 @@ import numpy as np
 # Sorting utilities - get_cell_idx / sort / prefix_sum
 # -----------------------------------------------------
 
-@cuda.jit
+@compile_cupy
 def get_cell_idx_per_particle(cell_idx, sorted_idx,
                               x, y, z,
                               invdz, zmin, Nz,
@@ -118,7 +118,7 @@ def sort_particles_per_cell(cell_idx, sorted_idx):
         # memory is not automatically released, after `argsort`
         # Here we force `cupy` to release the memory.
 
-@cuda.jit
+@compile_cupy
 def incl_prefix_sum(cell_idx, prefix_sum):
     """
     Perform an inclusive parallel prefix sum on the sorted
@@ -151,7 +151,7 @@ def incl_prefix_sum(cell_idx, prefix_sum):
             ci += 1
 
 
-@cuda.jit
+@compile_cupy
 def prefill_prefix_sum(cell_idx, prefix_sum, Ntot):
     """
     Prefill the prefix sum array so that:
@@ -186,7 +186,7 @@ def prefill_prefix_sum(cell_idx, prefix_sum, Ntot):
             # If this species has no particles, fill all cells with 0
             prefix_sum[i] = 0
 
-@cuda.jit
+@compile_cupy
 def write_sorting_buffer(sorted_idx, val, buf):
     """
     Writes the values of a particle array to a buffer,

--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -8,9 +8,7 @@ It defines the particle sorting methods on the GPU using CUDA.
 from numba import cuda
 from fbpic.utils.cuda import cupy_installed
 if cupy_installed:
-    import cupy
     from cupy.cuda import thrust
-    cupy_mempool = cupy.get_default_memory_pool()
 import math
 import numpy as np
 
@@ -105,8 +103,8 @@ def sort_particles_per_cell(cell_idx, sorted_idx):
     if Ntot > 0:
         if type(cell_idx) == np.ndarray or  type(sorted_idx) == np.ndarray:
             raise ValueError("Unexpected CPU array")
-        d_cell_idx = cupy.asarray(cell_idx)
-        d_sorted_idx = cupy.asarray(sorted_idx)
+        d_cell_idx = cell_idx
+        d_sorted_idx = sorted_idx
         # `thrust.argsort` will simultaneously:
         # - find the indices `sorted_idx` that sort the initial array cell_idx
         # - sort `cell_idx` in place
@@ -119,7 +117,6 @@ def sort_particles_per_cell(cell_idx, sorted_idx):
         # arrays in its memory pool. For performance reasons, this
         # memory is not automatically released, after `argsort`
         # Here we force `cupy` to release the memory.
-        cupy_mempool.free_all_blocks()
 
 @cuda.jit
 def incl_prefix_sum(cell_idx, prefix_sum):

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -125,6 +125,52 @@ def receive_data_from_gpu(simulation):
     # Receive fields from the GPU (if CUDA is used)
     simulation.fld.receive_fields_from_gpu()
 
+class GpuMemoryManager(object):
+    """
+    Context manager that temporarily moves the simulation data to the GPU,
+    if the data is originally on the CPU when entering the context manager
+    """
+
+    def __init__(self, simulation):
+        """
+        Initialize the context manager
+
+        Parameters:
+        -----------
+        simulation: object
+            A simulation object that contains the particle
+            (ptcl) and field object (fld)
+        """
+        # Check whether the data is initially on the CPU or GPU
+        self.fields_were_on_gpu = simulation.fld.data_is_on_gpu
+        self.species_were_on_gpu = [ species.data_is_on_gpu \
+                                     for species in simulation.ptcl ]
+        # Keep a reference to the simulation
+        self.sim = simulation
+
+    def __enter__(self):
+        """
+        Move the data to the GPU (if it was originally on the CPU)
+        """
+        if self.sim.use_cuda:
+            if not self.fields_were_on_gpu:
+                self.sim.fld.send_fields_to_gpu()
+            for i, species in enumerate(self.sim.ptcl):
+                if not self.species_were_on_gpu[i]:
+                    species.send_particles_to_gpu()
+
+    def __exit__(self, type, value, traceback):
+        """
+        Move the data back to the CPU (if it was originally on the CPU)
+        """
+        if self.sim.use_cuda:
+            if not self.fields_were_on_gpu:
+                self.sim.fld.receive_fields_from_gpu()
+            for i, species in enumerate(self.sim.ptcl):
+                if not self.species_were_on_gpu[i]:
+                    species.receive_particles_from_gpu()
+
+
 # -----------------------------------------------------
 # CUDA mpi management
 # -----------------------------------------------------

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -189,3 +189,182 @@ def mpi_select_gpus(mpi):
         if rank%n_gpus == i_gpu:
             cuda.select_device(i_gpu)
         mpi.COMM_WORLD.barrier()
+
+
+# -----------------------------------------------------
+# CUDA kernel decorator
+# -----------------------------------------------------
+
+if cupy_installed:
+
+    def get_args_hash(args):
+        """
+        Computes a hash from the argument types of a kernel call.
+        This takes into account the data types as well as (for arrays) the
+        number of dimensions.
+
+        Parameters:
+        -----------
+        args: A list of arguments (scalars or Cupy arrays).
+
+        Returns:
+        --------
+        hash: Hash value as an int.
+        """
+        types = []
+
+        # Loop over the arguments
+        for a in args:
+            # For array arguments: save the data type and the number of
+            # dimensions
+            if isinstance(a, cupy.ndarray):
+                types.append(a.dtype)
+                types.append(a.ndim)
+
+            # For scalar arguments: save only the data type
+            else:
+                types.append(type(a))
+
+        # Use the built-in Python hash function to compute the hash
+        return hash(tuple(types))
+
+    class compile_cupy(object):
+        """
+        This class defines a custom function decorator which compiles python
+        functions into GPU CUDA kernels. This decorator is meant to be used
+        in the same way as `numba.cuda.jit` but has lower kernel launch
+        overheads.
+
+        In practice, this is achieved by using `numba.cuda.jit` to compile the
+        kernels into PTX code, and by launching the PTX code through the `cupy`
+        framework (which has lower launch overhead than the `numba.cuda`
+        framework).
+
+        Similarly to `numba.cuda.jit`, this class decorates functions that
+        are defined with arbitrary argument types. The actual types of the
+        arguments is only known when the function is called, at which point
+        the corresponding CUDA kernel is compiled (Just-In-Time compilation).
+        This decorator stores previously-compiled kernels, so as to avoid
+        re-compiling if the function is called several times with the same
+        argument types.
+        """
+
+        def __init__(self, func):
+            """
+            Constructor of the decorator class.
+
+            Parameters:
+            -----------
+            func: The python function the decorator is applied to, which will
+                be compiled into a CUDA kernel.
+            """
+
+            self.python_func = func
+            self.kernel_dict = {} # Stores compiled kernels to avoid re-compilation
+
+        def __getitem__(self, bt):
+            """
+            Called when the kernel is called with square brackets, e.g.
+            ```
+            kernel[blocks_per_grid, threads_per_block]( *args )
+            ```
+            This is used to mimic the Numba launch syntax.
+
+            Parameters:
+            -----------
+            bt: A 2-tuple (blocks_per_grid, threads_per_block) giving the
+                thread and block size on the GPU.
+                Both blocks_per_grid and threads_per_block should themselves
+                be tuples, even in the 1D case.
+
+            Returns:
+            --------
+            call_kernel: A wrapper function which represents the kernel
+                specialized to the specified thread and block size, and
+                which can then be called with the kernel arguments.
+            """
+            blocks_per_grid = bt[0]
+            threads_per_block = bt[1]
+
+            # Cast the thread and block size to tuples if neccessary
+            # since Cupy does not accept them as simple numbers
+            if not isinstance(blocks_per_grid, tuple):
+                blocks_per_grid = (blocks_per_grid, )
+
+            if not isinstance(threads_per_block, tuple):
+                threads_per_block = (threads_per_block, )
+
+            # Define function that will be returned by the decorator
+            def call_kernel(*args):
+                """
+                Wrapper function for the actual kernel call. Checks if a
+                kernel for the specified argument types is already compiled,
+                and compiles one if needed. Then calls the kernel.
+
+                Parameters:
+                -----------
+                args: List of the kernel arguments.
+                    They should all be either scalar values (float, int,
+                    complex, bool) or Cupy arrays.
+                """
+                # Calculate a hash from the argument types to check whether a
+                # compatible kernel is already compiled.
+                hash = get_args_hash(args)
+
+                if hash not in self.kernel_dict:
+
+                    # Compile a Numba kernel for the specified arguments
+                    # using cuda.jit
+                    numba_kernel = cuda.jit()(self.python_func) \
+                        .specialize(*args)
+
+                    # Create a Cupy kernel module and load the PTX code of the
+                    # numba kernel
+                    module = cupy.cuda.function.Module()
+                    module.load(bytes(numba_kernel.ptx, 'UTF-8'))
+
+                    # Cache the resulting Cupy kernel in a dictionary using
+                    # the hash
+                    self.kernel_dict[hash] = module.get_function(
+                        numba_kernel.entry_name)
+
+                # Prepare the arguments for the Cupy kernel.
+                # Because of the way Numba JIT compilation works, the
+                # resulting kernels expect multiple arguments for each array.
+                kernel_args = []
+
+                # Loop over the given arguments
+                for a in args:
+
+                    # Check whether the argument is an array and requires
+                    # multiple kernel arguments.
+                    if isinstance(a, cupy.ndarray):
+                        # Append all required arguments to the list, in order:
+                        # - Two zeroes (corresponding to null pointers in C)
+                        # - The total size of the array
+                        # - The size in bytes of the array datatype
+                        # - The array itself
+                        # - The shape of the array, as single integers
+                        # - The strides of the array, as single integers
+                        # Note that due to the latter two entries, the actual
+                        # number of arguments per array depends on the number
+                        # of array dimensions.
+                        kernel_args.extend(
+                            [0, 0, a.size, a.dtype.itemsize, a])
+                        kernel_args.extend(a.shape)
+                        kernel_args.extend(a.strides)
+                    else:
+                        # For scalar arguments, simply append the
+                        # argument itself.
+                        kernel_args.append(a)
+
+                # Call the actual kernel from the cache.
+                # The arguments of the call are:
+                # - Blocks per grid (tuple)
+                # - Threads per blocks (tuple)
+                # - The prepared list of kernel arguments
+                self.kernel_dict[hash](blocks_per_grid, threads_per_block,
+                    kernel_args)
+
+            # __getitem__ returns the created wrapper method.
+            return call_kernel

--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -121,6 +121,7 @@ import numpy as np
 from scipy.constants import c, e, m_e, epsilon_0
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
+from fbpic.utils.cuda import GpuMemoryManager
 from fbpic.fields import Fields
 
 # Parameters
@@ -188,8 +189,10 @@ def simulate_periodic_plasma_wave( particle_shape, show=False ):
 
     # Save the initial density in spectral space, and consider it
     # to be the density of the (uninitialized) ions
-    sim.deposit('rho_prev', exchange=True)
-    sim.fld.spect2interp('rho_prev')
+    # (Move the simulation to GPU if needed, for this step)
+    with GpuMemoryManager(sim):
+        sim.deposit('rho_prev', exchange=True)
+        sim.fld.spect2interp('rho_prev')
     rho_ions = [ ]
     for m in range(len(sim.fld.interp)):
         rho_ions.append( -sim.fld.interp[m].rho.copy() )

--- a/tests/unautomated/test_cuda_transform.py
+++ b/tests/unautomated/test_cuda_transform.py
@@ -13,6 +13,9 @@ $ python tests/test_cuda_transform.py
 import numpy as np
 from fbpic.fields.spectral_transform import SpectralTransformer
 from numba import cuda
+from fbpic.utils.cuda import cupy_installed
+if cupy_installed:
+    from fbpic.utils.cuda import cupy
 import time
 
 if __name__ == '__main__' :
@@ -26,18 +29,18 @@ if __name__ == '__main__' :
     # Initialize the random test_field
     interp_field_r = np.random.rand(Nz, Nr) + 1.j*np.random.rand(Nz, Nr)
     interp_field_t = np.random.rand(Nz, Nr) + 1.j*np.random.rand(Nz, Nr)
-    d_interp_field_r = cuda.to_device( interp_field_r )
-    d_interp_field_t = cuda.to_device( interp_field_t )
+    d_interp_field_r = cupy.asarray( interp_field_r )
+    d_interp_field_t = cupy.asarray( interp_field_t )
     # Initialize the field in spectral space
     spect_field_p = np.empty_like( interp_field_r )
     spect_field_m = np.empty_like( interp_field_t )
-    d_spect_field_p = cuda.to_device( spect_field_p )
-    d_spect_field_m = cuda.to_device( spect_field_m )
+    d_spect_field_p = cupy.asarray( spect_field_p )
+    d_spect_field_m = cupy.asarray( spect_field_m )
     # Initialize the field after back and forth transformation
     back_field_r = np.empty_like( interp_field_r )
     back_field_t = np.empty_like( interp_field_t )
-    d_back_field_r = cuda.to_device( back_field_r )
-    d_back_field_t = cuda.to_device( back_field_t )
+    d_back_field_r = cupy.asarray( back_field_r )
+    d_back_field_t = cupy.asarray( back_field_t )
 
     # ----------------
     # Scalar transform
@@ -71,8 +74,8 @@ if __name__ == '__main__' :
     print( '\n Time taken on the GPU : %.3f ms\n' %(tmin*1e3) )
     
     # Check accuracy
-    check_spect_field_p = d_spect_field_p.copy_to_host()
-    check_back_field_r = d_back_field_r.copy_to_host()
+    check_spect_field_p = d_spect_field_p.get()
+    check_back_field_r = d_back_field_r.get()
     print( 'Max error on forward transform : %e' \
       % abs(spect_field_p - check_spect_field_p).max() )
     print( 'Max error on backward transform : %e\n' \
@@ -116,10 +119,10 @@ if __name__ == '__main__' :
     print( '\n Time taken on the GPU : %.3f ms\n' %(tmin*1e3) )
     
     # Check accuracy
-    check_spect_field_p = d_spect_field_p.copy_to_host()
-    check_spect_field_m = d_spect_field_m.copy_to_host()
-    check_back_field_r = d_back_field_r.copy_to_host()
-    check_back_field_t = d_back_field_t.copy_to_host()
+    check_spect_field_p = d_spect_field_p.get()
+    check_spect_field_m = d_spect_field_m.get()
+    check_back_field_r = d_back_field_r.get()
+    check_back_field_t = d_back_field_t.get()
     print( 'Max error on forward transform : %e' \
       % ( abs(spect_field_p - check_spect_field_p).max() \
       + abs(spect_field_m - check_spect_field_m).max() ) )


### PR DESCRIPTION
This merges the `cupy` branch into the `dev` branch.

This PR combines the following previous PR (that were made to the `cupy` branch):
- #429 (context manager that moves memory to the GPU)
- #430 (allocate data with `cupy` instead of `numba.cuda`)
- #431 (custom `cupy` decorator that reduces kernel launch overhead)
- #432 (check the version of `cupy`, `numba` and Python)
- #433 & #434 (move `cumsum` to GPU)
- #435 (clear `cupy` memory pool to avoid apparent growing memory usage)