### PR TITLE
Deactivate Python 2.7 in automated tests

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [3.6]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Python 2.7 is no longer officially maintained, and it seems that some FBPIC dependencies are now failing - when installed from Python 2.7 channels.

This PR deactivates Python 2 in the automated tests. From now on, only Python 3 will be tested.