### PR TITLE
Add install option for PICMI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ setup(
     tests_require=['more-itertools<6.0.0', 'pytest', 'openpmd_viewer'],
     cmdclass={'test': PyTest},
     install_requires=install_requires,
+    extras_require = {
+        'picmi':  ["picmistandard", "numexpr", "periodictable"],
+    },
     include_package_data=True,
     platforms='any',
     url='http://github.com/fbpic/fbpic',


### PR DESCRIPTION
This adds the `picmi` install option.

More specifically, when doing:
```
pip install fbpic[picmi]
```
this will automatically download the extra dependencies required to run fbpic with a PICMI script.