### PR TITLE
Added if to handle mpi4py 4.0

### DIFF
--- a/fbpic/utils/mpi.py
+++ b/fbpic/utils/mpi.py
@@ -36,9 +36,10 @@ try:
         mpi4py_version_number = mpi4py.__version__.split('.')
         mpi4py_major_version = int(mpi4py_version_number[0])
         mpi4py_minor_version = int(mpi4py_version_number[1])
-        if (mpi4py_major_version < 3) or (mpi4py_minor_version < 1):
-            raise RuntimeError(
-                "In order to use GPU Direct, you need to install mpi4py>=3.1.")
+        if mpi4py_major_version < 4:
+            if (mpi4py_major_version < 3) or (mpi4py_minor_version < 1):
+                raise RuntimeError(
+                    "In order to use GPU Direct, you need to install mpi4py>=3.1.")
 
 except ImportError:
     # If MPI is not installed, define dummy replacements


### PR DESCRIPTION
The current mpi4py version check fails when using mpi4py 4.0. Adding another if statement seems to fix this.