### PR TITLE
Remove code for cubic shape in antenna deposition

### DIFF
--- a/fbpic/particles/utilities/utility_methods.py
+++ b/fbpic/particles/utilities/utility_methods.py
@@ -72,18 +72,8 @@ def weights(x, invdx, offset, Nx, direction, shape_order):
         # Linear weight
         S[0,:] = i[1,:] - x_cell
         S[1,:] = x_cell - i[0,:]
-    elif shape_order == 3:
-        i[0,:] = np.floor(x_cell).astype('int') - 1
-        i[1,:] = i[0,:] + 1
-        i[2,:] = i[0,:] + 2
-        i[3,:] = i[0,:] + 3
-        # Cubic Weights
-        S[0,:] = -1./6. * ((x_cell-i[0])-2)**3
-        S[1,:] = 1./6. * (3*((x_cell-i[1])**3) - 6*((x_cell-i[1])**2)+4)
-        S[2,:] = 1./6. * (3*((i[2]-x_cell)**3) - 6*((i[2]-x_cell)**2)+4)
-        S[3,:] = -1./6. * ((i[3]-x_cell)-2)**3
     else:
-        raise ValueError("shapes other than linear and cubic are not supported yet.")
+        raise ValueError("shapes other than linear are not supported.")
 
     # Periodic boundary conditions in z
     if direction == 'z':


### PR DESCRIPTION
In FBPIC, the antenna always deposits with linear shape factor ; therefore, this PR removes the code for cubic shape factors.