### PR TITLE
ParticleChargeDensityDiagnostic without account for ion Z 

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -585,7 +585,8 @@ class Simulation(object):
 
 
     def deposit( self, fieldtype, exchange=False,
-                update_spectral=True, species_list=None ):
+                update_spectral=True, species_list=None,
+                account_ion_charge=True ):
         """
         Deposit the charge or the currents to the interpolation grid
         and then to the spectral grid.
@@ -610,6 +611,10 @@ class Simulation(object):
         species_list: list of `Particles` objects, or None
             The species which that should deposit their charge/current.
             If this is None, all species (and antennas) deposit.
+
+        account_ion_charge : bool
+            Choose if to take into account the actual charge state of ions
+            or to consider ions having Z=1.
         """
         # Shortcut
         fld = self.fld
@@ -628,7 +633,7 @@ class Simulation(object):
             fld.erase('rho')
             # Deposit the particle charge
             for species in species_list:
-                species.deposit( fld, 'rho' )
+                species.deposit( fld, 'rho', account_ion_charge=account_ion_charge )
             # Deposit the charge of the virtual particles in the antenna
             for antenna in antennas_list:
                 antenna.deposit( fld, 'rho' )
@@ -645,7 +650,7 @@ class Simulation(object):
             fld.erase('J')
             # Deposit the particle current
             for species in species_list:
-                species.deposit( fld, 'J' )
+                species.deposit( fld, 'J', account_ion_charge=account_ion_charge )
             # Deposit the current of the virtual particles in the antenna
             for antenna in antennas_list:
                 antenna.deposit( fld, 'J' )

--- a/fbpic/openpmd_diag/particle_density_diag.py
+++ b/fbpic/openpmd_diag/particle_density_diag.py
@@ -15,7 +15,7 @@ class ParticleChargeDensityDiagnostic(FieldDiagnostic):
 
     def __init__(self, period=None, sim=None, species={},
                 write_dir=None, iteration_min=0, iteration_max=np.inf,
-                dt_period=None ):
+                dt_period=None, account_ion_charge=True ):
         """
         Writes the charge density of the specified species in the
         openPMD file (one dataset per species)
@@ -47,6 +47,10 @@ class ParticleChargeDensityDiagnostic(FieldDiagnostic):
         iteration_min, iteration_max: ints
             The iterations between which data should be written
             (`iteration_min` is inclusive, `iteration_max` is exclusive)
+
+        account_ion_charge : bool
+            Choose if to take into account the actual charge state of ions
+            or to consider ions having Z=1.
         """
         # Check the arguments
         if sim is None:
@@ -68,6 +72,7 @@ class ParticleChargeDensityDiagnostic(FieldDiagnostic):
         # Register the arguments
         self.sim = sim
         self.species = species
+        self.account_ion_charge = account_ion_charge
 
     def write_hdf5( self, iteration ) :
         """
@@ -106,7 +111,8 @@ class ParticleChargeDensityDiagnostic(FieldDiagnostic):
             # Deposit and overwrite rho_next in spectral space as it will be
             # correctly updated anyways later in this iteration by the PIC loop
             sim.deposit( 'rho_next', species_list=[species_object],
-                        update_spectral=True, exchange=False )
+                        update_spectral=True, exchange=False,
+                        account_ion_charge=self.account_ion_charge )
             # Bring filtered particle density back to the intermediate grid
             self.fld.spect2interp('rho_next')
             # Exchange (add) the particle density between domains

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -830,7 +830,7 @@ class Particles(object) :
                                   'linear' or 'cubic' \
                                    but is `%s`" % self.particle_shape)
 
-    def deposit( self, fld, fieldtype ) :
+    def deposit( self, fld, fieldtype, account_ion_charge=True ) :
         """
         Deposit the particles charge or current onto the grid
 
@@ -846,6 +846,10 @@ class Particles(object) :
         fieldtype : string
              Indicates which field to deposit
              Either 'J' or 'rho'
+
+        account_ion_charge : bool
+            Choose if to take into account the actual charge state of ions
+            or to consider ions having Z=1.
         """
         # Skip deposition for neutral particles (e.g. photons)
         if self.q == 0:
@@ -867,7 +871,7 @@ class Particles(object) :
         # For ionizable atoms: set the effective weight to the weight
         # times the ionization level (on GPU, this needs to be done *after*
         # sorting, otherwise `weight` is not equal to the corresponding array)
-        if self.ionizer is not None:
+        if self.ionizer is not None and account_ion_charge:
             weight = self.ionizer.w_times_level
         else:
             weight = self.w


### PR DESCRIPTION
In a few cases, I've actually had a need to look at the evolution of ion plasma density without account for the ions ionization state, so I've added an option (channel formation). Not sure its of a great general use, but as it does not pollute the code too much, could be worth having it.