### PR TITLE
When using `verbose=2`, print node name whenever possible

### DIFF
--- a/fbpic/utils/printing.py
+++ b/fbpic/utils/printing.py
@@ -264,6 +264,9 @@ def get_gpu_message():
             rank, gpu_name, gpu.id, node)
     else:
         message = "\nFBPIC selected a %s GPU with id %s" %( gpu_name, gpu.id )
+        if mpi_installed:
+            node = MPI.Get_processor_name()            
+            message += " on node %s" %node
     return(message)
 
 def get_cpu_message():


### PR DESCRIPTION
When using `verbose=2`, the node name was not printed *for single-MPI simulations*.
Yet this information can be useful even for single-MPI simulation. This PR corrects this.