### PR TITLE
Update anaconda/miniconda links

### DIFF
--- a/docs/source/install/install_comet.rst
+++ b/docs/source/install/install_comet.rst
@@ -19,7 +19,7 @@ below:
 
    ::
 
-       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+       wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 
 -  Execute the Miniconda installation script
 

--- a/docs/source/install/install_juwels.rst
+++ b/docs/source/install/install_juwels.rst
@@ -25,7 +25,7 @@ To load the standard modules the ``.bashrc`` should contain the following:
 Installation of Anaconda
 ------------------------------------------------
 
-In order to download and install `Anaconda <https://www.continuum.io/downloads>`__, type:
+In order to download and install `Anaconda <https://docs.anaconda.com/anaconda/>`__, type:
 
 ::
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -5,8 +5,8 @@ Installing FBPIC
 ------------------
 
 The installation requires the
-`Anaconda <https://www.continuum.io/why-anaconda>`__ distribution of
-Python. If Anaconda is not your default Python distribution, download and install it from `here <https://www.continuum.io/downloads>`__.
+`Anaconda <https://docs.anaconda.com/anaconda/>`__ distribution of
+Python. If Anaconda is not your default Python distribution, download and install it from `here <https://docs.anaconda.com/anaconda/install/>`__.
 
 **Installation steps**:
 


### PR DESCRIPTION
Some links to Anaconda pages in the documentation are broken. This PR proposes to fix them.