### PR TITLE
Move shape factors to seperate file

### DIFF
--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -11,72 +11,14 @@ from fbpic.utils.cuda import compile_cupy
 import math
 from scipy.constants import c
 import numpy as np
+from fbpic.particles.deposition.particle_shapes import Sz_linear, \
+    Sr_linear, Sz_cubic, Sr_cubic
 
-# -------------------------------
-# Particle shape Factor functions
-# -------------------------------
-
-# Linear shapes
-@cuda.jit(device=True, inline=True)
-def z_shape_linear(cell_position, index):
-    iz = int(math.ceil(cell_position)) - 1
-    s = 0.
-    if index == 0:
-        s = iz+1.-cell_position
-    elif index == 1:
-        s = cell_position - iz
-    return s
-
-@cuda.jit(device=True, inline=True)
-def r_shape_linear(cell_position, index):
-    flip_factor = 1.
-    ir = int(math.ceil(cell_position)) - 1
-    s = 0.
-    if index == 0:
-        if ir < 0:
-            flip_factor = -1.
-        s = flip_factor*(ir+1.-cell_position)
-    elif index == 1:
-        s = flip_factor*(cell_position - ir)
-    return s
-
-# Cubic shapes
-@cuda.jit(device=True, inline=True)
-def z_shape_cubic(cell_position, index):
-    iz = int(math.ceil(cell_position)) - 2
-    s = 0.
-    if index == 0:
-        s = (-1./6.)*((cell_position-iz)-2)**3
-    elif index == 1:
-        s = (1./6.)*(3*((cell_position-(iz+1))**3)-6*((cell_position-(iz+1))**2)+4)
-    elif index == 2:
-        s = (1./6.)*(3*(((iz+2)-cell_position)**3)-6*(((iz+2)-cell_position)**2)+4)
-    elif index == 3:
-        s = (-1./6.)*(((iz+3)-cell_position)-2)**3
-    return s
-
-@cuda.jit(device=True, inline=True)
-def r_shape_cubic(cell_position, index):
-    flip_factor = 1.
-    ir = int(math.ceil(cell_position)) - 2
-    s = 0.
-    if index == 0:
-        if ir < 0:
-            flip_factor = -1.
-        s = flip_factor*(-1./6.)*((cell_position-ir)-2)**3
-    elif index == 1:
-        if ir+1 < 0:
-            flip_factor = -1.
-        s = flip_factor*(1./6.)*(3*((cell_position-(ir+1))**3)-6*((cell_position-(ir+1))**2)+4)
-    elif index == 2:
-        if ir+2 < 0:
-            flip_factor = -1.
-        s = flip_factor*(1./6.)*(3*(((ir+2)-cell_position)**3)-6*(((ir+2)-cell_position)**2)+4)
-    elif index == 3:
-        if ir+3 < 0:
-            flip_factor = -1.
-        s = flip_factor*(-1./6.)*(((ir+3)-cell_position)-2)**3
-    return s
+# JIT-compilation of particle shapes
+Sz_linear = cuda.jit(Sz_linear, device=True, inline=True)
+Sr_linear = cuda.jit(Sr_linear, device=True, inline=True)
+Sz_cubic = cuda.jit(Sz_cubic, device=True, inline=True)
+Sr_cubic = cuda.jit(Sr_cubic, device=True, inline=True)
 
 # -------------------------------
 # Field deposition - linear - rho
@@ -204,14 +146,14 @@ def deposit_rho_gpu_linear(x, y, z, w, q,
             # Mode 1
             R_m1_scal = wj * exptheta_m1
 
-            R_m0_00 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 0) * R_m0_scal
-            R_m0_01 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 1) * R_m0_scal
-            R_m1_00 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 0) * R_m1_scal
-            R_m1_01 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 1) * R_m1_scal
-            R_m0_10 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 0) * R_m0_scal
-            R_m0_11 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 1) * R_m0_scal
-            R_m1_10 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 0) * R_m1_scal
-            R_m1_11 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 1) * R_m1_scal
+            R_m0_00 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 0) * R_m0_scal
+            R_m0_01 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 1) * R_m0_scal
+            R_m1_00 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 0) * R_m1_scal
+            R_m1_01 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 1) * R_m1_scal
+            R_m0_10 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 0) * R_m0_scal
+            R_m0_11 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 1) * R_m0_scal
+            R_m1_10 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 0) * R_m1_scal
+            R_m1_11 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 1) * R_m1_scal
 
         # Calculate longitudinal indices at which to add charge
         iz0 = iz_upper - 1
@@ -415,31 +357,31 @@ def deposit_J_gpu_linear(x, y, z, w, q,
             J_t_m1_scal = wj * c * inv_gammaj*(cos*uyj - sin*uxj) * exptheta_m1
             J_z_m1_scal = wj * c * inv_gammaj*uzj * exptheta_m1
 
-            J_r_m0_00 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 0) * J_r_m0_scal
-            J_t_m0_00 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 0) * J_t_m0_scal
-            J_z_m0_00 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 0) * J_z_m0_scal
-            J_r_m0_01 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 1) * J_r_m0_scal
-            J_t_m0_01 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 1) * J_t_m0_scal
-            J_z_m0_01 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 1) * J_z_m0_scal
-            J_r_m1_00 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 0) * J_r_m1_scal
-            J_t_m1_00 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 0) * J_t_m1_scal
-            J_z_m1_00 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 0) * J_z_m1_scal
-            J_r_m1_01 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 1) * J_r_m1_scal
-            J_t_m1_01 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 1) * J_t_m1_scal
-            J_z_m1_01 += r_shape_linear(r_cell, 0)*z_shape_linear(z_cell, 1) * J_z_m1_scal
+            J_r_m0_00 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 0) * J_r_m0_scal
+            J_t_m0_00 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 0) * J_t_m0_scal
+            J_z_m0_00 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 0) * J_z_m0_scal
+            J_r_m0_01 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 1) * J_r_m0_scal
+            J_t_m0_01 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 1) * J_t_m0_scal
+            J_z_m0_01 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 1) * J_z_m0_scal
+            J_r_m1_00 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 0) * J_r_m1_scal
+            J_t_m1_00 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 0) * J_t_m1_scal
+            J_z_m1_00 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 0) * J_z_m1_scal
+            J_r_m1_01 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 1) * J_r_m1_scal
+            J_t_m1_01 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 1) * J_t_m1_scal
+            J_z_m1_01 += Sr_linear(r_cell, 0)*Sz_linear(z_cell, 1) * J_z_m1_scal
 
-            J_r_m0_10 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 0) * J_r_m0_scal
-            J_t_m0_10 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 0) * J_t_m0_scal
-            J_z_m0_10 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 0) * J_z_m0_scal
-            J_r_m0_11 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 1) * J_r_m0_scal
-            J_t_m0_11 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 1) * J_t_m0_scal
-            J_z_m0_11 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 1) * J_z_m0_scal
-            J_r_m1_10 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 0) * J_r_m1_scal
-            J_t_m1_10 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 0) * J_t_m1_scal
-            J_z_m1_10 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 0) * J_z_m1_scal
-            J_r_m1_11 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 1) * J_r_m1_scal
-            J_t_m1_11 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 1) * J_t_m1_scal
-            J_z_m1_11 += r_shape_linear(r_cell, 1)*z_shape_linear(z_cell, 1) * J_z_m1_scal
+            J_r_m0_10 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 0) * J_r_m0_scal
+            J_t_m0_10 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 0) * J_t_m0_scal
+            J_z_m0_10 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 0) * J_z_m0_scal
+            J_r_m0_11 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 1) * J_r_m0_scal
+            J_t_m0_11 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 1) * J_t_m0_scal
+            J_z_m0_11 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 1) * J_z_m0_scal
+            J_r_m1_10 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 0) * J_r_m1_scal
+            J_t_m1_10 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 0) * J_t_m1_scal
+            J_z_m1_10 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 0) * J_z_m1_scal
+            J_r_m1_11 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 1) * J_r_m1_scal
+            J_t_m1_11 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 1) * J_t_m1_scal
+            J_z_m1_11 += Sr_linear(r_cell, 1)*Sz_linear(z_cell, 1) * J_z_m1_scal
 
         # Calculate longitudinal indices at which to add charge
         iz0 = iz_upper - 1
@@ -662,41 +604,41 @@ def deposit_rho_gpu_cubic(x, y, z, w, q,
             # Mode 1
             R_m1_scal = wj * exptheta_m1
 
-            R_m0_00 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 0)*R_m0_scal
-            R_m1_00 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 0)*R_m1_scal
-            R_m0_01 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 1)*R_m0_scal
-            R_m1_01 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 1)*R_m1_scal
-            R_m0_02 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 2)*R_m0_scal
-            R_m1_02 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 2)*R_m1_scal
-            R_m0_03 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 3)*R_m0_scal
-            R_m1_03 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 3)*R_m1_scal
+            R_m0_00 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 0)*R_m0_scal
+            R_m1_00 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 0)*R_m1_scal
+            R_m0_01 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 1)*R_m0_scal
+            R_m1_01 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 1)*R_m1_scal
+            R_m0_02 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 2)*R_m0_scal
+            R_m1_02 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 2)*R_m1_scal
+            R_m0_03 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 3)*R_m0_scal
+            R_m1_03 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 3)*R_m1_scal
 
-            R_m0_10 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 0)*R_m0_scal
-            R_m1_10 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 0)*R_m1_scal
-            R_m0_11 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 1)*R_m0_scal
-            R_m1_11 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 1)*R_m1_scal
-            R_m0_12 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 2)*R_m0_scal
-            R_m1_12 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 2)*R_m1_scal
-            R_m0_13 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 3)*R_m0_scal
-            R_m1_13 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 3)*R_m1_scal
+            R_m0_10 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 0)*R_m0_scal
+            R_m1_10 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 0)*R_m1_scal
+            R_m0_11 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 1)*R_m0_scal
+            R_m1_11 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 1)*R_m1_scal
+            R_m0_12 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 2)*R_m0_scal
+            R_m1_12 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 2)*R_m1_scal
+            R_m0_13 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 3)*R_m0_scal
+            R_m1_13 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 3)*R_m1_scal
 
-            R_m0_20 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 0)*R_m0_scal
-            R_m1_20 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 0)*R_m1_scal
-            R_m0_21 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 1)*R_m0_scal
-            R_m1_21 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 1)*R_m1_scal
-            R_m0_22 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 2)*R_m0_scal
-            R_m1_22 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 2)*R_m1_scal
-            R_m0_23 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 3)*R_m0_scal
-            R_m1_23 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 3)*R_m1_scal
+            R_m0_20 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 0)*R_m0_scal
+            R_m1_20 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 0)*R_m1_scal
+            R_m0_21 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 1)*R_m0_scal
+            R_m1_21 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 1)*R_m1_scal
+            R_m0_22 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 2)*R_m0_scal
+            R_m1_22 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 2)*R_m1_scal
+            R_m0_23 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 3)*R_m0_scal
+            R_m1_23 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 3)*R_m1_scal
 
-            R_m0_30 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 0)*R_m0_scal
-            R_m1_30 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 0)*R_m1_scal
-            R_m0_31 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 1)*R_m0_scal
-            R_m1_31 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 1)*R_m1_scal
-            R_m0_32 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 2)*R_m0_scal
-            R_m1_32 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 2)*R_m1_scal
-            R_m0_33 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 3)*R_m0_scal
-            R_m1_33 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 3)*R_m1_scal
+            R_m0_30 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 0)*R_m0_scal
+            R_m1_30 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 0)*R_m1_scal
+            R_m0_31 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 1)*R_m0_scal
+            R_m1_31 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 1)*R_m1_scal
+            R_m0_32 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 2)*R_m0_scal
+            R_m1_32 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 2)*R_m1_scal
+            R_m0_33 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 3)*R_m0_scal
+            R_m1_33 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 3)*R_m1_scal
 
         # Calculate longitudinal indices at which to add charge
         iz0 = iz_upper - 2
@@ -1027,113 +969,113 @@ def deposit_J_gpu_cubic(x, y, z, w, q,
             J_t_m1_scal = wj * c * inv_gammaj*(cos*uyj - sin*uxj) * exptheta_m1
             J_z_m1_scal = wj * c * inv_gammaj*uzj * exptheta_m1
 
-            J_r_m0_00 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 0)*J_r_m0_scal
-            J_r_m1_00 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 0)*J_r_m1_scal
-            J_r_m0_01 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 1)*J_r_m0_scal
-            J_r_m1_01 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 1)*J_r_m1_scal
-            J_r_m0_02 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 2)*J_r_m0_scal
-            J_r_m1_02 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 2)*J_r_m1_scal
-            J_r_m0_03 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 3)*J_r_m0_scal
-            J_r_m1_03 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 3)*J_r_m1_scal
+            J_r_m0_00 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 0)*J_r_m0_scal
+            J_r_m1_00 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 0)*J_r_m1_scal
+            J_r_m0_01 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 1)*J_r_m0_scal
+            J_r_m1_01 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 1)*J_r_m1_scal
+            J_r_m0_02 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 2)*J_r_m0_scal
+            J_r_m1_02 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 2)*J_r_m1_scal
+            J_r_m0_03 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 3)*J_r_m0_scal
+            J_r_m1_03 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 3)*J_r_m1_scal
 
-            J_r_m0_10 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 0)*J_r_m0_scal
-            J_r_m1_10 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 0)*J_r_m1_scal
-            J_r_m0_11 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 1)*J_r_m0_scal
-            J_r_m1_11 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 1)*J_r_m1_scal
-            J_r_m0_12 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 2)*J_r_m0_scal
-            J_r_m1_12 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 2)*J_r_m1_scal
-            J_r_m0_13 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 3)*J_r_m0_scal
-            J_r_m1_13 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 3)*J_r_m1_scal
+            J_r_m0_10 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 0)*J_r_m0_scal
+            J_r_m1_10 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 0)*J_r_m1_scal
+            J_r_m0_11 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 1)*J_r_m0_scal
+            J_r_m1_11 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 1)*J_r_m1_scal
+            J_r_m0_12 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 2)*J_r_m0_scal
+            J_r_m1_12 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 2)*J_r_m1_scal
+            J_r_m0_13 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 3)*J_r_m0_scal
+            J_r_m1_13 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 3)*J_r_m1_scal
 
-            J_r_m0_20 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 0)*J_r_m0_scal
-            J_r_m1_20 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 0)*J_r_m1_scal
-            J_r_m0_21 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 1)*J_r_m0_scal
-            J_r_m1_21 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 1)*J_r_m1_scal
-            J_r_m0_22 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 2)*J_r_m0_scal
-            J_r_m1_22 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 2)*J_r_m1_scal
-            J_r_m0_23 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 3)*J_r_m0_scal
-            J_r_m1_23 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 3)*J_r_m1_scal
+            J_r_m0_20 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 0)*J_r_m0_scal
+            J_r_m1_20 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 0)*J_r_m1_scal
+            J_r_m0_21 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 1)*J_r_m0_scal
+            J_r_m1_21 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 1)*J_r_m1_scal
+            J_r_m0_22 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 2)*J_r_m0_scal
+            J_r_m1_22 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 2)*J_r_m1_scal
+            J_r_m0_23 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 3)*J_r_m0_scal
+            J_r_m1_23 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 3)*J_r_m1_scal
 
-            J_r_m0_30 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 0)*J_r_m0_scal
-            J_r_m1_30 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 0)*J_r_m1_scal
-            J_r_m0_31 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 1)*J_r_m0_scal
-            J_r_m1_31 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 1)*J_r_m1_scal
-            J_r_m0_32 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 2)*J_r_m0_scal
-            J_r_m1_32 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 2)*J_r_m1_scal
-            J_r_m0_33 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 3)*J_r_m0_scal
-            J_r_m1_33 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 3)*J_r_m1_scal
+            J_r_m0_30 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 0)*J_r_m0_scal
+            J_r_m1_30 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 0)*J_r_m1_scal
+            J_r_m0_31 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 1)*J_r_m0_scal
+            J_r_m1_31 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 1)*J_r_m1_scal
+            J_r_m0_32 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 2)*J_r_m0_scal
+            J_r_m1_32 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 2)*J_r_m1_scal
+            J_r_m0_33 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 3)*J_r_m0_scal
+            J_r_m1_33 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 3)*J_r_m1_scal
 
-            J_t_m0_00 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 0)*J_t_m0_scal
-            J_t_m1_00 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 0)*J_t_m1_scal
-            J_t_m0_01 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 1)*J_t_m0_scal
-            J_t_m1_01 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 1)*J_t_m1_scal
-            J_t_m0_02 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 2)*J_t_m0_scal
-            J_t_m1_02 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 2)*J_t_m1_scal
-            J_t_m0_03 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 3)*J_t_m0_scal
-            J_t_m1_03 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 3)*J_t_m1_scal
+            J_t_m0_00 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 0)*J_t_m0_scal
+            J_t_m1_00 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 0)*J_t_m1_scal
+            J_t_m0_01 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 1)*J_t_m0_scal
+            J_t_m1_01 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 1)*J_t_m1_scal
+            J_t_m0_02 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 2)*J_t_m0_scal
+            J_t_m1_02 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 2)*J_t_m1_scal
+            J_t_m0_03 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 3)*J_t_m0_scal
+            J_t_m1_03 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 3)*J_t_m1_scal
 
-            J_t_m0_10 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 0)*J_t_m0_scal
-            J_t_m1_10 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 0)*J_t_m1_scal
-            J_t_m0_11 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 1)*J_t_m0_scal
-            J_t_m1_11 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 1)*J_t_m1_scal
-            J_t_m0_12 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 2)*J_t_m0_scal
-            J_t_m1_12 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 2)*J_t_m1_scal
-            J_t_m0_13 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 3)*J_t_m0_scal
-            J_t_m1_13 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 3)*J_t_m1_scal
+            J_t_m0_10 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 0)*J_t_m0_scal
+            J_t_m1_10 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 0)*J_t_m1_scal
+            J_t_m0_11 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 1)*J_t_m0_scal
+            J_t_m1_11 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 1)*J_t_m1_scal
+            J_t_m0_12 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 2)*J_t_m0_scal
+            J_t_m1_12 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 2)*J_t_m1_scal
+            J_t_m0_13 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 3)*J_t_m0_scal
+            J_t_m1_13 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 3)*J_t_m1_scal
 
-            J_t_m0_20 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 0)*J_t_m0_scal
-            J_t_m1_20 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 0)*J_t_m1_scal
-            J_t_m0_21 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 1)*J_t_m0_scal
-            J_t_m1_21 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 1)*J_t_m1_scal
-            J_t_m0_22 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 2)*J_t_m0_scal
-            J_t_m1_22 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 2)*J_t_m1_scal
-            J_t_m0_23 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 3)*J_t_m0_scal
-            J_t_m1_23 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 3)*J_t_m1_scal
+            J_t_m0_20 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 0)*J_t_m0_scal
+            J_t_m1_20 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 0)*J_t_m1_scal
+            J_t_m0_21 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 1)*J_t_m0_scal
+            J_t_m1_21 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 1)*J_t_m1_scal
+            J_t_m0_22 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 2)*J_t_m0_scal
+            J_t_m1_22 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 2)*J_t_m1_scal
+            J_t_m0_23 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 3)*J_t_m0_scal
+            J_t_m1_23 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 3)*J_t_m1_scal
 
-            J_t_m0_30 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 0)*J_t_m0_scal
-            J_t_m1_30 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 0)*J_t_m1_scal
-            J_t_m0_31 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 1)*J_t_m0_scal
-            J_t_m1_31 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 1)*J_t_m1_scal
-            J_t_m0_32 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 2)*J_t_m0_scal
-            J_t_m1_32 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 2)*J_t_m1_scal
-            J_t_m0_33 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 3)*J_t_m0_scal
-            J_t_m1_33 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 3)*J_t_m1_scal
+            J_t_m0_30 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 0)*J_t_m0_scal
+            J_t_m1_30 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 0)*J_t_m1_scal
+            J_t_m0_31 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 1)*J_t_m0_scal
+            J_t_m1_31 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 1)*J_t_m1_scal
+            J_t_m0_32 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 2)*J_t_m0_scal
+            J_t_m1_32 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 2)*J_t_m1_scal
+            J_t_m0_33 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 3)*J_t_m0_scal
+            J_t_m1_33 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 3)*J_t_m1_scal
 
-            J_z_m0_00 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 0)*J_z_m0_scal
-            J_z_m1_00 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 0)*J_z_m1_scal
-            J_z_m0_01 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 1)*J_z_m0_scal
-            J_z_m1_01 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 1)*J_z_m1_scal
-            J_z_m0_02 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 2)*J_z_m0_scal
-            J_z_m1_02 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 2)*J_z_m1_scal
-            J_z_m0_03 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 3)*J_z_m0_scal
-            J_z_m1_03 += r_shape_cubic(r_cell, 0)*z_shape_cubic(z_cell, 3)*J_z_m1_scal
+            J_z_m0_00 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 0)*J_z_m0_scal
+            J_z_m1_00 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 0)*J_z_m1_scal
+            J_z_m0_01 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 1)*J_z_m0_scal
+            J_z_m1_01 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 1)*J_z_m1_scal
+            J_z_m0_02 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 2)*J_z_m0_scal
+            J_z_m1_02 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 2)*J_z_m1_scal
+            J_z_m0_03 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 3)*J_z_m0_scal
+            J_z_m1_03 += Sr_cubic(r_cell, 0)*Sz_cubic(z_cell, 3)*J_z_m1_scal
 
-            J_z_m0_10 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 0)*J_z_m0_scal
-            J_z_m1_10 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 0)*J_z_m1_scal
-            J_z_m0_11 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 1)*J_z_m0_scal
-            J_z_m1_11 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 1)*J_z_m1_scal
-            J_z_m0_12 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 2)*J_z_m0_scal
-            J_z_m1_12 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 2)*J_z_m1_scal
-            J_z_m0_13 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 3)*J_z_m0_scal
-            J_z_m1_13 += r_shape_cubic(r_cell, 1)*z_shape_cubic(z_cell, 3)*J_z_m1_scal
+            J_z_m0_10 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 0)*J_z_m0_scal
+            J_z_m1_10 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 0)*J_z_m1_scal
+            J_z_m0_11 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 1)*J_z_m0_scal
+            J_z_m1_11 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 1)*J_z_m1_scal
+            J_z_m0_12 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 2)*J_z_m0_scal
+            J_z_m1_12 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 2)*J_z_m1_scal
+            J_z_m0_13 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 3)*J_z_m0_scal
+            J_z_m1_13 += Sr_cubic(r_cell, 1)*Sz_cubic(z_cell, 3)*J_z_m1_scal
 
-            J_z_m0_20 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 0)*J_z_m0_scal
-            J_z_m1_20 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 0)*J_z_m1_scal
-            J_z_m0_21 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 1)*J_z_m0_scal
-            J_z_m1_21 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 1)*J_z_m1_scal
-            J_z_m0_22 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 2)*J_z_m0_scal
-            J_z_m1_22 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 2)*J_z_m1_scal
-            J_z_m0_23 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 3)*J_z_m0_scal
-            J_z_m1_23 += r_shape_cubic(r_cell, 2)*z_shape_cubic(z_cell, 3)*J_z_m1_scal
+            J_z_m0_20 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 0)*J_z_m0_scal
+            J_z_m1_20 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 0)*J_z_m1_scal
+            J_z_m0_21 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 1)*J_z_m0_scal
+            J_z_m1_21 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 1)*J_z_m1_scal
+            J_z_m0_22 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 2)*J_z_m0_scal
+            J_z_m1_22 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 2)*J_z_m1_scal
+            J_z_m0_23 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 3)*J_z_m0_scal
+            J_z_m1_23 += Sr_cubic(r_cell, 2)*Sz_cubic(z_cell, 3)*J_z_m1_scal
 
-            J_z_m0_30 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 0)*J_z_m0_scal
-            J_z_m1_30 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 0)*J_z_m1_scal
-            J_z_m0_31 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 1)*J_z_m0_scal
-            J_z_m1_31 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 1)*J_z_m1_scal
-            J_z_m0_32 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 2)*J_z_m0_scal
-            J_z_m1_32 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 2)*J_z_m1_scal
-            J_z_m0_33 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 3)*J_z_m0_scal
-            J_z_m1_33 += r_shape_cubic(r_cell, 3)*z_shape_cubic(z_cell, 3)*J_z_m1_scal
+            J_z_m0_30 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 0)*J_z_m0_scal
+            J_z_m1_30 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 0)*J_z_m1_scal
+            J_z_m0_31 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 1)*J_z_m0_scal
+            J_z_m1_31 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 1)*J_z_m1_scal
+            J_z_m0_32 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 2)*J_z_m0_scal
+            J_z_m1_32 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 2)*J_z_m1_scal
+            J_z_m0_33 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 3)*J_z_m0_scal
+            J_z_m1_33 += Sr_cubic(r_cell, 3)*Sz_cubic(z_cell, 3)*J_z_m1_scal
 
         # Calculate longitudinal indices at which to add charge
         iz0 = iz_upper - 2

--- a/fbpic/particles/deposition/particle_shapes.py
+++ b/fbpic/particles/deposition/particle_shapes.py
@@ -13,7 +13,7 @@ import math
 
 # Linear shapes
 def Sz_linear(cell_position, index):
-    iz = int(math.ceil(cell_position)) - 1
+    iz = math.floor(cell_position)
     s = 0.
     if index == 0:
         s = iz+1.-cell_position
@@ -23,7 +23,7 @@ def Sz_linear(cell_position, index):
 
 def Sr_linear(cell_position, index):
     flip_factor = 1.
-    ir = int(math.ceil(cell_position)) - 1
+    ir = math.floor(cell_position)
     s = 0.
     if index == 0:
         if ir < 0:
@@ -35,7 +35,7 @@ def Sr_linear(cell_position, index):
 
 # Cubic shapes
 def Sz_cubic(cell_position, index):
-    iz = int(math.ceil(cell_position)) - 2
+    iz = math.floor(cell_position) - 1.
     s = 0.
     if index == 0:
         s = (-1./6.)*((cell_position-iz)-2)**3
@@ -49,7 +49,7 @@ def Sz_cubic(cell_position, index):
 
 def Sr_cubic(cell_position, index):
     flip_factor = 1.
-    ir = int(math.ceil(cell_position)) - 2
+    ir = math.floor(cell_position) - 1.
     s = 0.
     if index == 0:
         if ir < 0:

--- a/fbpic/particles/deposition/particle_shapes.py
+++ b/fbpic/particles/deposition/particle_shapes.py
@@ -1,0 +1,70 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen, Kevin Peters
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines the linear and cubic particle shape factors for the deposition.
+"""
+import math
+
+# -------------------------------
+# Particle shape Factor functions
+# -------------------------------
+
+# Linear shapes
+def Sz_linear(cell_position, index):
+    iz = int(math.ceil(cell_position)) - 1
+    s = 0.
+    if index == 0:
+        s = iz+1.-cell_position
+    elif index == 1:
+        s = cell_position - iz
+    return s
+
+def Sr_linear(cell_position, index):
+    flip_factor = 1.
+    ir = int(math.ceil(cell_position)) - 1
+    s = 0.
+    if index == 0:
+        if ir < 0:
+            flip_factor = -1.
+        s = flip_factor*(ir+1.-cell_position)
+    elif index == 1:
+        s = flip_factor*(cell_position - ir)
+    return s
+
+# Cubic shapes
+def Sz_cubic(cell_position, index):
+    iz = int(math.ceil(cell_position)) - 2
+    s = 0.
+    if index == 0:
+        s = (-1./6.)*((cell_position-iz)-2)**3
+    elif index == 1:
+        s = (1./6.)*(3*((cell_position-(iz+1))**3)-6*((cell_position-(iz+1))**2)+4)
+    elif index == 2:
+        s = (1./6.)*(3*(((iz+2)-cell_position)**3)-6*(((iz+2)-cell_position)**2)+4)
+    elif index == 3:
+        s = (-1./6.)*(((iz+3)-cell_position)-2)**3
+    return s
+
+def Sr_cubic(cell_position, index):
+    flip_factor = 1.
+    ir = int(math.ceil(cell_position)) - 2
+    s = 0.
+    if index == 0:
+        if ir < 0:
+            flip_factor = -1.
+        s = flip_factor*(-1./6.)*((cell_position-ir)-2)**3
+    elif index == 1:
+        if ir+1 < 0:
+            flip_factor = -1.
+        s = flip_factor*(1./6.)*(3*((cell_position-(ir+1))**3)-6*((cell_position-(ir+1))**2)+4)
+    elif index == 2:
+        if ir+2 < 0:
+            flip_factor = -1.
+        s = flip_factor*(1./6.)*(3*(((ir+2)-cell_position)**3)-6*(((ir+2)-cell_position)**2)+4)
+    elif index == 3:
+        if ir+3 < 0:
+            flip_factor = -1.
+        s = flip_factor*(-1./6.)*(((ir+3)-cell_position)-2)**3
+    return s

--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -11,72 +11,14 @@ import numba
 from fbpic.utils.threading import njit_parallel, prange
 import math
 from scipy.constants import c
+from fbpic.particles.deposition.particle_shapes import Sz_linear, \
+    Sr_linear, Sz_cubic, Sr_cubic
 
-# -------------------------------
-# Particle shape Factor functions
-# -------------------------------
-
-# Linear shapes
-@numba.njit
-def Sz_linear(cell_position, index):
-    iz = np.floor(cell_position)
-    s = 0.
-    if index == 0:
-        s = iz+1.-cell_position
-    elif index == 1:
-        s = cell_position - iz
-    return s
-
-@numba.njit
-def Sr_linear(cell_position, index):
-    flip_factor = 1.
-    ir = np.floor(cell_position)
-    s = 0.
-    if index == 0:
-        if ir < 0:
-            flip_factor = -1.
-        s = flip_factor*(ir+1.-cell_position)
-    elif index == 1:
-        s = flip_factor*(cell_position - ir)
-    return s
-
-# Cubic shapes
-@numba.njit
-def Sz_cubic(cell_position, index):
-    iz = np.floor(cell_position) - 1.
-    s = 0.
-    if index == 0:
-        s = (-1./6.)*((cell_position-iz)-2)**3
-    elif index == 1:
-        s = (1./6.)*(3*((cell_position-(iz+1))**3)-6*((cell_position-(iz+1))**2)+4)
-    elif index == 2:
-        s = (1./6.)*(3*(((iz+2)-cell_position)**3)-6*(((iz+2)-cell_position)**2)+4)
-    elif index == 3:
-        s = (-1./6.)*(((iz+3)-cell_position)-2)**3
-    return s
-
-@numba.njit
-def Sr_cubic(cell_position, index):
-    flip_factor = 1.
-    ir = np.floor(cell_position) - 1.
-    s = 0.
-    if index == 0:
-        if ir < 0:
-            flip_factor = -1.
-        s = flip_factor*(-1./6.)*((cell_position-ir)-2)**3
-    elif index == 1:
-        if ir+1 < 0:
-            flip_factor = -1.
-        s = flip_factor*(1./6.)*(3*((cell_position-(ir+1))**3)-6*((cell_position-(ir+1))**2)+4)
-    elif index == 2:
-        if ir+2 < 0:
-            flip_factor = -1.
-        s = flip_factor*(1./6.)*(3*(((ir+2)-cell_position)**3)-6*(((ir+2)-cell_position)**2)+4)
-    elif index == 3:
-        if ir+3 < 0:
-            flip_factor = -1.
-        s = flip_factor*(-1./6.)*(((ir+3)-cell_position)-2)**3
-    return s
+# JIT-compilation of particle shapes
+Sz_linear = numba.njit(Sz_linear)
+Sr_linear = numba.njit(Sr_linear)
+Sz_cubic = numba.njit(Sz_cubic)
+Sr_cubic = numba.njit(Sr_cubic)
 
 # -------------------------------
 # Field deposition - linear - rho


### PR DESCRIPTION
In the current code, the particle shape factors are defined redundantly at three seperate locations. This PR moves them to a single file and imports them where needed.