### PR TITLE
Update Docs for Local Install from Source

### DIFF
--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -33,9 +33,9 @@ Python. If Anaconda is not your default Python distribution, download and instal
            pip install fbpic[picmi]
 
    .. note::
-       Instead of using ``pip``, you can also install FBPIC from the souces,
+       Instead of using ``pip``, you can also install FBPIC from the sources,
        by cloning the `code from Github <https://github.com/fbpic/fbpic>`_,
-       and typing ``python setup.py install``.
+       and executing ``python3 -m pip install .`` from the main directory.
 
 -  **Optional:** In order to be able to run the code on a GPU,
    install the additional package ``cudatoolkit`` and ``cupy`` --

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -33,7 +33,7 @@ Python. If Anaconda is not your default Python distribution, download and instal
            pip install fbpic[picmi]
 
    .. note::
-       Instead of using ``pip``, you can also install FBPIC from the sources,
+       Instead of using a release, you can also install FBPIC from the sources,
        by cloning the `code from Github <https://github.com/fbpic/fbpic>`_,
        and executing ``python3 -m pip install .`` from the main directory.
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -36,6 +36,7 @@ Python. If Anaconda is not your default Python distribution, download and instal
        Instead of using a release, you can also install FBPIC from the sources,
        by cloning the `code from Github <https://github.com/fbpic/fbpic>`_,
        and executing ``python3 -m pip install .`` from the main directory.
+       A shortcut for this is: ``python3 -m pip install git+https://github.com/fbpic/fbpic.git``.
 
 -  **Optional:** In order to be able to run the code on a GPU,
    install the additional package ``cudatoolkit`` and ``cupy`` --


### PR DESCRIPTION
Feedback received from @ax3l while troubleshooting local installation issues: calling `python setup.py install` is considered deprecated in the Python world.