### PR TITLE
Update badges for new Travis interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Fourier-Bessel Particle-In-Cell code (FBPIC)
 
-[![Build Status master](https://img.shields.io/travis/fbpic/fbpic/master.svg?label=master)](https://travis-ci.org/fbpic/fbpic/branches)
-[![Build Status dev](https://img.shields.io/travis/fbpic/fbpic/dev.svg?label=dev)](https://travis-ci.org/fbpic/fbpic/branches)
+[![Build Status master](https://img.shields.io/travis/fbpic/fbpic/master.svg?label=master)](https://travis-ci.com/fbpic/fbpic/branches)
+[![Build Status dev](https://img.shields.io/travis/fbpic/fbpic/dev.svg?label=dev)](https://travis-ci.com/fbpic/fbpic/branches)
 [![pypi version](https://img.shields.io/pypi/v/fbpic.svg)](https://pypi.python.org/pypi/fbpic)
 [![License](https://img.shields.io/pypi/l/fbpic.svg)](LICENSE.txt)
 [![DOI](https://zenodo.org/badge/69215997.svg)](https://zenodo.org/badge/latestdoi/69215997)


### PR DESCRIPTION
Travis CI is encouraging repos to transition from the legacy `travis-ci.org` interface to the new `travis-ci.com` interface. 
Thanks to @ax3l's help, I made the corresponding changes on the Travis CI side, for FBPIC. This PR simplies updates the badges, so that they reflect the status on `travis-ci.com`.