### PR TITLE
Fixes for picmi

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -481,10 +481,6 @@ class Simulation(object):
                 # were smoothed/corrected, and copy the data from the GPU.)
                 diag.write( self.iteration )
 
-            if i_step == N:
-                # Step "N+1" is started in order to get the final diagnostics written out
-                break
-
             # Push the particles' positions and velocities to t = (n+1/2) dt
             if move_momenta:
                 for species in ptcl:

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -418,7 +418,7 @@ class Simulation(object):
         # -----------------------------
 
         # Loop over timesteps
-        for i_step in range(N+1):
+        for i_step in range(N):
 
             # Show a progression bar and calculate ETA
             if show_progress and self.comm.rank==0:

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -418,7 +418,7 @@ class Simulation(object):
         # -----------------------------
 
         # Loop over timesteps
-        for i_step in range(N):
+        for i_step in range(N+1):
 
             # Show a progression bar and calculate ETA
             if show_progress and self.comm.rank==0:
@@ -480,6 +480,10 @@ class Simulation(object):
                 # (If needed: bring rho/J from spectral space, where they
                 # were smoothed/corrected, and copy the data from the GPU.)
                 diag.write( self.iteration )
+
+            if i_step == N:
+                # Step "N+1" is started in order to get the final diagnostics written out
+                break
 
             # Push the particles' positions and velocities to t = (n+1/2) dt
             if move_momenta:

--- a/fbpic/picmi/simulation.py
+++ b/fbpic/picmi/simulation.py
@@ -38,26 +38,41 @@ class Simulation( PICMI_Simulation ):
     # Redefine the `init` method, as required by the picmi `_ClassWithInit`
     def init(self, kw):
 
+        self.sim_kw = {}
+        for argname in ['use_ruyten_shapes', 'use_modified_volume']:
+            if f'fbpic_{argname}' in kw:
+                self.sim_kw[argname] = kw.pop(f'fbpic_{argname}')
+
+        self.step_kw = {}
+        for argname in ['correct_currents',
+                        'correct_divE',
+                        'use_true_rho',
+                        'move_positions',
+                        'move_momenta',
+                        'show_progress']:
+            if f'fbpic_{argname}' in kw:
+                self.step_kw[argname] = kw.pop(f'fbpic_{argname}')
+
         # Get the grid
         grid = self.solver.grid
         if not type(grid) == PICMI_CylindricalGrid:
             raise ValueError('When using fbpic with PICMI, '
                 'the grid needs to be a CylindricalGrid object.')
         # Check rmin and boundary conditions
-        assert grid.rmin == 0.
-        assert grid.bc_zmin == grid.bc_zmax
-        if grid.bc_zmin == 'reflective':
+        assert grid.lower_bound[0] == 0.
+        assert grid.lower_boundary_conditions[1] == grid.upper_boundary_conditions[1]
+        if grid.lower_boundary_conditions[1] == 'reflective':
             warnings.warn(
             "FBPIC does not support reflective boundary condition in z.\n"
             "The z boundary condition was automatically converted to 'open'.")
-            grid.bc_zmin = 'open'
-            grid.bc_zmax = 'open'
-        assert grid.bc_zmax in ['periodic', 'open']
-        assert grid.bc_rmax in ['reflective', 'open']
+            grid.lower_boundary_conditions[1] = 'open'
+            grid.upper_boundary_conditions[1] = 'open'
+        assert grid.upper_boundary_conditions[1] in ['periodic', 'open']
+        assert grid.upper_boundary_conditions[0] in ['reflective', 'open']
 
         # Determine timestep
         if self.solver.cfl is not None:
-            dz = (grid.zmax-grid.zmin)/grid.nz
+            dz = (grid.upper_bound[1]-grid.lower_bound[1])/grid.number_of_cells[1]
             dt = self.solver.cfl * dz / c
         elif self.time_step_size is not None:
             dt = self.time_step_size
@@ -106,14 +121,15 @@ class Simulation( PICMI_Simulation ):
 
         # Initialize and store the FBPIC simulation object
         self.fbpic_sim = FBPICSimulation(
-            Nz=int(grid.nz), zmin=grid.zmin, zmax=grid.zmax,
-            Nr=int(grid.nr), rmax=grid.rmax, Nm=grid.n_azimuthal_modes,
+            Nz=int(grid.number_of_cells[1]), zmin=grid.lower_bound[1], zmax=grid.upper_bound[1],
+            Nr=int(grid.number_of_cells[0]), rmax=grid.upper_bound[0], Nm=grid.n_azimuthal_modes,
             dt=dt, use_cuda=True, smoother=smoother, n_order=n_order,
-            boundaries={'z':grid.bc_zmax, 'r':grid.bc_rmax},
+            boundaries={'z':grid.upper_boundary_conditions[1], 'r':grid.upper_boundary_conditions[0]},
             n_guard=n_guard, verbose_level=verbose_level,
             particle_shape=self.particle_shape,
             v_comoving=v_comoving,
-            gamma_boost=self.gamma_boost )
+            gamma_boost=self.gamma_boost,
+            **self.sim_kw)
 
         # Set the moving window
         if grid.moving_window_velocity is not None:
@@ -262,24 +278,26 @@ class Simulation( PICMI_Simulation ):
                     z_injection_plane = injection_plane_position[-1]
                 gamma0_beta0 = s.initial_distribution.directed_velocity[-1]/c
                 gamma0 = ( 1 + gamma0_beta0**2 )**.5
+                dist = s.initial_distribution
                 fbpic_species = add_particle_bunch( self.fbpic_sim,
                     q=s.charge, m=s.mass, gamma0=gamma0, n=n0,
                     dens_func=dens_func, p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
-                    p_zmin=s.initial_distribution.lower_bound[-1],
-                    p_zmax=s.initial_distribution.upper_bound[-1],
+                    p_zmin=dist.lower_bound[-1] if dist.lower_bound[-1] is not None else -np.inf,
+                    p_zmax=dist.upper_bound[-1] if dist.upper_bound[-1] is not None else +np.inf,
                     p_rmin=0,
-                    p_rmax=s.initial_distribution.upper_bound[0],
+                    p_rmax=dist.upper_bound[0] if dist.upper_bound[0] is not None else +np.inf,
                     boost=self.fbpic_sim.boost,
                     z_injection_plane=z_injection_plane,
                     initialize_self_field=initialize_self_field,
                     boost_positions_in_dens_func=True )
             else:
+                dist = s.initial_distribution
                 fbpic_species = self.fbpic_sim.add_new_species(
                     q=s.charge, m=s.mass, n=n0,
                     dens_func=dens_func, p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
-                    p_zmin=s.initial_distribution.lower_bound[-1],
-                    p_zmax=s.initial_distribution.upper_bound[-1],
-                    p_rmax=s.initial_distribution.upper_bound[0],
+                    p_zmin=dist.lower_bound[-1] if dist.lower_bound[-1] is not None else -np.inf,
+                    p_zmax=dist.upper_bound[-1] if dist.upper_bound[-1] is not None else +np.inf,
+                    p_rmax=dist.upper_bound[0] if dist.upper_bound[0] is not None else +np.inf,
                     continuous_injection=s.initial_distribution.fill_in,
                     boost_positions_in_dens_func=True )
 
@@ -348,11 +366,11 @@ class Simulation( PICMI_Simulation ):
             else:
                 data_list = set()  # Use set to avoid redundancy
                 for data in diagnostic.data_list:
-                    if data in ['Ex', 'Ey', 'Ez']:
+                    if data in ['Ex', 'Ey', 'Ez', 'E']:
                         data_list.add('E')
-                    elif data in ['Bx', 'By', 'Bz']:
+                    elif data in ['Bx', 'By', 'Bz', 'B']:
                         data_list.add('B')
-                    elif data in ['Jx', 'Jy', 'Jz']:
+                    elif data in ['Jx', 'Jy', 'Jz', 'J']:
                         data_list.add('J')
                     elif data == 'rho':
                         data_list.add('rho')
@@ -394,8 +412,8 @@ class Simulation( PICMI_Simulation ):
 
         elif type(diagnostic) == PICMI_LabFrameFieldDiagnostic:
             diag = BackTransformedFieldDiagnostic(
-                    zmin_lab=diagnostic.grid.zmin,
-                    zmax_lab=diagnostic.grid.zmax,
+                    zmin_lab=diagnostic.grid.lower_bound[1],
+                    zmax_lab=diagnostic.grid.upper_bound[1],
                     v_lab=c,
                     dt_snapshots_lab=diagnostic.dt_snapshots,
                     Ntot_snapshots_lab=diagnostic.num_snapshots,
@@ -429,8 +447,8 @@ class Simulation( PICMI_Simulation ):
                     iteration_max=iteration_max)
             else:
                 diag = BackTransformedParticleDiagnostic(
-                    zmin_lab=diagnostic.grid.zmin,
-                    zmax_lab=diagnostic.grid.zmax,
+                    zmin_lab=diagnostic.grid.lower_bound[1],
+                    zmax_lab=diagnostic.grid.upper_bound[1],
                     v_lab=c,
                     dt_snapshots_lab=diagnostic.dt_snapshots,
                     Ntot_snapshots_lab=diagnostic.num_snapshots,
@@ -499,4 +517,4 @@ class Simulation( PICMI_Simulation ):
     def step(self, nsteps=None):
         if nsteps is None:
             nsteps = self.max_steps
-        self.fbpic_sim.step( nsteps )
+        self.fbpic_sim.step( nsteps , **self.step_kw)


### PR DESCRIPTION
This fixes several issues with the picmi interface.
 - Changes were needed for the grid since the single quantities like `nr` and `zmax` are no longer saved as attributes
 - Allowed `None` to be used for the bounds of the plasma
 - Added diagnostics for names like `E` and `B`
 - Added fbpic specific arguments for the Simulation class
 - Added a change to the main loop so that the diagnostics are written out for the last time step (is there a better way to do this?)