### PR TITLE
PICMI: read PSATD order in z from field solver

### DIFF
--- a/fbpic/picmi/simulation.py
+++ b/fbpic/picmi/simulation.py
@@ -65,7 +65,8 @@ class Simulation( PICMI_Simulation ):
         self.fbpic_sim = FBPICSimulation(
             Nz=int(grid.nz), zmin=grid.zmin, zmax=grid.zmax,
             Nr=int(grid.nr), rmax=grid.rmax, Nm=grid.n_azimuthal_modes,
-            dt=dt, use_cuda=True, smoother=smoother, n_order=32,
+            dt=dt, use_cuda=True, smoother=smoother,
+            n_order=self.solver.stencil_order[-1],
             boundaries={'z':grid.bc_zmax, 'r':grid.bc_rmax} )
 
         # Set the moving window

--- a/fbpic/picmi/simulation.py
+++ b/fbpic/picmi/simulation.py
@@ -61,12 +61,17 @@ class Simulation( PICMI_Simulation ):
                 n_passes=self.solver.source_smoother.n_pass,
                 compensator=self.solver.source_smoother.compensation )
 
+        # Order of the stencil for z derivatives in the Maxwell solver
+        if self.solver.stencil_order is None:
+            n_order = -1
+        else:
+            n_order = self.solver.stencil_order[-1]
+
         # Initialize and store the FBPIC simulation object
         self.fbpic_sim = FBPICSimulation(
             Nz=int(grid.nz), zmin=grid.zmin, zmax=grid.zmax,
             Nr=int(grid.nr), rmax=grid.rmax, Nm=grid.n_azimuthal_modes,
-            dt=dt, use_cuda=True, smoother=smoother,
-            n_order=self.solver.stencil_order[-1],
+            dt=dt, use_cuda=True, smoother=smoother, n_order=n_order,
             boundaries={'z':grid.bc_zmax, 'r':grid.bc_rmax} )
 
         # Set the moving window


### PR DESCRIPTION
With this PR the order of the finite stencil along z for the Maxwell field solver is read directly from the member `stencil_order` (vector of integers) of the class `PICMI_ElectromagneticSolver`, instead of being hard-coded as `n_order=32`.

If `stencil_order` is not initialized in the solver, the default is set to `n_order=-1`, which corresponds to infinite order and matches the default in the `Simulation` class. Not sure which default order you would like to keep for the PICMI interface.