### PR TITLE
patch for the numba issue with nested while loop in `py>=3.8`

### DIFF
--- a/fbpic/fields/numba_methods.py
+++ b/fbpic/fields/numba_methods.py
@@ -119,7 +119,7 @@ def numba_correct_currents_crossdeposition_standard( rho_prev, rho_next,
 
             # Increment ir
             ir += 1
-
+        ir += 0
     return
 
 @njit_parallel
@@ -285,6 +285,7 @@ def numba_correct_currents_crossdeposition_comoving(
 
             # Increment ir
             ir += 1
+        ir += 0
 
     return
 

--- a/fbpic/particles/elementary_process/ionization/numba_methods.py
+++ b/fbpic/particles/elementary_process/ionization/numba_methods.py
@@ -84,6 +84,7 @@ def ionize_ions_numba( N_batch, batch_size, Ntot,
 
             # Increment ip
             ip = ip + 1
+        ip += 0
 
     return( n_ionized, ionized_from, ionization_level, w_times_level )
 


### PR DESCRIPTION
This PR addresses the error
```
raise ValueError("Cannot add edge as dest node %s not in nodes %s" %
ValueError: Failed in nopython mode pipeline (step: convert to parfors)
Cannot add edge as dest node 10 not in nodes {288, 68, 102, 326, 264, 42, 76, 334, 14, 92, 242, 24, 26, 347, 220}
```
which results from some issue with the nested `while` loop and appears from numba methods with `py>=3.8`. More details are discussed in #488 