### PR TITLE
Refactor the code for Ruyten correction

### DIFF
--- a/fbpic/fields/interpolation_grid.py
+++ b/fbpic/fields/interpolation_grid.py
@@ -118,7 +118,21 @@ class InterpolationGrid(object) :
             # For standard shapes, the Ruyten coefficients are simply set to zero
             self.ruyten_linear_coef = np.zeros(Nr)
             self.ruyten_cubic_coef = np.zeros(Nr)
-        # TODO: Add comments
+        # Add one element (whose value is 0) at the beginning of the coefficient
+        # arrays. This element corresponds to the coefficient used by particles
+        # located in the first half of the first cell, radially.
+        # Note that, the Ruyten correction generally only affects the 2 nearest
+        # gridpoints - even with cubic shape - and that this correction has
+        # equal value but opposite sign at those 2 points.
+        # For the particles located in the first half of the first cell,
+        # only the first grid point is affected, and thus the Ruyten
+        # corrections (with equal value but opposite sign) is either summed
+        # or substracted at this point.
+        # When summed (e.g. for rho in mode m=0), the correction cancels out
+        # and so the actual value of the coefficient does not matter.
+        # When subtracted (e.g. for rho in mode m=1), setting the coefficient
+        # to 0 ensure that the correction does not modify the deposition of
+        # particles close to the axis.
         self.ruyten_linear_coef = np.concatenate(
                                     (np.array([0.]), self.ruyten_linear_coef) )
         self.ruyten_cubic_coef = np.concatenate(

--- a/fbpic/fields/interpolation_grid.py
+++ b/fbpic/fields/interpolation_grid.py
@@ -118,6 +118,11 @@ class InterpolationGrid(object) :
             # For standard shapes, the Ruyten coefficients are simply set to zero
             self.ruyten_linear_coef = np.zeros(Nr)
             self.ruyten_cubic_coef = np.zeros(Nr)
+        # TODO: Add comments
+        self.ruyten_linear_coef = np.concatenate(
+                                    (np.array([0.]), self.ruyten_linear_coef) )
+        self.ruyten_cubic_coef = np.concatenate(
+                                    (np.array([0.]), self.ruyten_cubic_coef) )
 
         # Allocate the fields arrays
         self.Er = np.zeros( (Nz, Nr), dtype='complex' )

--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -144,13 +144,9 @@ def deposit_rho_gpu_linear(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
 
             # Ruyten-corrected shape factor coefficients for both modes
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
-            if ir < 0:
-                bn_m0 = 0
-                bn_m1 = 0
-            else:
-                bn_m0 = beta_n_m0[ir]
-                bn_m1 = beta_n_m1[ir]
+            ir = min( int(math.ceil(r_cell)), Nr )
+            bn_m0 = beta_n_m0[ir]
+            bn_m1 = beta_n_m1[ir]
 
             # Calculate rho
             # --------------------------------------------
@@ -264,7 +260,7 @@ def deposit_J_gpu_linear(x, y, z, w, q,
     prefix_sum : 1darray of integers
         Represents the cumulative sum of
         the particles per cell
-    
+
     beta_n_m0, beta_n_m1 : 1darrays of floats
         Ruyten-corrected particle shape factor coefficients for mode 0 and 1
     """
@@ -364,13 +360,9 @@ def deposit_J_gpu_linear(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
 
             # Ruyten-corrected shape factor coefficients for both modes
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
-            if ir < 0:
-                bn_m0 = 0
-                bn_m1 = 0
-            else:
-                bn_m0 = beta_n_m0[ir]
-                bn_m1 = beta_n_m1[ir]
+            ir = min( int(math.ceil(r_cell)), Nr )
+            bn_m0 = beta_n_m0[ir]
+            bn_m1 = beta_n_m1[ir]
 
             # Calculate the currents
             # ----------------------
@@ -628,13 +620,9 @@ def deposit_rho_gpu_cubic(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
 
             # Ruyten-corrected shape factor coefficients for both modes
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
-            if ir < 0:
-                bn_m0 = 0
-                bn_m1 = 0
-            else:
-                bn_m0 = beta_n_m0[ir]
-                bn_m1 = beta_n_m1[ir]
+            ir = min( int(math.ceil(r_cell)), Nr )
+            bn_m0 = beta_n_m0[ir]
+            bn_m1 = beta_n_m1[ir]
 
             # Calculate rho
             # -------------
@@ -1002,13 +990,9 @@ def deposit_J_gpu_cubic(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
 
             # Ruyten-corrected shape factor coefficients for both modes
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
-            if ir < 0:
-                bn_m0 = 0
-                bn_m1 = 0
-            else:
-                bn_m0 = beta_n_m0[ir]
-                bn_m1 = beta_n_m1[ir]
+            ir = min( int(math.ceil(r_cell)), Nr )
+            bn_m0 = beta_n_m0[ir]
+            bn_m1 = beta_n_m1[ir]
 
             # Calculate the currents
             # --------------------------------------------

--- a/fbpic/particles/deposition/cuda_methods_one_mode.py
+++ b/fbpic/particles/deposition/cuda_methods_one_mode.py
@@ -148,11 +148,8 @@ def deposit_rho_gpu_linear_one_mode(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
 
             # Ruyten-corrected shape factor coefficient
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
-            if ir < 0:
-                bn = 0.
-            else:
-                bn = beta_n[ir]
+            ir = min( int(math.ceil(r_cell)), Nr )
+            bn = beta_n[ir]
 
             # Calculate rho
             # --------------------------------------------
@@ -343,11 +340,8 @@ def deposit_J_gpu_linear_one_mode(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
 
             # Ruyten-corrected shape factor coefficient
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
-            if ir < 0:
-                bn = 0.
-            else:
-                bn = beta_n[ir]
+            ir = min( int(math.ceil(r_cell)), Nr )
+            bn = beta_n[ir]
 
             # Calculate the currents
             # ----------------------
@@ -553,11 +547,8 @@ def deposit_rho_gpu_cubic_one_mode(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
 
             # Ruyten-corrected shape factor coefficient
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
-            if ir < 0:
-                bn = 0.
-            else:
-                bn = beta_n[ir]
+            ir = min( int(math.ceil(r_cell)), Nr )
+            bn = beta_n[ir]
 
             # Calculate rho
             # -------------
@@ -848,11 +839,8 @@ def deposit_J_gpu_cubic_one_mode(x, y, z, w, q,
             z_cell = invdz*(zj - zmin) - 0.5
 
             # Ruyten-corrected shape factor coefficient
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
-            if ir < 0:
-                bn = 0.
-            else:
-                bn = beta_n[ir]
+            ir = min( int(math.ceil(r_cell)), Nr )
+            bn = beta_n[ir]
 
             # Calculate the currents
             # --------------------------------------------

--- a/fbpic/particles/deposition/threading_methods.py
+++ b/fbpic/particles/deposition/threading_methods.py
@@ -83,7 +83,7 @@ def deposit_rho_numba_linear(x, y, z, w, q,
 
     beta_n_m_0 : 1darray of floats
         Ruyten-corrected particle shape factor coefficients for mode 0.
-        
+
     beta_n_m_higher : 1darray of floats
         Ruyten-corrected particle shape factor coefficients for higher modes.
         Ignored when Nm == 1.
@@ -128,16 +128,14 @@ def deposit_rho_numba_linear(x, y, z, w, q,
             # (`min` function avoids out-of-bounds access at high r)
             ir_cell = min( int(math.ceil(r_cell))+1, Nr+2 )
             iz_cell = int(math.ceil( z_cell )) + 1
-          
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )           
+
+            ir = min( int(math.ceil(r_cell)), Nr )
 
             # Add contribution of this particle to the global array
             for m in range(Nm):
 
                 # Ruyten-corrected shape factor coefficient
-                if ir < 0:
-                    bn = 0
-                elif m == 0:
+                if m == 0:
                     bn = beta_n_m_0[ir]
                 else:
                     bn = beta_n_m_higher[ir]
@@ -219,7 +217,7 @@ def deposit_J_numba_linear(x, y, z, w, q,
 
     beta_n_m_0 : 1darray of floats
         Ruyten-corrected particle shape factor coefficients for mode 0.
-        
+
     beta_n_m_higher : 1darray of floats
         Ruyten-corrected particle shape factor coefficients for higher modes.
         Ignored when Nm == 1.
@@ -277,15 +275,13 @@ def deposit_J_numba_linear(x, y, z, w, q,
             ir_cell = min( int(math.ceil(r_cell))+1, Nr+2 )
             iz_cell = int(math.ceil( z_cell )) + 1
 
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
+            ir = min( int(math.ceil(r_cell)), Nr )
 
             # Add contribution of this particle to the global array
             for m in range(Nm):
-                                
+
                 # Ruyten-corrected shape factor coefficient
-                if ir < 0:
-                    bn = 0
-                elif m == 0:
+                if m == 0:
                     bn = beta_n_m_0[ir]
                 else:
                     bn = beta_n_m_higher[ir]
@@ -372,7 +368,7 @@ def deposit_rho_numba_cubic(x, y, z, w, q,
 
     beta_n_m_0 : 1darray of floats
         Ruyten-corrected particle shape factor coefficients for mode 0.
-        
+
     beta_n_m_higher : 1darray of floats
         Ruyten-corrected particle shape factor coefficients for higher modes.
         Ignored when Nm == 1.
@@ -418,15 +414,13 @@ def deposit_rho_numba_cubic(x, y, z, w, q,
             ir_cell = min( int(math.ceil(r_cell)), Nr )
             iz_cell = int(math.ceil( z_cell ))
 
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
+            ir = min( int(math.ceil(r_cell)), Nr )
 
             # Add contribution of this particle to the global array
             for m in range(Nm):
 
                 # Ruyten-corrected shape factor coefficient
-                if ir < 0:
-                    bn = 0
-                elif m == 0:
+                if m == 0:
                     bn = beta_n_m_0[ir]
                 else:
                     bn = beta_n_m_higher[ir]
@@ -524,7 +518,7 @@ def deposit_J_numba_cubic(x, y, z, w, q,
 
     beta_n_m_0 : 1darray of floats
         Ruyten-corrected particle shape factor coefficients for mode 0.
-        
+
     beta_n_m_higher : 1darray of floats
         Ruyten-corrected particle shape factor coefficients for higher modes.
         Ignored when Nm == 1.
@@ -582,15 +576,13 @@ def deposit_J_numba_cubic(x, y, z, w, q,
             ir_cell = min( int(math.ceil(r_cell)), Nr )
             iz_cell = int(math.ceil( z_cell ))
 
-            ir = min( int(math.ceil(r_cell))-1, Nr-1 )
+            ir = min( int(math.ceil(r_cell)), Nr )
 
             # Add contribution of this particle to the global array
             for m in range(Nm):
 
                 # Ruyten-corrected shape factor coefficient
-                if ir < 0:
-                    bn = 0
-                elif m == 0:
+                if m == 0:
                     bn = beta_n_m_0[ir]
                 else:
                     bn = beta_n_m_higher[ir]

--- a/fbpic/particles/utilities/utility_methods.py
+++ b/fbpic/particles/utilities/utility_methods.py
@@ -78,8 +78,8 @@ def weights(x, invdx, offset, Nx, direction, shape_order, beta_n):
             S[1,:] = 1 - S[0,:]
         # Linear weight r
         elif direction == 'r':
-            ir = np.minimum(np.maximum(i[0,:], 0), Nx-1)
-            S[0,:] = (i[1,:] - x_cell) * (1.+beta_n[ir]*( x_cell - i[0,:] ))
+            ir = np.minimum(np.maximum(i[0,:], -1), Nx-1)
+            S[0,:] = (i[1,:] - x_cell) * (1.+beta_n[ir+1]*( x_cell - i[0,:] ))
             S[1,:] = 1 - S[0,:]
     else:
         raise ValueError("shapes other than linear are not supported.")


### PR DESCRIPTION
This refactors the code for the Ruyten correction, by removing the `if` condition in the deposition kernels and instead add an element in the Ruyten array (which corresponds to the particles in the first half of the first cell, radially.)

This should be equivalent to the previous implementation - except for the laser antenna: it seems that the laser antenna was using a non-zero Ruyten coeffficient for the particles in the first half of the first cell in the previous code.