### PR TITLE
Impose numba 0.49

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ it from [here](https://www.continuum.io/downloads).
 
 - Install the dependencies of FBPIC. This can be done in two lines:
 ```
-conda install numba scipy h5py mkl
+conda install numba==0.49 scipy h5py mkl
 conda install -c conda-forge mpi4py
 ```
 - Download and install FBPIC:

--- a/docs/source/install/install_comet.rst
+++ b/docs/source/install/install_comet.rst
@@ -38,7 +38,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-      conda install -c conda-forge numba scipy h5py mkl cudatoolkit=9.2
+      conda install -c conda-forge numba==0.49 scipy h5py mkl cudatoolkit=9.2
 
 
 -  Install ``mpi4py`` and ``cupy``

--- a/docs/source/install/install_juwels.rst
+++ b/docs/source/install/install_juwels.rst
@@ -36,7 +36,7 @@ Then install the dependencies of FBPIC:
 
 ::
 
-    conda install numba scipy h5py mkl
+    conda install numba==0.49 scipy h5py mkl
     conda install cudatoolkit=10.0
     pip install cupy-cuda100
 

--- a/docs/source/install/install_lawrencium.rst
+++ b/docs/source/install/install_lawrencium.rst
@@ -53,7 +53,7 @@ Installation of FBPIC and its dependencies
 
    ::
 
-       conda install -c conda-forge numba scipy h5py mkl cudatoolkit=10.0 mpi4py=*=*mpich*
+       conda install -c conda-forge numba==0.49 scipy h5py mkl cudatoolkit=10.0 mpi4py=*=*mpich*
        pip install cupy-cuda100
 
 -  Install ``fbpic``

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -14,7 +14,7 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
   ::
 
-     conda install numba scipy h5py mkl
+     conda install numba==0.49 scipy h5py mkl
      conda install -c conda-forge mpi4py
 
 -  Install ``fbpic``

--- a/docs/source/install/install_summit.rst
+++ b/docs/source/install/install_summit.rst
@@ -37,7 +37,7 @@ Installation of FBPIC and its dependencies
 
     ::
 
-        conda install -c conda-forge numba scipy h5py cython cudatoolkit=9.0
+        conda install -c conda-forge numba==0.49 scipy h5py cython cudatoolkit=9.0
 
 - Install ``cupy`` (This step can take a few minutes.)
 

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -251,6 +251,11 @@ class Simulation(object):
                     'requires `numba` version 0.46 (or later).\n(The `numba` '
                     'version on your current system is 0.%d.)\nPlease install'
                     ' the latest version of `numba`.' %numba_minor_version)
+            elif numba_minor_version == 50:
+                raise RuntimeError(
+                    'Numba version 0.50 does not work on GPU with FBPIC. \n'
+                    'Please install version 0.49 instead: \n'
+                    'conda install numba==0.49')
             elif sys.version_info.major < 3:
                 raise RuntimeError(
                     'In order to run on GPUs, FBPIC version 0.16 and later \n'


### PR DESCRIPTION
Downloading the latest numba from `conda` typically results in an compilation error on GPU, which can be difficult for users to diagnose. (see #458 )

Therefore, this PR modifies the documentation to recommend the installation of `numba 0.49`, and adds an error message when `numba 0.50` is detected.