### PR TITLE
PICMI: Add uniform distribution and default number of steps

### DIFF
--- a/fbpic/picmi/__init__.py
+++ b/fbpic/picmi/__init__.py
@@ -36,6 +36,7 @@ from picmistandard import PICMI_GriddedLayout as GriddedLayout
 from picmistandard import PICMI_PseudoRandomLayout as PseudoRandomLayout
 from picmistandard import PICMI_GaussianBunchDistribution as GaussianBunchDistribution
 from picmistandard import PICMI_AnalyticDistribution as AnalyticDistribution
+from picmistandard import PICMI_UniformDistribution as UniformDistribution
 # - For diagnostics
 from picmistandard import PICMI_FieldDiagnostic as FieldDiagnostic
 from picmistandard import PICMI_ParticleDiagnostic as ParticleDiagnostic

--- a/fbpic/picmi/__init__.py
+++ b/fbpic/picmi/__init__.py
@@ -47,5 +47,5 @@ from .simulation import Simulation
 __all__ = [ 'codename', 'Simulation', 'CylindricalGrid', 'BinomialSmoother',
     'ElectromagneticSolver', 'Species', 'MultiSpecies', 'LaserAntenna',
     'GaussianLaser', 'GriddedLayout', 'PseudoRandomLayout',
-    'GaussianBunchDistribution', 'AnalyticDistribution',
+    'GaussianBunchDistribution', 'AnalyticDistribution', 'UniformDistribution',
     'FieldDiagnostic', 'ParticleDiagnostic', 'constants' ]


### PR DESCRIPTION
This PR adds support for PICMI's `UniformDistribution` in FBPIC. (Before this PR, the only other supported distribution for evenly-spaced particles is the `AnalyticalDistribution`.)

In addition, this PR incorporates a small change to the `step` function: this is because picmi allows the number of timesteps to be passed either to `step`, or the the `Simulation` `__init__` function.