### PR TITLE
Fix handling of error in particle output

### DIFF
--- a/fbpic/openpmd_diag/boosted_particle_diag.py
+++ b/fbpic/openpmd_diag/boosted_particle_diag.py
@@ -383,8 +383,9 @@ class BackTransformedParticleDiagnostic(ParticleDiagnostic):
                             species_grp[particle_var], particle_var )
 
                     else :
-                        raise ValueError("Invalid string in %s of species"
-                                             %(particle_var))
+                        raise ValueError(
+                            "Invalid quantity for particle output: %s"
+                            %(quantity) )
 
                 # Setup the hdf5 groups for "position" and "momentum"
                 if self.rank == 0:


### PR DESCRIPTION
When the user passes an invalid quantity to the `BackTransformedParticleDiagnostic` (e.g. request to output `uw` instead of `uz`), instead of printing a helpful error message, `fbpic` was hitting an undefined variable (`particle_var`) and was printing a confusing message.

This fixes the issue.