### PR TITLE
Paraxial Approximation Laser

### DIFF
--- a/fbpic/lpa_utils/laser/__init__.py
+++ b/fbpic/lpa_utils/laser/__init__.py
@@ -5,9 +5,17 @@ It imports functions which are useful when initializing a laser pulse
 from .laser import add_laser, add_laser_pulse
 from .laser_profiles import GaussianLaser, LaguerreGaussLaser, \
               DonutLikeLaguerreGaussLaser, FlattenedGaussianLaser, \
-              FewCycleLaser
+              FewCycleLaser, ParaxialApproximationLaser
+from .longitudinal_laser_profiles import GaussianChirpedLongitudinalProfile
+from .transverse_laser_profiles import GaussianTransverseProfile, \
+    LaguerreGaussTransverseProfile, DonutLikeLaguerreGaussTransverseProfile, \
+    FlattenedGaussianTransverseProfile
 
 __all__ = ['add_laser', 'add_laser_pulse',
             'GaussianLaser', 'LaguerreGaussLaser',
             'DonutLikeLaguerreGaussLaser', 'FlattenedGaussianLaser',
-            'FewCycleLaser']
+            'FewCycleLaser', 'ParaxialApproximationLaser',
+            'GaussianChirpedLongitudinalProfile', 'GaussianTransverseProfile',
+            'LaguerreGaussTransverseProfile',
+            'DonutLikeLaguerreGaussTransverseProfile',
+            'FlattenedGaussianTransverseProfile']

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -152,7 +152,7 @@ class ParaxialApproximationLaser( LaserProfile ):
         # (Note that for a transform-limited Gaussian laser pulse, E0
         # corresponds to the peak electric field at the focus. For any other
         # profile, however, the actual peak electric field can be different.)
-        self.E0 = np.sqrt( 2*E_laser / (epsilon_0 * long_int * trans_int ) )
+        E0 = np.sqrt( 2*E_laser / (epsilon_0 * long_int * trans_int ) )
         self.E0x = E0 * np.cos(theta_pol)
         self.E0y = E0 * np.sin(theta_pol)
 

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -146,8 +146,8 @@ class ParaxialApproximationLaser( LaserProfile ):
 
         # Calculate and store a number of parameters for the laser
         self.k0 = k0
-        long_int = self.longitudinal_profile.squared_profile_integral
-        trans_int = self.transverse_profile.squared_profile_integral
+        long_int = self.longitudinal_profile.squared_profile_integral()
+        trans_int = self.transverse_profile.squared_profile_integral()
         # Define a normalized peak electric field E0
         # (Note that for a transform-limited Gaussian laser pulse, E0
         # corresponds to the peak electric field at the focus. For any other

--- a/fbpic/lpa_utils/laser/longitudinal_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/longitudinal_laser_profiles.py
@@ -182,4 +182,4 @@ class GaussianChirpedLongitudinalProfile(LaserLongitudinalProfile):
         """
         See the docstring of LaserLongitudinalProfile.squared_profile_integral
         """
-        return (0.5 * np.pi * self.inv_ctau2)**.5
+        return (0.5 * np.pi * 1./self.inv_ctau2)**.5

--- a/tests/test_parax_approx_laser.py
+++ b/tests/test_parax_approx_laser.py
@@ -1,0 +1,128 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This test file is part of FB-PIC (Fourier-Bessel Particle-In-Cell).
+
+It tests the Paraxial Approximation laser profile, using combinations of
+different transverse and longitudinal laser profiles.
+In each case, the laser is initialized before the focal plane propagated to
+the focus. This test then automatically checks that the pulse energy is
+correct. For a Gaussian laser, the peak normalized vector potential in focus
+is also checked.
+
+Usage :
+-------
+In order to let Python check the agreement:
+$ python tests/test_parax_approx_laser.py
+or
+$ py.test -q tests/test_parax_approx_laser.py
+or
+$ python setup.py test
+"""
+import numpy as np
+from scipy.constants import c, epsilon_0, m_e, e
+from fbpic.main import Simulation
+from fbpic.lpa_utils.laser import add_laser_pulse, ParaxialApproximationLaser,\
+    GaussianChirpedLongitudinalProfile, GaussianTransverseProfile, \
+    FlattenedGaussianTransverseProfile, DonutLikeLaguerreGaussTransverseProfile
+
+# Parameters
+# ----------
+
+use_cuda = True
+
+# Simulation box
+Nz = 800
+zmin = -20.e-6
+zmax = 20.e-6
+Nr = 300
+rmax = 150.e-6
+Nm = 3
+n_order = -1
+# Laser pulse
+w0 = 17.e-6
+ctau = 5.e-6
+k0 = 2*np.pi/0.8e-6
+E_laser = 1. # a0 = 2.22
+phi2_chirp = 200.e-30
+# Propagation
+zfoc = 1600.e-6
+Lprop = 1600.e-6
+
+# Checking the results
+rtol = 1.e-2
+
+def retrieve_pulse_energy(Er, r, dr, dz):
+    """
+    Function that calculates the pulse energy from the electric field data
+    """
+    I = c * epsilon_0 * (2 * Er) ** 2
+    P = np.sum(I * 2 * np.pi * r[:, np.newaxis] * dr, axis=0)
+    E_laser = np.sum(P * dz / c)
+    return E_laser
+
+def test_laser_periodic(case='gaussian'):
+    """
+    Function that is run by py.test, when doing `python setup.py test`
+    Test the propagation of a laser in a periodic box.
+    """
+    # Propagate the pulse in a single step
+    dt = Lprop*1./c
+
+    # Initialize the simulation object
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
+                      n_order=n_order, zmin=zmin,
+                      boundaries={'z':'periodic', 'r':'reflective'} )
+
+    # Define the profile
+    if case == 'gaussian':
+        long_prof = GaussianChirpedLongitudinalProfile(
+            tau=ctau/c, z0=0., phi2_chirp=0.)
+        trans_prof = GaussianTransverseProfile(waist=w0, zf=zfoc)
+    elif case == 'flattened_chirped':
+        long_prof = GaussianChirpedLongitudinalProfile(
+            tau=ctau/c, z0=0., phi2_chirp=phi2_chirp)
+        trans_prof = FlattenedGaussianTransverseProfile(
+            w0=w0, N=30, zf=zfoc)
+    elif case == 'donut_chirped':
+        long_prof = GaussianChirpedLongitudinalProfile(
+            tau=ctau/c, z0=0., phi2_chirp=phi2_chirp)
+        trans_prof = DonutLikeLaguerreGaussTransverseProfile(
+            waist=w0, zf=zfoc, p=2, m=1)
+    else:
+        raise ValueError('Unknown case')
+    # Construct Paraxial Approximation Laser
+    profile = ParaxialApproximationLaser(long_prof, trans_prof, E_laser)
+    # Initialize the laser fields
+    add_laser_pulse( sim, profile )
+
+    # Propagate the pulse
+    sim.step(1)
+
+    # Get pulse energy and peak electric field
+    if case == 'gaussian' or case == 'flattened_chirped':
+        # mode 1
+        Er = sim.fld.interp[1].Er.real.T.copy()
+    elif case == 'donut_chirped':
+        # mode 2 & scale Er by a factor of 2 for correct pulse energy
+        Er = sim.fld.interp[2].Er.real.T.copy()*2
+    r = sim.fld.interp[1].r
+    dr = sim.fld.interp[1].dr
+    dz = sim.fld.interp[1].dz
+    E_laser_sim = retrieve_pulse_energy(Er, r, dr, dz)
+
+    # Check the validity
+    assert np.allclose( E_laser_sim, E_laser, atol=rtol*E_laser )
+
+    # Check peak normalized amplitude for Gaussian laser
+    if case == 'gaussian':
+        E0_sim = 2*Er.max()
+        a0_sim = E0_sim / (m_e * c ** 2 * k0 / e)
+        assert np.allclose( a0_sim, 2.22, atol=3*rtol*2.22 )
+
+if __name__ == '__main__' :
+    cases = ['gaussian', 'flattened_chirped', 'donut_chirped']
+    for case in cases:
+        # Run the testing function
+        test_laser_periodic(case)


### PR DESCRIPTION
This PR introduces a new laser, the `ParaxialApproximationLaser`, which provides an easy way for  users to create custom laser profiles. For example, a laser pulse that has a flattened Gaussian transverse profile and a chirped Gaussian longitudinal profile can now be created as follows:

```python
from fbpic.lpa_utils.laser import ParaxialApproximationLaser, \
    GaussianChirpedLongitudinalProfile, FlattenedGaussianTransverseProfile
longitudinal_profile = GaussianChirpedLongitudinalProfile(tau, z0, lambda0, phi2_chirp)
transverse_profile = FlattenedGaussianTransverseProfile(w0, N, zf, lambda0)
laser_profile = ParaxialApproximationLaser(longitudinal_profile, transverse_profile, E_laser, theta_pol=0.)
```

Note that the pulse energy `E_laser` is passed as a parameter to this new laser profile, as it is unpractical to define an arbitrary laser profile in terms of the peak normalized vector potential.

Please merge #560 before merging this PR.