### PR TITLE
Catch cupy memory error

### DIFF
--- a/fbpic/particles/utilities/cuda_sorting.py
+++ b/fbpic/particles/utilities/cuda_sorting.py
@@ -10,6 +10,7 @@ from fbpic.utils.cuda import cuda_installed
 if cuda_installed:
     from fbpic.utils.cuda import compile_cupy
     from cupy.cuda import thrust
+    from fbpic.utils.printing import catch_gpu_memory_error
 import math
 import numpy as np
 
@@ -86,6 +87,7 @@ def get_cell_idx_per_particle(cell_idx, sorted_idx,
             # Calculate the 1D cell_idx
             cell_idx[i] = ir_upper + iz_upper * (Nr+1)
 
+@catch_gpu_memory_error
 def sort_particles_per_cell(cell_idx, sorted_idx):
     """
     Sort the cell index of the particles and

--- a/fbpic/utils/printing.py
+++ b/fbpic/utils/printing.py
@@ -7,8 +7,10 @@ It defines a set of generic functions for printing simulation information.
 """
 import sys, time
 from fbpic import __version__
-from fbpic.utils.cuda import cuda, cuda_installed
 from fbpic.utils.mpi import MPI, mpi_installed, gpudirect_enabled
+from fbpic.utils.cuda import cuda, cuda_installed
+if cuda_installed:
+    from cupy.cuda.memory import OutOfMemoryError
 # Check if terminal is correctly set to UTF-8 and set progress character
 if sys.stdout.encoding == 'UTF-8':
     progress_char = u'\u2588'
@@ -316,7 +318,7 @@ def catch_gpu_memory_error( f ):
     def g(*args, **kwargs):
         try:
             return f(*args, **kwargs)
-        except cuda.cudadrv.driver.CudaAPIError as e:
+        except OutOfMemoryError as e:
             handle_cuda_memory_error( e, f.__name__ )
     # Decorator: return the new function
     return(g)


### PR DESCRIPTION
It seems that the code that catches memory error was not updated when we switched from the `numba.cuda` allocation to the `cupy` allocation.

I also added the decorator `catch_gpu_memory_error` around the sorting routine (`cupy` needs to allocate temporary arrays under the hood, when performing the Radix Sort).