### PR TITLE
Close #574: Document how to install the PICMI dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ conda install -c conda-forge mpi4py
 ```
 pip install fbpic
 ```
+(If you want to run FBPIC through the [PICMI](https://picmi-standard.github.io/)
+interface, you can instead use `pip install fbpic[picmi]`.)
 
 - **Optional:** in order to run on GPU, install the additional package
 `cudatoolkit` and `cupy` -- e.g. using CUDA version 10.0.

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -22,11 +22,20 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
        pip install fbpic
 
-   Alternatively, instead of using ``pip``, you can also install FBPIC
-   from the souces, by cloning the `code from Github
-   <https://github.com/fbpic/fbpic>`_, and typing ``python setup.py
-   install``.
+   .. note::
 
+       If you want to run FBPIC through the
+       `PICMI interface <https://picmi-standard.github.io/>`__, you can instead
+       use
+
+       ::
+
+           pip install fbpic[picmi]
+
+   .. note::
+       Instead of using ``pip``, you can also install FBPIC from the souces,
+       by cloning the `code from Github <https://github.com/fbpic/fbpic>`_,
+       and typing ``python setup.py install``.
 
 -  **Optional:** In order to be able to run the code on a GPU,
    install the additional package ``cudatoolkit`` and ``cupy`` --


### PR DESCRIPTION
This adds documentation on how to install the PICMI dependencies:
![Screen Shot 2022-03-14 at 11 49 07 AM](https://user-images.githubusercontent.com/6685781/158240672-61739b10-d17f-4a85-8a02-dfe9c610ceab.png)

