### PR TITLE
Use single flag `cuda_installed` for both `cupy` and `numba.cuda`

### DIFF
--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -19,9 +19,8 @@ from .particle_buffer_handling import remove_outside_particles, \
      add_buffers_to_particles, shift_particles_periodic_subdomain
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
+if cuda_installed and cupy_installed:
     import cupy
-if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d
     from .cuda_methods import cuda_damp_EB_left, cuda_damp_EB_right, \
                                 cuda_damp_EB_left_pml, cuda_damp_EB_right_pml

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -19,7 +19,7 @@ from .particle_buffer_handling import remove_outside_particles, \
      add_buffers_to_particles, shift_particles_periodic_subdomain
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cuda_installed and cupy_installed:
+if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d
     from .cuda_methods import cuda_damp_EB_left, cuda_damp_EB_right, \

--- a/fbpic/boundaries/boundary_communicator.py
+++ b/fbpic/boundaries/boundary_communicator.py
@@ -18,7 +18,7 @@ from .pml_damping import PMLDamper
 from .particle_buffer_handling import remove_outside_particles, \
      add_buffers_to_particles, shift_particles_periodic_subdomain
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d

--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -8,7 +8,7 @@ It defines the structure necessary to handle mpi buffers for the fields
 import numpy as np
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed and cuda_installed:
+if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d
     from .cuda_methods import \

--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -7,7 +7,7 @@ It defines the structure necessary to handle mpi buffers for the fields
 """
 import numpy as np
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d

--- a/fbpic/boundaries/field_buffer_handling.py
+++ b/fbpic/boundaries/field_buffer_handling.py
@@ -8,9 +8,8 @@ It defines the structure necessary to handle mpi buffers for the fields
 import numpy as np
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
+if cupy_installed and cuda_installed:
     import cupy
-if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d
     from .cuda_methods import \
         copy_vec_to_gpu_buffer, \

--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -7,7 +7,7 @@ It defines the structure necessary to implement the moving window.
 """
 from fbpic.utils.threading import njit_parallel, prange
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed, cupy_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d, compile_cupy
 

--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -8,7 +8,7 @@ It defines the structure necessary to implement the moving window.
 from fbpic.utils.threading import njit_parallel, prange
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed, cupy_installed
-if cuda_installed and cupy_installed:
+if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d, compile_cupy
 
 class MovingWindow(object):
@@ -238,7 +238,7 @@ def shift_spect_array_cpu( field_array, shift_factor, n_move ):
         for ir in range( Nr ):
             field_array[iz, ir] *= power_shift
 
-if cuda_installed and cupy_installed:
+if cuda_installed:
 
     @compile_cupy
     def shift_spect_array_gpu( field_array, shift_factor, n_move ):

--- a/fbpic/boundaries/moving_window.py
+++ b/fbpic/boundaries/moving_window.py
@@ -7,8 +7,8 @@ It defines the structure necessary to implement the moving window.
 """
 from fbpic.utils.threading import njit_parallel, prange
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
-if cuda_installed:
+from fbpic.utils.cuda import cuda_installed, cupy_installed
+if cuda_installed and cupy_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_2d, compile_cupy
 
 class MovingWindow(object):
@@ -238,7 +238,7 @@ def shift_spect_array_cpu( field_array, shift_factor, n_move ):
         for ir in range( Nr ):
             field_array[iz, ir] *= power_shift
 
-if cuda_installed:
+if cuda_installed and cupy_installed:
 
     @compile_cupy
     def shift_spect_array_gpu( field_array, shift_factor, n_move ):

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -8,7 +8,7 @@ It defines the structure necessary to handle mpi buffers for the particles
 import numpy as np
 import numba
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 from fbpic.utils.printing import catch_gpu_memory_error
 if cuda_installed:
     import cupy

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -10,9 +10,8 @@ import numba
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
 from fbpic.utils.printing import catch_gpu_memory_error
-if cupy_installed:
+if cuda_installed and cupy_installed:
     import cupy
-if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 def remove_outside_particles(species, fld, n_guard, left_proc, right_proc):
@@ -558,7 +557,7 @@ def shift_particles_periodic_numba( z, zmin, zmax ):
 
 # Cuda routines
 # -------------
-if cuda_installed:
+if cuda_installed and cupy_installed:
 
     @compile_cupy
     def split_particles_to_buffers( particle_array, left_buffer,

--- a/fbpic/boundaries/particle_buffer_handling.py
+++ b/fbpic/boundaries/particle_buffer_handling.py
@@ -10,7 +10,7 @@ import numba
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
 from fbpic.utils.printing import catch_gpu_memory_error
-if cuda_installed and cupy_installed:
+if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
@@ -557,7 +557,7 @@ def shift_particles_periodic_numba( z, zmin, zmax ):
 
 # Cuda routines
 # -------------
-if cuda_installed and cupy_installed:
+if cuda_installed:
 
     @compile_cupy
     def split_particles_to_buffers( particle_array, left_buffer,

--- a/fbpic/boundaries/pml_damping.py
+++ b/fbpic/boundaries/pml_damping.py
@@ -7,9 +7,8 @@ It defines the structure that damps the fields in the guard cells.
 """
 import numpy as np
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
+if cuda_installed and cupy_installed:
     import cupy
-if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda, compile_cupy
 
 class PMLDamper(object):
@@ -107,7 +106,7 @@ def generate_pml_damp_array( n_pml, cdt_over_dr ):
     return( damping_array )
 
 
-if cuda_installed:
+if cuda_installed and cupy_installed:
     @compile_cupy
     def cuda_damp_pml_EB( Et, Et_pml, Ez, Bt, Bt_pml, Bz,
                       damp_array, n_pml ) :

--- a/fbpic/boundaries/pml_damping.py
+++ b/fbpic/boundaries/pml_damping.py
@@ -7,7 +7,7 @@ It defines the structure that damps the fields in the guard cells.
 """
 import numpy as np
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cuda_installed and cupy_installed:
+if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda, compile_cupy
 
@@ -106,7 +106,7 @@ def generate_pml_damp_array( n_pml, cdt_over_dr ):
     return( damping_array )
 
 
-if cuda_installed and cupy_installed:
+if cuda_installed:
     @compile_cupy
     def cuda_damp_pml_EB( Et, Et_pml, Ez, Bt, Bt_pml, Bz,
                       damp_array, n_pml ) :

--- a/fbpic/boundaries/pml_damping.py
+++ b/fbpic/boundaries/pml_damping.py
@@ -6,7 +6,7 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the structure that damps the fields in the guard cells.
 """
 import numpy as np
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda, compile_cupy

--- a/fbpic/fields/interpolation_grid.py
+++ b/fbpic/fields/interpolation_grid.py
@@ -9,7 +9,7 @@ import numpy as np
 from fbpic.fields.spectral_transform.hankel import DHT
 from scipy.special import j1, jn_zeros
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda_tpb_bpg_2d

--- a/fbpic/fields/interpolation_grid.py
+++ b/fbpic/fields/interpolation_grid.py
@@ -10,9 +10,8 @@ from fbpic.fields.spectral_transform.hankel import DHT
 from scipy.special import j1, jn_zeros
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
+if cuda_installed and cupy_installed:
     import cupy
-if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
     from .cuda_methods import \
         cuda_erase_scalar, cuda_erase_vector, \

--- a/fbpic/fields/interpolation_grid.py
+++ b/fbpic/fields/interpolation_grid.py
@@ -10,7 +10,7 @@ from fbpic.fields.spectral_transform.hankel import DHT
 from scipy.special import j1, jn_zeros
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cuda_installed and cupy_installed:
+if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
     from .cuda_methods import \

--- a/fbpic/fields/psatd_coefs.py
+++ b/fbpic/fields/psatd_coefs.py
@@ -7,8 +7,8 @@ It defines the PsatdCoeffs class.
 """
 import numpy as np
 from scipy.constants import c, mu_0, epsilon_0
-from fbpic.utils.cuda import cupy_installed
-if cupy_installed:
+from fbpic.utils.cuda import cuda_installed
+if cuda_installed:
     from fbpic.utils.cuda import cupy
 
 

--- a/fbpic/fields/spectral_grid.py
+++ b/fbpic/fields/spectral_grid.py
@@ -15,7 +15,7 @@ from .numba_methods import numba_push_eb_standard, numba_push_eb_comoving, \
     numba_correct_currents_crossdeposition_comoving, \
     numba_filter_scalar, numba_filter_vector
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda_tpb_bpg_2d

--- a/fbpic/fields/spectral_grid.py
+++ b/fbpic/fields/spectral_grid.py
@@ -16,9 +16,8 @@ from .numba_methods import numba_push_eb_standard, numba_push_eb_comoving, \
     numba_filter_scalar, numba_filter_vector
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
+if cupy_installed and cuda_installed:
     import cupy
-if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
     from .cuda_methods import \
     cuda_correct_currents_curlfree_standard, \

--- a/fbpic/fields/spectral_grid.py
+++ b/fbpic/fields/spectral_grid.py
@@ -16,7 +16,7 @@ from .numba_methods import numba_push_eb_standard, numba_push_eb_comoving, \
     numba_filter_scalar, numba_filter_vector
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed and cuda_installed:
+if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
     from .cuda_methods import \

--- a/fbpic/fields/spectral_transform/fourier.py
+++ b/fbpic/fields/spectral_transform/fourier.py
@@ -10,10 +10,9 @@ import numpy as np
 import numba
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed, cupy_installed
-if cuda_installed:
+if cuda_installed and cupy_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda_gpu_model
     from .cuda_methods import cuda_copy_2d_to_1d, cuda_copy_1d_to_2d
-if cupy_installed:
     import cupy
     from cupy.cuda import cufft
 

--- a/fbpic/fields/spectral_transform/fourier.py
+++ b/fbpic/fields/spectral_transform/fourier.py
@@ -9,7 +9,7 @@ and is used in spectral_transformer.py
 import numpy as np
 import numba
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed, cupy_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda_gpu_model
     from .cuda_methods import cuda_copy_2d_to_1d, cuda_copy_1d_to_2d

--- a/fbpic/fields/spectral_transform/fourier.py
+++ b/fbpic/fields/spectral_transform/fourier.py
@@ -10,7 +10,7 @@ import numpy as np
 import numba
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed, cupy_installed
-if cuda_installed and cupy_installed:
+if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda_gpu_model
     from .cuda_methods import cuda_copy_2d_to_1d, cuda_copy_1d_to_2d
     import cupy

--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -15,7 +15,7 @@ from scipy.special import jn, jn_zeros
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed, cupy_installed
 from .numba_methods import numba_copy_2dC_to_2dR, numba_copy_2dR_to_2dC
-if cuda_installed and cupy_installed:
+if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda_gpu_model
     from .cuda_methods import cuda_copy_2dC_to_2dR, cuda_copy_2dR_to_2dC
     import cupy

--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -15,10 +15,9 @@ from scipy.special import jn, jn_zeros
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed, cupy_installed
 from .numba_methods import numba_copy_2dC_to_2dR, numba_copy_2dR_to_2dC
-if cuda_installed:
+if cuda_installed and cupy_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda_gpu_model
     from .cuda_methods import cuda_copy_2dC_to_2dR, cuda_copy_2dR_to_2dC
-if cupy_installed:
     import cupy
     from cupy.cuda import device, cublas
 

--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -13,7 +13,7 @@ import numpy as np
 from scipy.special import jn, jn_zeros
 
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed, cupy_installed
+from fbpic.utils.cuda import cuda_installed
 from .numba_methods import numba_copy_2dC_to_2dR, numba_copy_2dR_to_2dC
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d, cuda_gpu_model

--- a/fbpic/fields/spectral_transform/spectral_transformer.py
+++ b/fbpic/fields/spectral_transform/spectral_transformer.py
@@ -13,7 +13,7 @@ from .fourier import FFT
 from .numba_methods import numba_rt_to_pm, numba_pm_to_rt
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cuda_installed and cupy_installed:
+if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
     from .cuda_methods import cuda_rt_to_pm, cuda_pm_to_rt

--- a/fbpic/fields/spectral_transform/spectral_transformer.py
+++ b/fbpic/fields/spectral_transform/spectral_transformer.py
@@ -12,7 +12,7 @@ from .fourier import FFT
 
 from .numba_methods import numba_rt_to_pm, numba_pm_to_rt
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda_tpb_bpg_2d

--- a/fbpic/fields/spectral_transform/spectral_transformer.py
+++ b/fbpic/fields/spectral_transform/spectral_transformer.py
@@ -13,9 +13,8 @@ from .fourier import FFT
 from .numba_methods import numba_rt_to_pm, numba_pm_to_rt
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
+if cuda_installed and cupy_installed:
     import cupy
-if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_2d
     from .cuda_methods import cuda_rt_to_pm, cuda_pm_to_rt
 

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -14,7 +14,7 @@ from fbpic.particles.deposition.numba_methods import deposit_field_numba
 
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cuda_installed and cupy_installed:
+if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
@@ -493,7 +493,7 @@ class LaserAntenna( object ):
                     self.d_Jr_buffer, self.d_Jt_buffer, self.d_Jz_buffer,
                     grid[m].Jr, grid[m].Jt, grid[m].Jz, m )
 
-if cuda_installed and cupy_installed:
+if cuda_installed:
 
     @compile_cupy
     def add_rho_to_gpu_array( iz_min, rho_buffer, rho, m ):

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -14,9 +14,8 @@ from fbpic.particles.deposition.numba_methods import deposit_field_numba
 
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
+if cuda_installed and cupy_installed:
     import cupy
-if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 class LaserAntenna( object ):
@@ -494,7 +493,7 @@ class LaserAntenna( object ):
                     self.d_Jr_buffer, self.d_Jt_buffer, self.d_Jz_buffer,
                     grid[m].Jr, grid[m].Jt, grid[m].Jz, m )
 
-if cuda_installed:
+if cuda_installed and cupy_installed:
 
     @compile_cupy
     def add_rho_to_gpu_array( iz_min, rho_buffer, rho, m ):

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -13,7 +13,7 @@ from fbpic.particles.utilities.utility_methods import weights
 from fbpic.particles.deposition.numba_methods import deposit_field_numba
 
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -13,7 +13,8 @@ from fbpic.utils.mpi import MPI
 # Check if threading is available
 from .utils.threading import threading_enabled, numba_minor_version
 # Check if CUDA is available, then import CUDA functions
-from .utils.cuda import cuda_installed, cupy_installed, cupy_major_version
+from .utils.cuda import cuda_installed, numba_cuda_installed, \
+    cupy_installed, cupy_major_version
 if cuda_installed:
     from .utils.cuda import send_data_to_gpu, \
                 receive_data_from_gpu, mpi_select_gpus

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -13,7 +13,7 @@ from fbpic.utils.mpi import MPI
 # Check if threading is available
 from .utils.threading import threading_enabled, numba_minor_version
 # Check if CUDA is available, then import CUDA functions
-from .utils.cuda import cuda_installed, numba_cuda_installed, \
+from .utils.cuda import cuda_installed, \
     cupy_installed, cupy_major_version
 if cuda_installed:
     from .utils.cuda import send_data_to_gpu, \

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -14,7 +14,7 @@ from fbpic.utils.mpi import MPI
 from .utils.threading import threading_enabled, numba_minor_version
 # Check if CUDA is available, then import CUDA functions
 from .utils.cuda import cuda_installed, \
-    cupy_installed, cupy_major_version
+    cupy_installed, cupy_major_version, numba_cuda_installed
 if cuda_installed:
     from .utils.cuda import send_data_to_gpu, \
                 receive_data_from_gpu, mpi_select_gpus
@@ -229,18 +229,19 @@ class Simulation(object):
         # Check whether to use CUDA
         self.use_cuda = use_cuda
         if self.use_cuda and not cuda_installed:
-            warnings.warn(
-                'Cuda not available for the simulation.\n'
-                'Performing the simulation on CPU.' )
+            warning_message = 'GPU not available for the simulation.\n'
+            if not numba_cuda_installed:
+                warning_message += \
+                '(This is because the `numba` package was not able to find a GPU.)\n'
+            elif not cupy_installed:
+                warning_message += \
+                '(This is because the `cupy` package is not installed.)\n'
+            warning_message += 'Performing the simulation on CPU.'
+            warnings.warn( warning_message )
             self.use_cuda = False
         # Check that cupy, numba and Python have the right version
         if self.use_cuda:
-            if not cupy_installed:
-                raise RuntimeError(
-                    'In order to run on GPUs, FBPIC version 0.13 and later \n'
-                    'require the `cupy` package.\n'
-                    'See the FBPIC documentation in order to install cupy.')
-            elif cupy_major_version < 7:
+            if cupy_major_version < 7:
                 raise RuntimeError(
                     'In order to run on GPUs, FBPIC version 0.16 and later \n'
                     'requires `cupy` version 7 (or later).\n(The `cupy` version'

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -17,7 +17,7 @@ from scipy.constants import c
 from .field_diag import FieldDiagnostic
 
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -18,7 +18,7 @@ from .field_diag import FieldDiagnostic
 
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cuda_installed and cupy_installed:
+if cuda_installed:
     import cupy
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
@@ -733,7 +733,7 @@ class SliceHandler:
         fields[ f2i['rho'], ... ] = rho_lab
         fields[ f2i['Jz'], ... ] = Jz_lab
 
-if cuda_installed and cupy_installed:
+if cuda_installed:
 
     @compile_cupy
     def extract_slice_cuda( Nr, iz, Sz, slice_arr,

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -18,9 +18,8 @@ from .field_diag import FieldDiagnostic
 
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
+if cuda_installed and cupy_installed:
     import cupy
-if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
 
 class BackTransformedFieldDiagnostic(FieldDiagnostic):
@@ -734,7 +733,7 @@ class SliceHandler:
         fields[ f2i['rho'], ... ] = rho_lab
         fields[ f2i['Jz'], ... ] = Jz_lab
 
-if cuda_installed:
+if cuda_installed and cupy_installed:
 
     @compile_cupy
     def extract_slice_cuda( Nr, iz, Sz, slice_arr,

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -18,7 +18,7 @@ from .particle_diag import ParticleDiagnostic
 
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed, cupy_installed
-if cuda_installed and cupy_installed:
+if cuda_installed:
     from .cuda_methods import extract_slice_from_gpu
 
 class BackTransformedParticleDiagnostic(ParticleDiagnostic):

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -17,8 +17,8 @@ from scipy.constants import c, e
 from .particle_diag import ParticleDiagnostic
 
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
-if cuda_installed:
+from fbpic.utils.cuda import cuda_installed, cupy_installed
+if cuda_installed and cupy_installed:
     from .cuda_methods import extract_slice_from_gpu
 
 class BackTransformedParticleDiagnostic(ParticleDiagnostic):

--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -17,7 +17,7 @@ from scipy.constants import c, e
 from .particle_diag import ParticleDiagnostic
 
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed, cupy_installed
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     from .cuda_methods import extract_slice_from_gpu
 

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -15,8 +15,8 @@ from .particle_diag import ParticleDiagnostic
 from fbpic.utils.mpi import comm
 
 # Check if CUDA is available, then import CUDA
-from fbpic.utils.cuda import cupy_installed
-if cupy_installed:
+from fbpic.utils.cuda import cuda_installed
+if cuda_installed:
     import cupy
 
 def set_periodic_checkpoint( sim, period, checkpoint_dir='./checkpoints' ):

--- a/fbpic/particles/elementary_process/compton/compton.py
+++ b/fbpic/particles/elementary_process/compton/compton.py
@@ -17,7 +17,7 @@ from fbpic.utils.printing import catch_gpu_memory_error
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
     from numba.cuda.random import create_xoroshiro128p_states
-if cuda_installed and cupy_installed:
+if cuda_installed:
     from .cuda_methods import get_photon_density_gaussian_cuda, \
         determine_scatterings_cuda, scatter_photons_electrons_cuda
 

--- a/fbpic/particles/elementary_process/compton/compton.py
+++ b/fbpic/particles/elementary_process/compton/compton.py
@@ -12,7 +12,7 @@ from .numba_methods import get_photon_density_gaussian_numba, \
 from ..cuda_numba_utils import allocate_empty, reallocate_and_copy_old, \
                                 perform_cumsum, generate_new_ids
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed, cupy_installed
+from fbpic.utils.cuda import cuda_installed
 from fbpic.utils.printing import catch_gpu_memory_error
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d

--- a/fbpic/particles/elementary_process/compton/compton.py
+++ b/fbpic/particles/elementary_process/compton/compton.py
@@ -12,11 +12,12 @@ from .numba_methods import get_photon_density_gaussian_numba, \
 from ..cuda_numba_utils import allocate_empty, reallocate_and_copy_old, \
                                 perform_cumsum, generate_new_ids
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed
+from fbpic.utils.cuda import cuda_installed, cupy_installed
 from fbpic.utils.printing import catch_gpu_memory_error
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
     from numba.cuda.random import create_xoroshiro128p_states
+if cuda_installed and cupy_installed:
     from .cuda_methods import get_photon_density_gaussian_cuda, \
         determine_scatterings_cuda, scatter_photons_electrons_cuda
 

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -9,13 +9,10 @@ It defines a number of methods that are useful for elementary processes
 import numpy as np
 from fbpic.utils.threading import njit_parallel, prange
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
+from fbpic.utils.cuda import cuda_installed
+if cuda_installed:
     import cupy
-if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
-if cuda_installed:
-    from fbpic.utils.cuda import compile_cupy
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
     
 def allocate_empty( shape, use_cuda, dtype ):
     """

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -14,7 +14,7 @@ if cupy_installed:
     import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
-if cuda_installed and cupy_installed:
+if cuda_installed:
     from fbpic.utils.cuda import compile_cupy
     
 def allocate_empty( shape, use_cuda, dtype ):
@@ -151,7 +151,7 @@ def copy_particle_data_numba( Ntot, old_array, new_array ):
         new_array[ip] = old_array[ip]
     return( new_array )
 
-if cuda_installed and cupy_installed:
+if cuda_installed:
     @compile_cupy
     def copy_particle_data_cuda( Ntot, old_array, new_array ):
         """

--- a/fbpic/particles/elementary_process/cuda_numba_utils.py
+++ b/fbpic/particles/elementary_process/cuda_numba_utils.py
@@ -13,8 +13,10 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
-
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d
+if cuda_installed and cupy_installed:
+    from fbpic.utils.cuda import compile_cupy
+    
 def allocate_empty( shape, use_cuda, dtype ):
     """
     Allocate and return an empty array, of size `N` and type `dtype`,
@@ -149,7 +151,7 @@ def copy_particle_data_numba( Ntot, old_array, new_array ):
         new_array[ip] = old_array[ip]
     return( new_array )
 
-if cuda_installed:
+if cuda_installed and cupy_installed:
     @compile_cupy
     def copy_particle_data_cuda( Ntot, old_array, new_array ):
         """

--- a/fbpic/particles/elementary_process/ionization/ionizer.py
+++ b/fbpic/particles/elementary_process/ionization/ionizer.py
@@ -43,7 +43,7 @@ if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
 if cupy_installed:
     import cupy    
-if cuda_installed and cupy_installed:
+if cuda_installed:
     from .cuda_methods import ionize_ions_cuda, copy_ionized_electrons_cuda
     
 class Ionizer(object):

--- a/fbpic/particles/elementary_process/ionization/ionizer.py
+++ b/fbpic/particles/elementary_process/ionization/ionizer.py
@@ -37,13 +37,11 @@ from ..cuda_numba_utils import allocate_empty, reallocate_and_copy_old, \
                                 perform_cumsum_2d, generate_new_ids
 
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cuda_installed, cupy_installed
+from fbpic.utils.cuda import cuda_installed
 from fbpic.utils.printing import catch_gpu_memory_error
 if cuda_installed:
+    import cupy
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
-if cupy_installed:
-    import cupy    
-if cuda_installed:
     from .cuda_methods import ionize_ions_cuda, copy_ionized_electrons_cuda
     
 class Ionizer(object):

--- a/fbpic/particles/elementary_process/ionization/ionizer.py
+++ b/fbpic/particles/elementary_process/ionization/ionizer.py
@@ -41,9 +41,10 @@ from fbpic.utils.cuda import cuda_installed, cupy_installed
 from fbpic.utils.printing import catch_gpu_memory_error
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
-    from .cuda_methods import ionize_ions_cuda, copy_ionized_electrons_cuda
 if cupy_installed:
     import cupy    
+if cuda_installed and cupy_installed:
+    from .cuda_methods import ionize_ions_cuda, copy_ionized_electrons_cuda
     
 class Ionizer(object):
     """

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -31,7 +31,7 @@ from fbpic.utils.threading import nthreads, get_chunk_indices
 from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
-if cuda_installed and cupy_installed:
+if cuda_installed:
     # Load the CUDA methods
     from fbpic.utils.cuda import cuda_tpb_bpg_1d, cuda_gpu_model
     from .push.cuda_methods import push_p_gpu, push_p_ioniz_gpu, \

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -28,11 +28,10 @@ from .deposition.threading_methods import \
 # Check if threading is enabled
 from fbpic.utils.threading import nthreads, get_chunk_indices
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
-    import cupy
+from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     # Load the CUDA methods
+    import cupy    
     from fbpic.utils.cuda import cuda_tpb_bpg_1d, cuda_gpu_model
     from .push.cuda_methods import push_p_gpu, push_p_ioniz_gpu, \
                                 push_p_after_plane_gpu, push_x_gpu

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -31,7 +31,7 @@ from fbpic.utils.threading import nthreads, get_chunk_indices
 from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
-if cuda_installed:
+if cuda_installed and cupy_installed:
     # Load the CUDA methods
     from fbpic.utils.cuda import cuda_tpb_bpg_1d, cuda_gpu_model
     from .push.cuda_methods import push_p_gpu, push_p_ioniz_gpu, \

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -12,8 +12,10 @@ from fbpic.utils.cuda import cupy_installed, cuda_installed
 if cupy_installed:
     import cupy
 if cuda_installed:
-    from fbpic.utils.cuda import cuda_tpb_bpg_1d, compile_cupy
-
+    from fbpic.utils.cuda import cuda_tpb_bpg_1d
+if cuda_installed and cupy_installed:
+    from fbpic.utils.cuda import compile_cupy
+    
 class ParticleTracker(object):
     """
     Class that stores particles ids and attributes new ids when necessary
@@ -132,7 +134,7 @@ class ParticleTracker(object):
         n = int( (global_id_max - comm.rank)/self.id_step ) + 1
         self.next_attibuted_id = comm.rank + n*self.id_step
 
-if cuda_installed:
+if cuda_installed and cupy_installed:
 
     @compile_cupy
     def generate_ids_gpu( id_array, i_start, i_end,

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -13,7 +13,7 @@ if cupy_installed:
     import cupy
 if cuda_installed:
     from fbpic.utils.cuda import cuda_tpb_bpg_1d
-if cuda_installed and cupy_installed:
+if cuda_installed:
     from fbpic.utils.cuda import compile_cupy
     
 class ParticleTracker(object):
@@ -134,7 +134,7 @@ class ParticleTracker(object):
         n = int( (global_id_max - comm.rank)/self.id_step ) + 1
         self.next_attibuted_id = comm.rank + n*self.id_step
 
-if cuda_installed and cupy_installed:
+if cuda_installed:
 
     @compile_cupy
     def generate_ids_gpu( id_array, i_start, i_end,

--- a/fbpic/particles/tracking/tracking.py
+++ b/fbpic/particles/tracking/tracking.py
@@ -8,13 +8,10 @@ It defines the structure and methods associated with particle tracking.
 import numpy as np
 from numba import cuda
 # Check if CUDA is available, then import CUDA functions
-from fbpic.utils.cuda import cupy_installed, cuda_installed
-if cupy_installed:
+from fbpic.utils.cuda import cuda_installed
+if cuda_installed:
     import cupy
-if cuda_installed:
-    from fbpic.utils.cuda import cuda_tpb_bpg_1d
-if cuda_installed:
-    from fbpic.utils.cuda import compile_cupy
+    from fbpic.utils.cuda import cuda_tpb_bpg_1d, compile_cupy
     
 class ParticleTracker(object):
     """

--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -6,8 +6,9 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines the particle sorting methods on the GPU using CUDA.
 """
 from numba import cuda
-from fbpic.utils.cuda import cupy_installed, compile_cupy
-if cupy_installed:
+from fbpic.utils.cuda import cuda_installed
+if cuda_installed:
+    from fbpic.utils.cuda import compile_cupy
     from cupy.cuda import thrust
 import math
 import numpy as np

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -195,7 +195,7 @@ def mpi_select_gpus(mpi):
 # CUDA kernel decorator
 # -----------------------------------------------------
 
-if cupy_installed:
+if cupy_installed and cuda_installed:
 
     def get_args_hash(args):
         """

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -30,7 +30,7 @@ except (ImportError, AssertionError):
     cupy_installed = False
     cupy_major_version = None
 
-cuda_installed = (numba_cuda_installed)
+cuda_installed = (numba_cuda_installed and cupy_installed)
     
 # -----------------------------------------------------
 # CUDA grid utilities

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -9,11 +9,11 @@ from numba import cuda
 
 # Check if CUDA is available and set variable accordingly
 try:
-    cuda_installed = cuda.is_available()
+    numba_cuda_installed = cuda.is_available()
 except Exception:
-    cuda_installed = False
+    numba_cuda_installed = False
 
-if cuda_installed:
+if numba_cuda_installed:
     # Infer if GPU is P100 or V100 or other
     if "P100" in str(cuda.gpus[0]._device.name):
         cuda_gpu_model = "P100"
@@ -30,6 +30,8 @@ except (ImportError, AssertionError):
     cupy_installed = False
     cupy_major_version = None
 
+cuda_installed = (numba_cuda_installed and cupy_installed)
+    
 # -----------------------------------------------------
 # CUDA grid utilities
 # -----------------------------------------------------

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -30,7 +30,7 @@ except (ImportError, AssertionError):
     cupy_installed = False
     cupy_major_version = None
 
-cuda_installed = (numba_cuda_installed and cupy_installed)
+cuda_installed = (numba_cuda_installed)
     
 # -----------------------------------------------------
 # CUDA grid utilities
@@ -197,7 +197,7 @@ def mpi_select_gpus(mpi):
 # CUDA kernel decorator
 # -----------------------------------------------------
 
-if cupy_installed and cuda_installed:
+if cuda_installed:
 
     def get_args_hash(args):
         """

--- a/tests/unautomated/test_cuda_transform.py
+++ b/tests/unautomated/test_cuda_transform.py
@@ -12,9 +12,9 @@ $ python tests/test_cuda_transform.py
 """
 import numpy as np
 from fbpic.fields.spectral_transform import SpectralTransformer
-from numba import cuda
-from fbpic.utils.cuda import cupy_installed
-if cupy_installed:
+from fbpic.utils.cuda import cuda_installed
+if cuda_installed:
+    from numba import cuda
     from fbpic.utils.cuda import cupy
 import time
 


### PR DESCRIPTION
When `cupy` is not installed, *but* the machine on which FBPIC is run has a GPU, the code crashes (even when setting `use_cuda=False`). 

This is because in this case `cuda_installed` is `True`, but `cupy_installed` is `False`. In this case, because of some inconsistencies in the `import` statements, `fbpic` tries to import some functions that depend on `cupy`.

In order to fix this, I created a single flag `cuda_installed`, which is `True` *only* if both `numba.cuda` and `cupy` are available.

Most of the changes in this PR are systematic (i.e. remove `cupy_installed` in various places). I would still recommend to have a look at `main.py`, since I changed the warning message there.