### PR TITLE
Fix GPUdirect for cupy arrays

### DIFF
--- a/docs/source/install/install_juwels.rst
+++ b/docs/source/install/install_juwels.rst
@@ -19,7 +19,8 @@ To load the standard modules the ``.bashrc`` should contain the following:
 
 ::
 
-    module load intel-para/2019a
+    module load GCC/8.3.0
+    module load MVAPICH2/2.3.3-GDR
 
 Installation of Anaconda
 ------------------------------------------------
@@ -47,7 +48,13 @@ library that is loaded on the cluster via the modules.
 
 ::
 
-   pip install mpi4py --no-cache-dir
+    pip install mpi4py --no-cache-dir
+
+If you want to use GPUdirect, you instead need the development version:
+
+::
+
+    pip install git+https://bitbucket.org/mpi4py/mpi4py.git --no-cache-dir
 
 You can check if the correct MPI is linked by opening a ``python`` shell
 and checking:
@@ -109,3 +116,12 @@ tasks (e.g. 8 GPUs). ``--pty`` activates continuous console output and
 established with ``ssh -Y username@juwels.fz-juelich.de``.
 
 ``srun --ntasks=8 --forward-x --pty python run_file.py``
+
+**Using GPUdirect**
+
+To take advantage of direct communication between MPI and the GPUs, run:
+
+``export FBPIC_ENABLE_GPUDIRECT=1``
+
+Note that this will only work with the correct MPI implementation (i.e. the
+cluster modules above) and requires the development version of ``mpi4py``.

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -644,14 +644,10 @@ class BoundaryCommunicator(object):
         # Prepare MPI call by pointing to the correct sending/receiving buffers
         if gpudirect_enabled:
             # Create create pointers to GPU array, for cuda-aware MPI
-            send_l = get_gpu_mpi_buffer(
-                        self.mpi_buffers.d_send_l[exchange_type] )
-            send_r = get_gpu_mpi_buffer(
-                        self.mpi_buffers.d_send_r[exchange_type] )
-            recv_l = get_gpu_mpi_buffer(
-                        self.mpi_buffers.d_recv_l[exchange_type] )
-            recv_r = get_gpu_mpi_buffer(
-                        self.mpi_buffers.d_recv_r[exchange_type] )
+            send_l = self.mpi_buffers.d_send_l[exchange_type] 
+            send_r = self.mpi_buffers.d_send_r[exchange_type]
+            recv_l = self.mpi_buffers.d_recv_l[exchange_type] 
+            recv_r = self.mpi_buffers.d_recv_r[exchange_type] 
         else:
             # Use arrays that are on the CPU
             send_l = self.mpi_buffers.send_l[ exchange_type ]
@@ -1226,23 +1222,3 @@ class BoundaryCommunicator(object):
         if self.rank == root:
             return(gathered_array)
 
-
-def get_gpu_mpi_buffer(gpu_array):
-    """
-    Prepare a GPU array to be send via GPUDirect with CUDA-aware MPI by
-    creating an MPI buffer object with mpi4py.
-
-    Parameters:
-    ------------
-    gpu_array: a numba GPU device array
-        The GPU array for which an MPI buffer is created
-
-    Returns:
-    --------
-    mpi_buffer: an MPI buffer object
-        A buffer that can be send via GPUDirect with CUDA-aware MPI
-    """
-    gpu_mpi_buffer = MPI.memory.fromaddress(
-        gpu_array.device_ctypes_pointer.value,
-        gpu_array.alloc_size )
-    return gpu_mpi_buffer

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -8,7 +8,7 @@ It defines the structure necessary to implement the boundary exchanges.
 import warnings
 import numpy as np
 from scipy.constants import c
-from fbpic.utils.mpi import MPI, comm, mpi_type_dict, \
+from fbpic.utils.mpi import comm, mpi_type_dict, \
     mpi_installed, gpudirect_enabled
 from fbpic.fields.fields import InterpolationGrid
 from fbpic.fields.utility_methods import get_stencil_reach

--- a/fbpic/utils/mpi.py
+++ b/fbpic/utils/mpi.py
@@ -9,6 +9,7 @@ is not installed
 import os
 try:
     # Try to import MPI objects
+    import mpi4py
     from mpi4py import MPI
     from mpi4py.MPI import COMM_WORLD as comm
     # Dictionary of correspondance between numpy types and mpi types
@@ -30,6 +31,14 @@ try:
             gpudirect_enabled = False
     else:
         gpudirect_enabled = False
+
+    if gpudirect_enabled:
+        mpi4py_version_number = mpi4py.__version__.split('.')
+        mpi4py_major_version = int(mpi4py_version_number[0])
+        mpi4py_minor_version = int(mpi4py_version_number[1])
+        if (mpi4py_major_version < 3) or (mpi4py_minor_version < 1):
+            raise RuntimeError(
+                "In order to use GPU Direct, you need to install mpi4py>=3.1.")
 
 except ImportError:
     # If MPI is not installed, define dummy replacements


### PR DESCRIPTION
Since the last version of FBPIC, GPUdirect (i.e. direct MPI communication between GPUs) no longer works because the `numba` arrays have been replaced by `cupy` arrays. This PR fixes this issue.

It should be noted that GPUdirect only works with the development version of `mpi4py` (3.1.0a0), where a new interface for this functionality has been introduced (see [the cupy documentation](https://docs-cupy.chainer.org/en/stable/reference/interoperability.html)).

The PR also updates the documentation regarding installation on JUWELS to include GPUdirect.