### PR TITLE
Fix cupy 9 compatibility

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -33,7 +33,7 @@ jobs:
       name: Install dependencies
       run: |
         conda install --yes "numba<0.49" scipy h5py mkl pytest pyflakes python=${{ matrix.python-version }};
-        conda install --yes -c conda-forge mpi4py;
+        conda install --yes -c conda-forge mpich mpi4py;
         pip install openPMD-viewer;
         python setup.py install
     - shell: bash -l {0}

--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -144,8 +144,10 @@ class DHT(object):
             self.alpha = 1
             self.beta = 0
             if cupy_version >= (9,0):
-                self.alpha = cupy.array(alpha, dtype=d_in.dtype).data.ptr
-                self.beta = cupy.array(beta, dtype=d_in.dtype).data.ptr
+                self.alpha_ary = cupy.array(self.alpha, dtype=self.d_in.dtype)
+                self.alpha = self.alpha_ary.data.ptr
+                self.beta_ary = cupy.array(self.beta, dtype=self.d_in.dtype)
+                self.beta = self.beta_ary.data.ptr
             # Initialize cuBLAS
             self.blas = device.get_cublas_handle()
             # Set optimal number of CUDA threads per block

--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -144,10 +144,10 @@ class DHT(object):
             self.alpha = 1
             self.beta = 0
             if cupy_version >= (9,0):
-                self.alpha_ary = cupy.array(self.alpha, dtype=self.d_in.dtype)
-                self.alpha = self.alpha_ary.data.ptr
-                self.beta_ary = cupy.array(self.beta, dtype=self.d_in.dtype)
-                self.beta = self.beta_ary.data.ptr
+                self.alpha_ary = np.array(self.alpha, dtype=self.d_in.dtype)
+                self.alpha = self.alpha_ary.ctypes.data
+                self.beta_ary = np.array(self.beta, dtype=self.d_in.dtype)
+                self.beta = self.beta_ary.ctypes.data
             # Initialize cuBLAS
             self.blas = device.get_cublas_handle()
             # Set optimal number of CUDA threads per block


### PR DESCRIPTION
Cupy 9 requires a helper GPU array (instead of a scalar) that is passed as an argument to the cuBLAS dgemm call during the Hankel transform.

- [x] Test with cupy 8 and 9