### PR TITLE
Squared profile integrals

### DIFF
--- a/fbpic/lpa_utils/laser/longitudinal_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/longitudinal_laser_profiles.py
@@ -69,6 +69,22 @@ class LaserLongitudinalProfile(object):
         # (This should be replaced by any class that inherits from this one.)
         return np.zeros_like(z, dtype='complex')
 
+    def squared_profile_integral(self):
+        """
+        Return the integral of the square of the absolute value of
+        of the (complex) laser profile along the `z` axis:
+
+        .. math::
+
+            \\int_{-\\infty}^\\infty \,dz|f(z)|^2
+
+        Returns:
+        --------
+        integral: float
+        """
+        # The base class only defines a dummy implementation
+        # (This should be replaced by any class that inherits from this one.)
+        return 0
 
 # Particular classes for each longitudinal laser profile
 # ------------------------------------------------------
@@ -161,3 +177,9 @@ class GaussianChirpedLongitudinalProfile(LaserLongitudinalProfile):
         profile = np.exp(exp_argument) / stretch_factor ** 0.5
 
         return profile
+
+    def squared_profile_integral(self):
+        """
+        See the docstring of LaserLongitudinalProfile.squared_profile_integral
+        """
+        return (0.5 * np.pi * self.inv_ctau2)**.5

--- a/fbpic/lpa_utils/laser/transverse_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/transverse_laser_profiles.py
@@ -65,7 +65,26 @@ class LaserTransverseProfile(object):
         """
         # The base class only defines dummy fields
         # (This should be replaced by any class that inherits from this one.)
+        #TODO: Raise exception
         return np.zeros_like(x, dtype='complex')
+
+    def squared_profile_integral(self):
+        """
+        Return the integral of the square of the absolute value of
+        of the (complex) laser profile in the transverse plane:
+
+        .. math::
+
+            \\int_0^{2\\pi} d\\theta \\int_0^\\infty dr|f(r, \\theta)|^2
+
+        Returns:
+        --------
+        integral: float
+        """
+        # The base class only defines a dummy implementation
+        # (This should be replaced by any class that inherits from this one.)
+        #TODO: Raise exception
+        return 0
 
 
 # Particular classes for each transverse laser profile
@@ -141,6 +160,13 @@ class GaussianTransverseProfile(LaserTransverseProfile):
         profile = np.exp(exp_argument) / diffract_factor
 
         return profile
+
+    def squared_profile_integral(self):
+        """
+        See the docstring of LaserTransverseProfile.squared_profile_integral
+        """
+        return 0.5 * np.pi * self.w0**2
+
 
 class LaguerreGaussTransverseProfile( LaserTransverseProfile ):
     """Class that calculates a Laguerre-Gauss transverse laser profile."""
@@ -279,6 +305,12 @@ class LaguerreGaussTransverseProfile( LaserTransverseProfile ):
 
         return profile
 
+    def squared_profile_integral(self):
+        """
+        See the docstring of LaserTransverseProfile.squared_profile_integral
+        """
+        return 0.5 * np.pi * self.w0**2
+
 class DonutLikeLaguerreGaussTransverseProfile( LaserTransverseProfile ):
     """Define the complex transverse profile of a donut-like Laguerre-Gauss
     laser."""
@@ -394,6 +426,12 @@ class DonutLikeLaguerreGaussTransverseProfile( LaserTransverseProfile ):
         profile *= self.scaled_amplitude
 
         return profile
+
+    def squared_profile_integral(self):
+        """
+        See the docstring of LaserTransverseProfile.squared_profile_integral
+        """
+        return 0.5 * np.pi * self.w0**2
 
 class FlattenedGaussianTransverseProfile( LaserTransverseProfile ):
     """Define the complex transverse profile of a focused flattened Gaussian

--- a/fbpic/lpa_utils/laser/transverse_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/transverse_laser_profiles.py
@@ -559,3 +559,9 @@ class FlattenedGaussianTransverseProfile( LaserTransverseProfile ):
         profile = laguerre_sum * np.exp( exp_argument ) / diffract_factor
 
         return profile
+
+    def squared_profile_integral(self):
+        """
+        See the docstring of LaserTransverseProfile.squared_profile_integral
+        """
+        return 0.5 * np.pi * (self.N + 1) * self.w0**2 * sum( self.cn**2 ) 

--- a/fbpic/lpa_utils/laser/transverse_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/transverse_laser_profiles.py
@@ -564,4 +564,4 @@ class FlattenedGaussianTransverseProfile( LaserTransverseProfile ):
         """
         See the docstring of LaserTransverseProfile.squared_profile_integral
         """
-        return 0.5 * np.pi * (self.N + 1) * self.w0**2 * sum( self.cn**2 ) 
+        return 0.5 * np.pi * self.w_foc**2 * sum( self.cn**2 ) 

--- a/fbpic/lpa_utils/laser/transverse_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/transverse_laser_profiles.py
@@ -65,7 +65,6 @@ class LaserTransverseProfile(object):
         """
         # The base class only defines dummy fields
         # (This should be replaced by any class that inherits from this one.)
-        #TODO: Raise exception
         return np.zeros_like(x, dtype='complex')
 
     def squared_profile_integral(self):
@@ -75,7 +74,7 @@ class LaserTransverseProfile(object):
 
         .. math::
 
-            \\int_0^{2\\pi} d\\theta \\int_0^\\infty dr|f(r, \\theta)|^2
+            \\int_0^{2\\pi} d\\theta \\int_0^\\infty r \,dr|f(r, \\theta)|^2
 
         Returns:
         --------
@@ -83,7 +82,6 @@ class LaserTransverseProfile(object):
         """
         # The base class only defines a dummy implementation
         # (This should be replaced by any class that inherits from this one.)
-        #TODO: Raise exception
         return 0
 
 
@@ -564,4 +562,4 @@ class FlattenedGaussianTransverseProfile( LaserTransverseProfile ):
         """
         See the docstring of LaserTransverseProfile.squared_profile_integral
         """
-        return 0.5 * np.pi * self.w_foc**2 * sum( self.cn**2 ) 
+        return 0.5 * np.pi * self.w_foc**2 * sum( self.cn**2 )


### PR DESCRIPTION
This adds the calculation of the integrals of the different profiles. This will be useful in order to initialize a laser of a given desired energy.

For the flattened gaussian laser, I tested the validity of the formula with the following code:
```
import numpy as np
import matplotlib.pyplot as plt
from fbpic.lpa_utils.laser.transverse_laser_profiles import FlattenedGaussianTransverseProfile
w0 = 15.3e-6
x = np.linspace(-10*w0, 10*w0, 2000)
y = np.linspace(-10*w0, 10*w0, 2000)
x2d, y2d = np.meshgrid( x, y)

plt.figure(figsize=(6,6))
for N in range(0,10,2):
    profile = FlattenedGaussianTransverseProfile(w0, N)
    plt.subplot(211)
    plt.plot( 1.e6*x, profile.evaluate(x, 0, 0).real, label=N )
    plt.subplot(212)
    E = abs(profile.evaluate(x2d, y2d, z=0))
    integral = (E**2).sum()*(x[1]-x[0])*(y[1]-y[0])
    plt.plot( [N], [profile.squared_profile_integral()], '+' )
    plt.plot( [N], [integral], 'x' )
plt.subplot(211)
plt.xlabel('x (micron)')
plt.ylabel('Profile')
plt.legend(loc=0)
plt.subplot(212)
plt.xlabel('N')
plt.ylabel('Transverse intregral')
plt.tight_layout()
```
which produces the following plot. (The bottom plot compares the numerical integral with the implemented formula, for different values of N.)
<img width="502" alt="Screen Shot 2021-11-09 at 9 44 38 AM" src="https://user-images.githubusercontent.com/6685781/140977221-e34e90a5-8a14-4d8d-8fff-af6d05e89393.png">

