### PR TITLE
Added optional GDD, TOD, FOD; added subtraction of linear phase

### DIFF
--- a/fbpic/lpa_utils/laser/longitudinal_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/longitudinal_laser_profiles.py
@@ -8,6 +8,7 @@ It defines a set of common longitudinal laser profiles.
 import numpy as np
 from scipy.constants import c
 from scipy.interpolate import interp1d
+from scipy.special import factorial
 
 # Generic classes
 # ---------------
@@ -190,7 +191,10 @@ class CustomSpectrumLongitudinalProfile(LaserLongitudinalProfile):
     """Class that calculates a longitudinal profile with a user defined
     spectral amplitude and phase."""
 
-    def __init__(self, z0, spectrum_file, propagation_direction=1):
+    def __init__(self, z0, spectrum_file,
+                 phi2_chirp=0., phi3_chirp=0., phi4_chirp=0.,
+                 subtract_linear_phase=False,
+                 propagation_direction=1):
         """
         Define the complex longitudinal profile of the laser pulse,
         from the spectrum provided in `spectrum_file`.
@@ -229,40 +233,71 @@ class CustomSpectrumLongitudinalProfile(LaserLongitudinalProfile):
             in the file. The spectral phase can be omitted, in which case it
             will be assumed to be 0.
 
+        phi2_chirp: float (in second^2), optional
+            The amount of temporal chirp, at focus (in the lab frame).
+
+        phi3_chirp: float (in second^3), optional
+            The amount of third order dispersion, at focus (in the lab frame).
+            This parameter leads to an asymmetrical temporal shape of the laser
+            pulse.
+
+        phi4_chirp: float (in second^4), optional
+            Fourth order dispersion at focus (in the lab frame).
+
+        subtract_linear_phase: bool, optional
+            If True, a linear slope in the spectral phase read
+            from spectrum_file will be subtracted from it. A non-zero
+            linear slope leads to pulse being shifted in time.
+
         propagation_direction: int, optional
             Indicates in which direction the laser propagates.
             This should be either 1 (laser propagates towards positive z)
             or -1 (laser propagates towards negative z).
         """
         # Initialize propagation direction
-        LaserLongitudinalProfile.__init__(self,propagation_direction,
+        LaserLongitudinalProfile.__init__(self, propagation_direction,
                                           gpu_capable=False)
 
         # Load the spectrum from the text file
         spectrum_data = np.loadtxt( spectrum_file, delimiter='\t' )
-        wavelength = spectrum_data[:,0]
-        intensity = spectrum_data[:,1]
+        wavelength = spectrum_data[:, 0]
+        intensity = spectrum_data[:, 1]
         if spectrum_data.shape[1] < 3:
-            phase = np.zeros_like(wavelength)
+            spectral_phase = np.zeros_like(wavelength)
         else:
-            phase = spectrum_data[:,2]
+            spectral_phase = spectrum_data[:, 2]
+        omega_axis = 2 * np.pi * c / wavelength
+
+        # Subtract linear slope, if asked to
+        if subtract_linear_phase:
+            # Fit a 4 order polynomial and subtract the linear term
+            poly_coeffs = np.polyfit(omega_axis, spectral_phase, 4)
+            spectral_phase -= omega_axis * poly_coeffs[-1]
 
         # Compute central wavelength from the text file data
-        self.lambda0 = np.trapz(wavelength*intensity,wavelength) * \
-                        1./np.trapz(intensity,wavelength)
-        self.k0 = 2*np.pi/self.lambda0
+        self.lambda0 = np.trapz(wavelength*intensity, wavelength) * \
+                        1. / np.trapz(intensity, wavelength)
+        self.k0 = 2 * np.pi / self.lambda0
+
+        # Apply spectral phase expansion terms
+        spectral_phase += 1 / factorial(2) * phi2_chirp * \
+                          (omega_axis - self.k0 * c) ** 2
+        spectral_phase += 1 / factorial(3) * phi3_chirp * \
+                          (omega_axis - self.k0 * c) ** 3
+        spectral_phase += 1 / factorial(4) * phi4_chirp * \
+                          (omega_axis - self.k0 * c) ** 4
 
         # Create functions that interpolate the spectral phase and intensity
         # from the text file data
-        spectral_inten_fn = interp1d( 2*np.pi*c/wavelength,
+        spectral_inten_fn = interp1d( omega_axis,
                                       intensity*wavelength**2,
-                                      fill_value=0,bounds_error=False)
-        spectral_phase_fn = interp1d( 2*np.pi*c/wavelength, phase,
+                                      fill_value=0, bounds_error=False)
+        spectral_phase_fn = interp1d( omega_axis, spectral_phase,
                                       fill_value=0, bounds_error=False)
 
         # Computation Parameters
-        lambda_resolution = self.lambda0/1000 # spectral resolution
-        dt = lambda_resolution/c
+        lambda_resolution = self.lambda0 / 1000  # spectral resolution
+        dt = lambda_resolution / c
         time_window = self.lambda0 * self.lambda0 / c / lambda_resolution
         Nt = np.round(time_window/dt).astype(int)
 


### PR DESCRIPTION
Hey, as discussed, I added the option to include GDD, TOD, FOD in the spectral phase. I also added the option to subtract a linear phase term.

In terms of the other point from our discussion, namely
- We will also add the optional to pass arrays, along with helper functions to create the array corresponding to e.g. a Gaussian pulse etc.

I think nothing needs to be done to this code: according to numpy.loadtxt docu, the file argument (spectrum_file in our case) can also be a list of strings, so any helper class can simply wrap its output to a list of strings and pass that to this class.

Let me know if the docstrings make sense :)