### PR TITLE
Do not use numba 0.49 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes numba scipy h5py mkl
+  - conda install --yes "numba<0.49" scipy h5py mkl
   - conda install --yes -c conda-forge mpi4py mpich
   - pip install pyflakes pytest==4.6
   - python setup.py install


### PR DESCRIPTION
It seems that Travis builds are stalling (and therefore failing) when using the new numba 0.49. 

While we investigate this problem, this PR forces Travis to use a lower version, so that builds can still work.