### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -32,8 +32,8 @@ jobs:
     - shell: bash -eo pipefail -l {0}
       name: Install dependencies
       run: |
-        conda install --yes -c conda-forge numba scipy h5py mkl mpich mpi4py matplotlib python=${{ matrix.python-version }};
-        pip install openPMD-viewer pytest pyflakes;
+        conda install --yes -c conda-forge numba scipy h5py mkl mpich mpi4py matplotlib python=${{ matrix.python-version }}
+        pip install openPMD-viewer pytest pyflakes
         python -m pip install .
 
     - shell: bash -eo pipefail -l {0}
@@ -43,9 +43,9 @@ jobs:
     - shell: bash -eo pipefail -l {0}
       name: FBPIC physics tests
       run: |
-        export NUMBA_THREADING_LAYER=omp;
-        export MKL_NUM_THREADS=2;
-        export NUMBA_NUM_THREADS=2;
+        export NUMBA_THREADING_LAYER=omp
+        export MKL_NUM_THREADS=2
+        export NUMBA_NUM_THREADS=2
         python -m pytest tests --ignore=tests/unautomated
     - shell: bash -eo pipefail -l {0}
       name: PICMI test

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -39,22 +39,24 @@ jobs:
     - shell: bash -eo pipefail -l {0}
       name: pyflakes
       run: python -m pyflakes .
+
     - shell: bash -eo pipefail -l {0}
       name: FBPIC physics tests
       run: python setup.py test
     - shell: bash -eo pipefail -l {0}
       name: PICMI test
       run: |
-        pip install wget picmistandard numexpr periodictable;
-        cd tests/unautomated;
-        curl https://raw.githubusercontent.com/picmi-standard/picmi/master/Examples/laser_acceleration/laser_acceleration_PICMI.py -o fbpic_script.py;
-        python test_picmi.py;
+        pip install wget picmistandard numexpr periodictable
+        cd tests/unautomated
+        curl https://raw.githubusercontent.com/picmi-standard/picmi/master/Examples/laser_acceleration/laser_acceleration_PICMI.py -o fbpic_script.py
+        python test_picmi.py
         rm fbpic_script.py
+
     - shell: bash -eo pipefail -l {0}
       name: PICMI boosted test
       run: |
-        cd tests/unautomated;
-        curl https://raw.githubusercontent.com/picmi-standard/picmi/master/Examples/laser_acceleration/lpa_boostedframe_PICMI.py -o fbpic_script.py;
-        cat fbpic_script.py;
-        python test_picmi.py;
+        cd tests/unautomated
+        curl https://raw.githubusercontent.com/picmi-standard/picmi/master/Examples/laser_acceleration/lpa_boostedframe_PICMI.py -o fbpic_script.py
+        cat fbpic_script.py
+        python test_picmi.py
         rm fbpic_script.py

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -32,10 +32,10 @@ jobs:
     - shell: bash -eo pipefail -l {0}
       name: Install dependencies
       run: |
-        conda install --yes "numba<0.49" scipy h5py mkl pytest pyflakes python=${{ matrix.python-version }};
-        conda install --yes -c conda-forge mpich mpi4py;
-        pip install openPMD-viewer;
-        python setup.py install
+        conda install --yes -c conda-forge mamba
+        mamba install --yes -c conda-forge "numba<0.49" pip scipy h5py mkl pytest pyflakes python=${{ matrix.python-version }} mpich mpi4py openpmd-viewer
+        python -m pip install .
+
     - shell: bash -eo pipefail -l {0}
       name: pyflakes
       run: python -m pyflakes .

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.6]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
 
@@ -33,7 +33,7 @@ jobs:
       name: Install dependencies
       run: |
         conda install --yes -c conda-forge mamba
-        mamba install --yes -c conda-forge numba pip scipy h5py mkl pytest pyflakes python=${{ matrix.python-version }} mpich mpi4py openpmd-viewer
+        mamba install --yes -c conda-forge "numba<0.49" pip scipy h5py mkl pytest pyflakes python=${{ matrix.python-version }} mpich mpi4py openpmd-viewer
         python -m pip install .
 
     - shell: bash -eo pipefail -l {0}

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.8]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -29,20 +29,20 @@ jobs:
         channels: conda-forge,defaults
         channel-priority: true
 
-    - shell: bash -l {0}
+    - shell: bash -eo pipefail -l {0}
       name: Install dependencies
       run: |
         conda install --yes "numba<0.49" scipy h5py mkl pytest pyflakes python=${{ matrix.python-version }};
         conda install --yes -c conda-forge mpich mpi4py;
         pip install openPMD-viewer;
         python setup.py install
-    - shell: bash -l {0}
+    - shell: bash -eo pipefail -l {0}
       name: pyflakes
       run: python -m pyflakes .
-    - shell: bash -l {0}
+    - shell: bash -eo pipefail -l {0}
       name: FBPIC physics tests
       run: python setup.py test
-    - shell: bash -l {0}
+    - shell: bash -eo pipefail -l {0}
       name: PICMI test
       run: |
         pip install wget picmistandard numexpr periodictable;
@@ -50,7 +50,7 @@ jobs:
         curl https://raw.githubusercontent.com/picmi-standard/picmi/master/Examples/laser_acceleration/laser_acceleration_PICMI.py -o fbpic_script.py;
         python test_picmi.py;
         rm fbpic_script.py
-    - shell: bash -l {0}
+    - shell: bash -eo pipefail -l {0}
       name: PICMI boosted test
       run: |
         cd tests/unautomated;

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -33,7 +33,7 @@ jobs:
       name: Install dependencies
       run: |
         conda install --yes -c conda-forge mamba
-        mamba install --yes -c conda-forge "numba<0.49" pip scipy h5py mkl pytest pyflakes python=${{ matrix.python-version }} mpich mpi4py openpmd-viewer
+        mamba install --yes -c conda-forge numba pip scipy h5py mkl pytest pyflakes python=${{ matrix.python-version }} mpich mpi4py openpmd-viewer
         python -m pip install .
 
     - shell: bash -eo pipefail -l {0}


### PR DESCRIPTION
I saw in #582 that CI is failing with:
```
FBPIC physics tests
$ python setup.py test
...
Traceback (most recent call last):
  File "/usr/share/miniconda/envs/testing/lib/python3.6/site-packages/importlib_metadata/_compat.py", line 9, in <module>
    from typing import Protocol
ImportError: cannot import name 'Protocol'
...
  File "/usr/share/miniconda/envs/testing/lib/python3.6/site-packages/typing_extensions.py", line 159, in <module>
    class _FinalForm(typing._SpecialForm, _root=True):
AttributeError: module 'typing' has no attribute '_SpecialForm'
```

This PR contains the following fixes:
- [x] CI: `bash -l ...`: actually fail on first error now
- [x] CI: modernize conda install
- [x] CI: cleanup