### PR TITLE
Update travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 # The validity of this file can be checked here: http://lint.travis-ci.org/
 
 sudo: false
-dist: precise
 language: python
 python:
     - "2.7"


### PR DESCRIPTION
We were using an old Linux environment for the Travis tests ; this PR changes this to the current default environment (Xenial).