### PR TITLE
Use add_laser_pulse in example scripts

### DIFF
--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -186,10 +186,6 @@ if __name__ == '__main__':
     if track_bunch:
         bunch.track( sim.comm )
 
-    # Add a laser to the fields of the simulation
-    add_laser( sim, a0, w0, ctau, z0, lambda0=lambda0,
-           zf=zfoc, gamma_boost=boost.gamma0 )
-
     # Create a Gaussian laser profile
     laser_profile = GaussianLaser(a0, w0, ctau, z0, lambda0=lambda0, zf=z_foc)
     # Add a laser to the fields of the simulation

--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -21,7 +21,8 @@ import numpy as np
 from scipy.constants import c, e, m_e, m_p
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
-from fbpic.lpa_utils.laser import add_laser
+from fbpic.lpa_utils.laser import add_laser_pulse
+from fbpic.lpa_utils.laser.laser_profiles import GaussianLaser
 from fbpic.lpa_utils.bunch import add_particle_bunch
 from fbpic.lpa_utils.boosted_frame import BoostConverter
 from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic, \
@@ -188,6 +189,12 @@ if __name__ == '__main__':
     # Add a laser to the fields of the simulation
     add_laser( sim, a0, w0, ctau, z0, lambda0=lambda0,
            zf=zfoc, gamma_boost=boost.gamma0 )
+
+    # Create a Gaussian laser profile
+    laser_profile = GaussianLaser(a0, w0, ctau, z0, lambda0=lambda0, zf=z_foc)
+    # Add a laser to the fields of the simulation
+    add_laser_pulse( sim, laser_profile, gamma_boost=boost.gamma0,
+                     method='antenna', z0_antenna=0)
 
     # Convert parameter to boosted frame
     v_window_boosted, = boost.velocity( [ v_window ] )

--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -187,7 +187,7 @@ if __name__ == '__main__':
         bunch.track( sim.comm )
 
     # Create a Gaussian laser profile
-    laser_profile = GaussianLaser(a0, w0, ctau, z0, lambda0=lambda0, zf=z_foc)
+    laser_profile = GaussianLaser(a0, w0, ctau, z0, lambda0=lambda0, zf=zfoc)
     # Add a laser to the fields of the simulation
     add_laser_pulse( sim, laser_profile, gamma_boost=boost.gamma0,
                      method='antenna', z0_antenna=0)

--- a/docs/source/example_input/boosted_frame_script.py
+++ b/docs/source/example_input/boosted_frame_script.py
@@ -64,7 +64,7 @@ dt = min( rmax/(2*boost.gamma0*Nr)/c, (zmax-zmin)/Nz/c )  # Timestep (seconds)
 # The laser (conversion to boosted frame is done inside 'add_laser')
 a0 = 2.          # Laser amplitude
 w0 = 50.e-6      # Laser waist
-ctau = 5.e-6     # Laser duration
+tau = 16.e-15     # Laser duration
 z0 = -10.e-6     # Laser centroid
 zfoc = 0.e-6     # Focal position
 lambda0 = 0.8e-6 # Laser wavelength
@@ -187,7 +187,7 @@ if __name__ == '__main__':
         bunch.track( sim.comm )
 
     # Create a Gaussian laser profile
-    laser_profile = GaussianLaser(a0, w0, ctau, z0, lambda0=lambda0, zf=zfoc)
+    laser_profile = GaussianLaser(a0, w0, tau, z0, lambda0=lambda0, zf=zfoc)
     # Add a laser to the fields of the simulation
     add_laser_pulse( sim, laser_profile, gamma_boost=boost.gamma0,
                      method='antenna', z0_antenna=0)

--- a/docs/source/example_input/ionization_script.py
+++ b/docs/source/example_input/ionization_script.py
@@ -71,7 +71,7 @@ p_nt = 4         # Number of particles per cell along theta
 # The laser
 a0 = 4.          # Laser amplitude
 w0 = 5.e-6       # Laser waist
-ctau = 5.e-6     # Laser duration
+tau = 16.e-15     # Laser duration
 z0 = -5.e-6      # Laser centroid
 z_foc = 20.e-6   # Focal position
 
@@ -138,7 +138,7 @@ if __name__ == '__main__':
     atoms_N.make_ionizable( 'N', target_species=elec_from_N, level_start=5 )
 
     # Create a Gaussian laser profile
-    laser_profile = GaussianLaser(a0, w0, ctau, z0, zf=z_foc)
+    laser_profile = GaussianLaser(a0, w0, tau, z0, zf=z_foc)
     # Add the laser to the fields of the simulation
     add_laser_pulse( sim, laser_profile)
 

--- a/docs/source/example_input/ionization_script.py
+++ b/docs/source/example_input/ionization_script.py
@@ -25,7 +25,8 @@ import numpy as np
 from scipy.constants import c, e, m_e, m_p
 # Import the relevant structures from fbpic
 from fbpic.main import Simulation
-from fbpic.lpa_utils.laser import add_laser
+from fbpic.lpa_utils.laser import add_laser_pulse
+from fbpic.lpa_utils.laser.laser_profiles import GaussianLaser
 from fbpic.openpmd_diag import FieldDiagnostic, \
     ParticleDiagnostic, ParticleChargeDensityDiagnostic, \
     set_periodic_checkpoint, restart_from_checkpoint
@@ -136,8 +137,10 @@ if __name__ == '__main__':
     elec_from_N = sim.add_new_species( q=-e, m=m_e )
     atoms_N.make_ionizable( 'N', target_species=elec_from_N, level_start=5 )
 
-    # Add a laser to the fields of the simulation
-    add_laser( sim, a0, w0, ctau, z0, zf=z_foc )
+    # Create a Gaussian laser profile
+    laser_profile = GaussianLaser(a0, w0, ctau, z0, zf=z_foc)
+    # Add the laser to the fields of the simulation
+    add_laser_pulse( sim, laser_profile)
 
     if use_restart is False:
         # Track electrons if required (species 0 correspond to the electrons)

--- a/docs/source/example_input/lwfa_script.py
+++ b/docs/source/example_input/lwfa_script.py
@@ -67,7 +67,7 @@ p_nt = 4         # Number of particles per cell along theta
 # The laser
 a0 = 4.          # Laser amplitude
 w0 = 5.e-6       # Laser waist
-ctau = 5.e-6     # Laser duration
+tau = 16.e-15     # Laser duration
 z0 = 15.e-6      # Laser centroid
 
 # The moving window
@@ -121,7 +121,7 @@ if __name__ == '__main__':
 
     # Load initial fields
     # Create a Gaussian laser profile
-    laser_profile = GaussianLaser(a0, w0, ctau, z0)
+    laser_profile = GaussianLaser(a0, w0, tau, z0)
     # Add the laser to the fields of the simulation
     add_laser_pulse( sim, laser_profile)
 

--- a/docs/source/example_input/lwfa_script.py
+++ b/docs/source/example_input/lwfa_script.py
@@ -21,7 +21,8 @@ import numpy as np
 from scipy.constants import c, e, m_e
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
-from fbpic.lpa_utils.laser import add_laser
+from fbpic.lpa_utils.laser import add_laser_pulse
+from fbpic.lpa_utils.laser.laser_profiles import GaussianLaser
 from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic, \
      set_periodic_checkpoint, restart_from_checkpoint
 
@@ -119,8 +120,10 @@ if __name__ == '__main__':
         p_nz=p_nz, p_nr=p_nr, p_nt=p_nt )
 
     # Load initial fields
-    # Add a laser to the fields of the simulation
-    add_laser( sim, a0, w0, ctau, z0 )
+    # Create a Gaussian laser profile
+    laser_profile = GaussianLaser(a0, w0, ctau, z0)
+    # Add the laser to the fields of the simulation
+    add_laser_pulse( sim, laser_profile)
 
     if use_restart is False:
         # Track electrons if required (species 0 correspond to the electrons)

--- a/docs/source/example_input/parametric_script.py
+++ b/docs/source/example_input/parametric_script.py
@@ -70,7 +70,7 @@ p_nt = 4         # Number of particles per cell along theta
 
 # The laser
 w0 = 5.e-6       # Laser waist
-ctau = 5.e-6     # Laser duration
+ctau = 16.e-15     # Laser duration
 z0 = 15.e-6      # Laser centroid
 
 # Parametric scan: Give a list of a0 values to scan,
@@ -133,7 +133,7 @@ if __name__ == '__main__':
 
     # Load initial fields
     # Create a Gaussian laser profile
-    laser_profile = GaussianLaser(a0, w0, ctau, z0)
+    laser_profile = GaussianLaser(a0, w0, tau, z0)
     # Add the laser to the fields of the simulation
     add_laser_pulse( sim, laser_profile)
 

--- a/docs/source/example_input/parametric_script.py
+++ b/docs/source/example_input/parametric_script.py
@@ -24,7 +24,8 @@ import numpy as np
 from scipy.constants import c, e, m_e
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
-from fbpic.lpa_utils.laser import add_laser
+from fbpic.lpa_utils.laser import add_laser_pulse
+from fbpic.lpa_utils.laser.laser_profiles import GaussianLaser
 from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic, \
      set_periodic_checkpoint, restart_from_checkpoint
 # Parametric scan: import mpi4py so as to be able to give different
@@ -131,8 +132,10 @@ if __name__ == '__main__':
                 p_nz=p_nz, p_nr=p_nr, p_nt=p_nt )
 
     # Load initial fields
-    # Add a laser to the fields of the simulation
-    add_laser( sim, a0, w0, ctau, z0 )
+    # Create a Gaussian laser profile
+    laser_profile = GaussianLaser(a0, w0, ctau, z0)
+    # Add the laser to the fields of the simulation
+    add_laser_pulse( sim, laser_profile)
 
     if use_restart is True:
         # Load the fields and particles from the latest checkpoint file

--- a/docs/source/example_input/parametric_script.py
+++ b/docs/source/example_input/parametric_script.py
@@ -70,7 +70,7 @@ p_nt = 4         # Number of particles per cell along theta
 
 # The laser
 w0 = 5.e-6       # Laser waist
-ctau = 16.e-15     # Laser duration
+tau = 16.e-15     # Laser duration
 z0 = 15.e-6      # Laser centroid
 
 # Parametric scan: Give a list of a0 values to scan,


### PR DESCRIPTION
This PR updated the example scripts to use the newer laser API. First, a laser profile is created, e.g. through `GaussianLaser()`, and it is then added to the simulation by calling the function `add_laser_pulse(sim, laser_profile, ...)`. The boosted frame example now uses the `antenna` method to add the laser pulse.