### PR TITLE
Fix PICMI calculation of dt so that it is consistent with other codes

### DIFF
--- a/fbpic/picmi/simulation.py
+++ b/fbpic/picmi/simulation.py
@@ -58,7 +58,11 @@ class Simulation( PICMI_Simulation ):
         # Determine timestep
         if self.solver.cfl is not None:
             dz = (grid.zmax-grid.zmin)/grid.nz
-            dt = self.solver.cfl * dz / c
+            dr = (grid.rmax-grid.rmin)/grid.nr
+            if self.gamma_boost is not None:
+                beta = np.sqrt(1. - 1./self.gamma_boost**2)
+                dr = dr/((1+beta)*self.gamma_boost)
+            dt = self.solver.cfl * min(dz, dr) / c
         elif self.time_step_size is not None:
             dt = self.time_step_size
         else:


### PR DESCRIPTION
This updates the calculation of `dt` in PICMI so as to ensure that it takes `dr` into account.