### PR TITLE
Convert while loops to for loops

### DIFF
--- a/fbpic/fields/numba_methods.py
+++ b/fbpic/fields/numba_methods.py
@@ -93,11 +93,7 @@ def numba_correct_currents_crossdeposition_standard( rho_prev, rho_next,
     """
     # Loop over the 2D grid
     for iz in prange(Nz):
-        # Loop through the radial points
-        # (Note: a while loop is used here, because numba 0.34 does
-        # not support nested prange and range loops)
-        ir = 0
-        while ir < Nr:
+        for ir in range(Nr):
 
             # Calculate the intermediate variable Dz and Dxy
             # (Such that Dz + Dxy is the error in the continuity equation)
@@ -116,9 +112,6 @@ def numba_correct_currents_crossdeposition_standard( rho_prev, rho_next,
             if kz[iz, ir] != 0:
                 inv_kz = 1./kz[iz, ir]
                 Jz[iz, ir] += 1.j * Dz * inv_kz
-
-            # Increment ir
-            ir += 1
 
     return
 
@@ -256,11 +249,7 @@ def numba_correct_currents_crossdeposition_comoving(
     """
     # Loop over the 2D grid
     for iz in prange(Nz):
-        # Loop through the radial points
-        # (Note: a while loop is used here, because numba 0.34 does
-        # not support nested prange and range loops)
-        ir = 0
-        while ir < Nr:
+        for ir in range(Nr):
 
             # Calculate the intermediate variable Dz and Dxy
             # (Such that Dz + Dxy is the error in the continuity equation)
@@ -282,9 +271,6 @@ def numba_correct_currents_crossdeposition_comoving(
             if kz[iz, ir] != 0:
                 inv_kz = 1./kz[iz, ir]
                 Jz[iz, ir] += 1.j * Dz * inv_kz
-
-            # Increment ir
-            ir += 1
 
     return
 

--- a/fbpic/particles/elementary_process/ionization/numba_methods.py
+++ b/fbpic/particles/elementary_process/ionization/numba_methods.py
@@ -47,11 +47,8 @@ def ionize_ions_numba( N_batch, batch_size, Ntot,
             n_ionized[i_level, i_batch] = 0
 
         # Loop through the batch
-        # (Note: a while loop is used here, because numba 0.34 does
-        # not support nested prange and range loops)
         N_max = min( (i_batch+1)*batch_size, Ntot )
-        ip = i_batch*batch_size
-        while ip < N_max:
+        for ip in range(i_batch*batch_size, N_max):
 
             # Skip the ionization routine, if the maximal ionization level
             # has already been reached for this macroparticle
@@ -81,9 +78,6 @@ def ionize_ions_numba( N_batch, batch_size, Ntot,
                     w_times_level[ip] = w[ip] * ionization_level[ip]
                 else:
                     ionized_from[ip] = -1
-
-            # Increment ip
-            ip = ip + 1
 
     return( n_ionized, ionized_from, ionization_level, w_times_level )
 


### PR DESCRIPTION
The while loops in some function were introduced a long time ago, due to a quirk in an old version of numba.
But I think that this quirk has been fixed since a long time. As a result, I tried to convert those while loops to for loops.