### PR TITLE
Improve performance of external fields on GPU

### DIFF
--- a/fbpic/lpa_utils/external_fields.py
+++ b/fbpic/lpa_utils/external_fields.py
@@ -7,6 +7,9 @@ inv_c = 1./c
 import numpy as np
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed
+if cuda_installed:
+    from fbpic.utils.cuda import compile_cupy, cuda_tpb_bpg_1d
+    from numba import cuda
 
 class ExternalField( object ):
 
@@ -130,8 +133,16 @@ class ExternalField( object ):
         cpu_compiler = vectorize( signature, target='cpu', nopython=True )
         self.cpu_func = cpu_compiler( func )
         if cuda_installed:
-            gpu_compiler = vectorize( signature, target='cuda' )
-            self.gpu_func = gpu_compiler( func )
+            # First create a device inline function
+            inline_func = cuda.jit( func, inline=True, device=True )
+            # Then create a CUDA kernel and compile it the usual way
+            def external_field_kernel( F, x, y, z, t, amplitude, length_scale ):
+                i = cuda.grid(1)
+    
+                if i < F.shape[0]:
+                    F[i] = inline_func( F[i], x[i], y[i], z[i], t, amplitude, length_scale )
+
+            self.gpu_func = compile_cupy( external_field_kernel )
 
         # Convert the field back to the boosted frame
         if (gamma_boost is not None) and (gamma_boost != 1.):
@@ -191,6 +202,9 @@ class ExternalField( object ):
                         self.cpu_func( field, species.x, species.y, species.z,
                               t, amplitude, self.length_scale, out=field )
                     else:
-                        # Call the GPU function
-                        self.gpu_func( field, species.x, species.y, species.z,
-                              t, amplitude, self.length_scale, out=field )
+                        # Get the threads per block and the blocks per grid
+                        dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( species.Ntot )
+                        # Call the GPU kernel
+                        self.gpu_func[dim_grid_1d, dim_block_1d](
+                            field, species.x, species.y, species.z,
+                            t, amplitude, self.length_scale )


### PR DESCRIPTION
This PR improves the performance of external fields when on GPU.

In the current code, `numba.vectorize` is used to compile the user-defined field functions for GPU. This is slow and also causes `memcopy` operations every call. In this PR, `cuda.jit` is instead used to compile an inline function, which is then embedded in a standard kernel compiled with `compile_cupy` to benefit from cupy's smaller kernel call overhead.