### PR TITLE
Enable caching in `numba.jit`, even when threading is activated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes numba scipy h5py mkl
+  - conda install --yes "numba<0.49" scipy h5py mkl
   - conda install --yes -c conda-forge mpi4py mpich
   - pip install pyflakes pytest==4.6
   - python setup.py install

--- a/fbpic/utils/threading.py
+++ b/fbpic/utils/threading.py
@@ -42,13 +42,14 @@ if threading_enabled:
 # Set the function njit_parallel and prange to the correct object
 if not threading_enabled:
     # Use regular serial compilation function
-    # Uses `cache=True` to avoid re-compilation (not available with threading)
+    # Uses `cache=True` to avoid re-compilation
     njit_parallel = njit( cache=True )
     prange = range
     nthreads = 1
 else:
-    # Use the parallel compilation function
-    njit_parallel = njit( parallel=True )
+    # Use the parallel compilation function (Use caching if available)
+    cache = (numba_minor_version >= 45)
+    njit_parallel = njit( parallel=True, cache=cache )
     prange = numba_prange
     nthreads = numba.config.NUMBA_NUM_THREADS
 


### PR DESCRIPTION
**Please merge #444 first**

Starting with numba 0.45, the option `cache=True` is available even when `parallel=True`. This makes compilation much faster. Therefore, this PR enables this option for all JIT compilation in FBPIC.