### PR TITLE
Fix PICMI field diagnostic

### DIFF
--- a/fbpic/picmi/simulation.py
+++ b/fbpic/picmi/simulation.py
@@ -378,7 +378,10 @@ class Simulation( PICMI_Simulation ):
                         data_list.add('J')
                     elif data == 'rho':
                         data_list.add('rho')
-                data_list = list(data_list)
+                # Use sorted to make sure that each MPI rank goes through
+                # fields in the same order, when dumping to disk (esp.
+                # since this operation requires an MPI gather)
+                data_list = sorted(list(data_list))
 
         if type(diagnostic) == PICMI_FieldDiagnostic:
 


### PR DESCRIPTION
In the PICMI interface, the list of fields that each MPI rank needs to output was determined by a Python `set`, which was then converted to a list. However, the order of the elements is not deterministic, in this conversion. 

Therefore, different MPI ranks (for the same simulation) could end up with having this list in different orders. This is problematic, since, in the diagnostic code, each MPI rank loops through the field by using this list, and performs MPI Gather with the other ranks within this loop. This means that the MPI gather was potentially gathering different fields (e.g. `Jy` and `Ex`) into the same array!

This is now fixed by imposing the order of elements.

Closes #587 