### PR TITLE
Pass plasma extent to Particles and ContinuousInjector

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -911,6 +911,9 @@ class Simulation(object):
                 # Finally transform the longitudinal momentum
                 uz_m = self.boost.gamma0*( uz_m - self.boost.beta0*gamma_m )
 
+            # Store p_zmin and p_zmax to pass to Particles
+            p_extent = (p_zmin, p_zmax)
+
             # Modify input particle bounds, in order to only initialize the
             # particles in the local sub-domain
             zmin_local_domain, zmax_local_domain = self.comm.get_zmin_zmax(
@@ -957,7 +960,7 @@ class Simulation(object):
                         ux_m=ux_m, uy_m=uy_m, uz_m=uz_m,
                         ux_th=ux_th, uy_th=uy_th, uz_th=uz_th,
                         continuous_injection=continuous_injection,
-                        dz_particles=dz_particles )
+                        dz_particles=dz_particles, p_extent=p_extent )
 
         # Add it to the list of species and return it to the user
         self.ptcl.append( new_species )

--- a/fbpic/particles/injection/continuous_injection.py
+++ b/fbpic/particles/injection/continuous_injection.py
@@ -17,7 +17,7 @@ class ContinuousInjector( object ):
     """
 
     def __init__(self, Npz, zmin, zmax, dz_particles, Npr, rmin, rmax,
-                Nptheta, n, dens_func, ux_m, uy_m, uz_m, ux_th, uy_th, uz_th ):
+                Nptheta, n, dens_func, ux_m, uy_m, uz_m, ux_th, uy_th, uz_th, p_extent=None ):
         """
         Initialize continuous injection
 
@@ -29,6 +29,7 @@ class ContinuousInjector( object ):
         self.Npr = Npr
         self.rmin = rmin
         self.rmax = rmax
+        self.p_extent = p_extent
         self.Nptheta = Nptheta
         self.n = n
         self.dens_func = dens_func
@@ -181,9 +182,9 @@ class ContinuousInjector( object ):
 
         # Create new particle cells
         # Determine the positions between which new particles will be created
-        Npz = self.nz_inject
         zmax = self.z_end_plasma
         zmin = self.z_end_plasma - self.nz_inject*self.dz_particles
+        Npz = 0 if (self.p_extent and (zmax < self.p_extent[0] or zmin > self.p_extent[1])) else self.nz_inject
         # Create the particles
         Ntot, x, y, z, ux, uy, uz, inv_gamma, w = generate_evenly_spaced(
                 Npz, zmin, zmax, self.Npr, self.rmin, self.rmax,

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -67,7 +67,7 @@ class Particles(object) :
                     ux_th=0., uy_th=0., uz_th=0.,
                     dens_func=None, continuous_injection=True,
                     grid_shape=None, particle_shape='linear',
-                    use_cuda=False, dz_particles=None ):
+                    use_cuda=False, dz_particles=None, p_extent=None ):
         """
         Initialize a uniform set of particles
 
@@ -185,7 +185,7 @@ class Particles(object) :
                                                 Npr, rmin, rmax,
                                                 Nptheta, n, dens_func,
                                                 ux_m, uy_m, uz_m,
-                                                ux_th, uy_th, uz_th )
+                                                ux_th, uy_th, uz_th, p_extent=p_extent )
         else:
             self.injector = None
 


### PR DESCRIPTION
This PR passes the user-defined plasma extent (`p_zmin` and `p_zmax`) on to the `Particles` and `ContinuousInjector` classes. The values passed currently have been modified to within the initial domain. This change allows the continuous injector to check whether the loading region is within the plasma extent **before** creating particles that are eventually ignored due to having zero weight. This can save a lot of time for short plasma species with many particles per cell.