### PR TITLE
Revert antenna to previous behavior

### DIFF
--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -160,7 +160,6 @@ class LaserAntenna( object ):
         # Register whether the antenna deposits on the local domain
         # (gets updated by `update_current_rank`)
         self.deposit_on_this_rank = False
-        self.active_update_v = False
 
         # Initialize small-size buffers where the particles charge and currents
         # will be deposited before being added to the regular, large-size array
@@ -204,13 +203,6 @@ class LaserAntenna( object ):
         else:
             self.deposit_on_this_rank = False
 
-        zmin_global, zmax_global = comm.get_zmin_zmax(
-            local=False, with_damp=True, with_guard=True )
-        if (z_antenna >= zmin_global) and (z_antenna < zmax_global):
-            self.active_update_v = True
-        else:
-            self.active_update_v = False
-
     def push_x( self, dt, x_push=1., y_push=1., z_push=1. ):
         """
         Push the position of the virtual particles in the antenna
@@ -246,11 +238,6 @@ class LaserAntenna( object ):
         t: float (seconds)
             The time at which to calculate the velocities
         """
-        # Interrupt this function if the antenna is not currently
-        # active on the global domain (as determined by `update_current_rank`)
-        if not self.active_update_v:
-            return
-
         # When running in a boosted frame, convert the position and time at
         # which to find the laser amplitude.
         if self.boost is not None:


### PR DESCRIPTION
This PR reverts the change from #461, because we recently observed that it unexpectedly changed the results of some recent boosted-frame simulations. 

@hightower8083 Sorry for the delay in incorporating this feature. I'll investigate the changes and will merge into `dev` again once this is cleared up.