### PR TITLE
Detect UUID and check for GPU oversubscription

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -241,10 +241,10 @@ class Simulation(object):
             self.use_cuda = False
         # Check that cupy, numba and Python have the right version
         if self.use_cuda:
-            if cupy_version < (8,1):
+            if cupy_version < (7,0):
                 raise RuntimeError(
                     'In order to run on GPUs, FBPIC version 0.20 and later \n'
-                    'requires `cupy` version 8.1 (or later).\n(The `cupy` '
+                    'requires `cupy` version 7.0 (or later).\n(The `cupy` '
                     'version on your current system is %d.%d.)\nPlease '
                     'install the latest version of `cupy`.' %cupy_version)
             elif numba_version < (0,46):

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -11,10 +11,10 @@ This file steers and controls the simulation.
 # as it sets the cuda context)
 from fbpic.utils.mpi import MPI
 # Check if threading is available
-from .utils.threading import threading_enabled, numba_minor_version
+from .utils.threading import threading_enabled, numba_version
 # Check if CUDA is available, then import CUDA functions
 from .utils.cuda import cuda_installed, \
-    cupy_installed, cupy_major_version, numba_cuda_installed
+    cupy_installed, cupy_version, numba_cuda_installed
 if cuda_installed:
     from .utils.cuda import send_data_to_gpu, \
                 receive_data_from_gpu, mpi_select_gpus
@@ -241,18 +241,18 @@ class Simulation(object):
             self.use_cuda = False
         # Check that cupy, numba and Python have the right version
         if self.use_cuda:
-            if cupy_major_version < 7:
+            if cupy_version < (8,1):
                 raise RuntimeError(
-                    'In order to run on GPUs, FBPIC version 0.16 and later \n'
-                    'requires `cupy` version 7 (or later).\n(The `cupy` version'
-                    ' on your current system is %d.)\nPlease install the '
-                    'latest version of `cupy`.' %cupy_major_version)
-            elif numba_minor_version < 46:
+                    'In order to run on GPUs, FBPIC version 0.20 and later \n'
+                    'requires `cupy` version 8.1 (or later).\n(The `cupy` '
+                    'version on your current system is %d.%d.)\nPlease '
+                    'install the latest version of `cupy`.' %cupy_version)
+            elif numba_version < (0,46):
                 raise RuntimeError(
                     'In order to run on GPUs, FBPIC version 0.16 and later \n'
                     'requires `numba` version 0.46 (or later).\n(The `numba` '
-                    'version on your current system is 0.%d.)\nPlease install'
-                    ' the latest version of `numba`.' %numba_minor_version)
+                    'version on your current system is %d.%d.)\nPlease install'
+                    ' the latest version of `numba`.' %numba_version)
             elif sys.version_info.major < 3:
                 raise RuntimeError(
                     'In order to run on GPUs, FBPIC version 0.16 and later \n'

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -280,11 +280,11 @@ def mpi_select_gpus(mpi):
     # Check that no GPU was selected more than once
     if rank == 0:
         if len(uuids) > len(set(uuids)):
-            warnings.warn("""
-            GPUs have been oversubscribed by MPI ranks. This means that the
-            same GPU was selected by more than one parallel process, which
-            will result in poor performance. (See the FBPIC output with
-            `verbose_level = 2` for more details.)""")
+            warnings.warn(
+            "GPUs have been oversubscribed by MPI ranks.\n"
+            "This means that the same GPU was selected by more than one "
+            "parallel process,\nwhich will result in poor performance.\n"
+            "(See the FBPIC output with `verbose_level = 2` for more details.)")
 
 
 # -----------------------------------------------------

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -185,7 +185,7 @@ class GpuMemoryManager(object):
 
 def get_uuid(gpu_id):
     """
-    Returns the UUID of a GPU device.
+    Returns the UUID of a GPU device (or None if it cannot determine it)
 
     Parameters:
     -----------
@@ -194,8 +194,11 @@ def get_uuid(gpu_id):
     Returns:
     --------
     uuid: Unique identifier (UUID) of the GPU (str)
-
     """
+    # For cupy version below 8.1, we cannot determine the uuid
+    if cupy_version < (8,1):
+        return None
+
     # Get UUID using cupy
     uuid = cupy.cuda.runtime.getDeviceProperties(gpu_id)['uuid']
     # conversion strategy from numba PR #6700
@@ -279,7 +282,7 @@ def mpi_select_gpus(mpi):
 
     # Check that no GPU was selected more than once
     if rank == 0:
-        if len(uuids) > len(set(uuids)):
+        if not (None in uuids) and (len(uuids) > len(set(uuids))):
             warnings.warn(
             "GPUs have been oversubscribed by MPI ranks.\n"
             "This means that the same GPU was selected by more than one "

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -5,6 +5,7 @@
 This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
 It defines a set of generic functions that operate on a GPU.
 """
+import warnings
 import numba
 numba_minor_version = int(numba.__version__.split('.')[1])
 from numba import cuda

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -7,7 +7,8 @@ It defines a set of generic functions that operate on a GPU.
 """
 import warnings
 import numba
-numba_minor_version = int(numba.__version__.split('.')[1])
+numba_version = (int(numba.__version__.split('.')[0]),
+                 int(numba.__version__.split('.')[1]))
 from numba import cuda
 import numpy as np
 
@@ -29,10 +30,11 @@ if numba_cuda_installed:
 try:
     import cupy
     cupy_installed = cupy.is_available()
-    cupy_major_version = int(cupy.__version__[0])
+    cupy_version = (int(cupy.__version__.split('.')[0]),
+                    int(cupy.__version__.split('.')[1]))
 except (ImportError, AssertionError):
     cupy_installed = False
-    cupy_major_version = None
+    cupy_version = None
 
 cuda_installed = (numba_cuda_installed and cupy_installed)
 
@@ -326,7 +328,7 @@ if cuda_installed:
             module.load(bytes(numba_kernel.ptx, 'UTF-8'))
 
             # Save the resulting Cupy kernel
-            if numba_minor_version > 50:
+            if numba_version[1] > 50:
                 kernel_name = numba_kernel.definition.entry_name
             else:
                 kernel_name = numba_kernel.entry_name
@@ -404,7 +406,7 @@ if cuda_installed:
 
                         # Cache the resulting Cupy kernel in a dictionary using
                         # the hash
-                        if numba_minor_version > 50:
+                        if numba_version[1] > 50:
                             kernel_name = numba_kernel.definition.entry_name
                         else:
                             kernel_name = numba_kernel.entry_name

--- a/fbpic/utils/mpi.py
+++ b/fbpic/utils/mpi.py
@@ -59,6 +59,9 @@ except ImportError:
         def barrier(self):
             pass
 
+        def gather(self, x):
+            return [x]
+
     class DummyMPI(object):
         """Dummy replacement for mpi4py.MPI when mpi4py is not installed."""
 

--- a/fbpic/utils/printing.py
+++ b/fbpic/utils/printing.py
@@ -272,7 +272,7 @@ def get_gpu_message():
     # Print the GPU UUID, if available
     uuid = get_uuid(gpu.id)
     if uuid is not None:
-        message += "\n(GPU UUID: %s)"
+        message += "\n(GPU UUID: %s)" % uuid
     return(message)
 
 def get_cpu_message():

--- a/fbpic/utils/printing.py
+++ b/fbpic/utils/printing.py
@@ -8,7 +8,7 @@ It defines a set of generic functions for printing simulation information.
 import sys, time
 from fbpic import __version__
 from fbpic.utils.mpi import MPI, mpi_installed, gpudirect_enabled
-from fbpic.utils.cuda import cuda, cuda_installed
+from fbpic.utils.cuda import cuda, cuda_installed, get_uuid
 if cuda_installed:
     from cupy.cuda.memory import OutOfMemoryError
 # Check if terminal is correctly set to UTF-8 and set progress character
@@ -262,12 +262,13 @@ def get_gpu_message():
     if MPI.COMM_WORLD.size > 1:
         rank = MPI.COMM_WORLD.rank
         node = MPI.Get_processor_name()
-        message = "\nMPI rank %d selected a %s GPU with id %s on node %s" %(
-            rank, gpu_name, gpu.id, node)
+        message = "\nMPI rank %d selected a %s GPU with id %s (UUID: %s) \
+            on node %s" %(rank, gpu_name, gpu.id, get_uuid(gpu.id), node)
     else:
-        message = "\nFBPIC selected a %s GPU with id %s" %( gpu_name, gpu.id )
+        message = "\nFBPIC selected a %s GPU with id %s (UUID: %s)" %(
+            gpu_name, gpu.id, get_uuid(gpu.id) )
         if mpi_installed:
-            node = MPI.Get_processor_name()            
+            node = MPI.Get_processor_name()
             message += " on node %s" %node
     return(message)
 

--- a/fbpic/utils/printing.py
+++ b/fbpic/utils/printing.py
@@ -262,14 +262,17 @@ def get_gpu_message():
     if MPI.COMM_WORLD.size > 1:
         rank = MPI.COMM_WORLD.rank
         node = MPI.Get_processor_name()
-        message = "\nMPI rank %d selected a %s GPU with id %s (UUID: %s) \
-            on node %s" %(rank, gpu_name, gpu.id, get_uuid(gpu.id), node)
+        message = "\nMPI rank %d selected a %s GPU with id %s on node %s" %(
+            rank, gpu_name, gpu.id, node)
     else:
-        message = "\nFBPIC selected a %s GPU with id %s (UUID: %s)" %(
-            gpu_name, gpu.id, get_uuid(gpu.id) )
+        message = "\nFBPIC selected a %s GPU with id %s" %( gpu_name, gpu.id )
         if mpi_installed:
             node = MPI.Get_processor_name()
             message += " on node %s" %node
+    # Print the GPU UUID, if available
+    uuid = get_uuid(gpu.id)
+    if uuid is not None:
+        message += "\n(GPU UUID: %s)"
     return(message)
 
 def get_cpu_message():

--- a/fbpic/utils/threading.py
+++ b/fbpic/utils/threading.py
@@ -10,7 +10,7 @@ import warnings
 import numpy as np
 from numba import njit
 import numba
-numba_minor_version = int(numba.__version__.split('.')[1])
+numba_version = int(numba.__version__.split('.')[1])
 
 # By default threading is enabled, except on Windows (not supported by Numba)
 threading_enabled = True

--- a/fbpic/utils/threading.py
+++ b/fbpic/utils/threading.py
@@ -10,7 +10,8 @@ import warnings
 import numpy as np
 from numba import njit
 import numba
-numba_version = int(numba.__version__.split('.')[1])
+numba_version = (int(numba.__version__.split('.')[0]),
+                 int(numba.__version__.split('.')[1]))
 
 # By default threading is enabled, except on Windows (not supported by Numba)
 threading_enabled = True

--- a/fbpic/utils/threading.py
+++ b/fbpic/utils/threading.py
@@ -30,7 +30,7 @@ if threading_enabled:
         from numba import prange as numba_prange
         # Check that numba is version 0.34 or higher than 0.36
         # (other versions fail)
-        assert ( numba_minor_version==34 or numba_minor_version >= 36 )
+        assert ( numba_version[1]==34 or numba_version[1] >= 36 )
     except (ImportError, AssertionError):
         threading_enabled = False
         warnings.warn(
@@ -55,7 +55,7 @@ if not threading_enabled:
     nthreads = 1
 else:
     # Use the parallel compilation function (Use caching if available)
-    if numba_minor_version < 45:
+    if numba_version[1] < 45:
         caching = False
     njit_parallel = njit( parallel=True, cache=caching )
     prange = numba_prange


### PR DESCRIPTION
This PR prints a unique GPU ID when setting `verbose_level = 2` in the `Simulation` object.
It also checks for oversubscription of GPUs, i.e., if the same GPU was selected by more than one rank, in which case a warning is printed.

The PR also required minor improvements to the version checking of the `cupy` and `numba` package.