### PR TITLE
Make FBPIC compatible with numba version 0.56: Remove use of `ptx`

### DIFF
--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -386,7 +386,8 @@ if cuda_installed:
             # numba kernel
             module = cupy.cuda.function.Module()
             if numba_version[1] >= 53:
-                ptx = next(iter(numba_kernel.overloads.values())).ptx
+                kernel = next(iter(numba_kernel.overloads.values()))
+                ptx = kernel._codelibrary.get_asm_str()
                 module.load(bytes(ptx, 'UTF-8'))
             else:
                 module.load(bytes(numba_kernel.ptx, 'UTF-8'))

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -385,9 +385,12 @@ if cuda_installed:
             # Create a Cupy kernel module and load the PTX code of the
             # numba kernel
             module = cupy.cuda.function.Module()
-            if numba_version[1] >= 53:
+            if numba_version[1] >= 56:
                 kernel = next(iter(numba_kernel.overloads.values()))
                 ptx = kernel._codelibrary.get_asm_str()
+                module.load(bytes(ptx, 'UTF-8'))
+            elif numba_version[1] >= 53:
+                ptx = next(iter(numba_kernel.overloads.values())).ptx
                 module.load(bytes(ptx, 'UTF-8'))
             else:
                 module.load(bytes(numba_kernel.ptx, 'UTF-8'))

--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -8,7 +8,8 @@ It defines a set of generic functions that operate on a GPU.
 import warnings
 import numba
 numba_version = (int(numba.__version__.split('.')[0]),
-                 int(numba.__version__.split('.')[1]))
+                 int(numba.__version__.split('.')[1]),
+                 int(numba.__version__.split('.')[2]))
 from numba import cuda
 import numpy as np
 
@@ -386,6 +387,10 @@ if cuda_installed:
             # numba kernel
             module = cupy.cuda.function.Module()
             if numba_version[1] >= 56:
+                if numba_version[2] == 0:
+                    raise RuntimeError(
+                        'FBPIC is incompatible with numba 0.56.0.\n'
+                        'Please install either a later or an earlier version.')
                 kernel = next(iter(numba_kernel.overloads.values()))
                 ptx = kernel._codelibrary.get_asm_str()
                 module.load(bytes(ptx, 'UTF-8'))


### PR DESCRIPTION
This PR addresses #602 attempts to remove the use of `ptx`, which is not supported anymore in numba `0.56`.
The fix is based on this line of numba code:
https://github.com/numba/numba/pull/8191/files#diff-ad6746f9263e40f10fa2a85537c0da56a1a8abfd7a0743ec0c06e3a14e3df0e7L193
Importantly, this change is in an `if` condition, based on the detected version of `numba`, so that the code remains compatible with previous versions of `numba`.

**Current status**:
Update: the issue described below was fixed in `numba 0.56.2`, thanks to [this PR](https://github.com/numba/numba/pull/8310>). As a result, FBPIC does not work with `numba 0.56.0` on GPU, but works with both previous versions of `numba` and later versions of `numba`.
~~The fix works with `numba 0.55.2` (for which it is however not required, since 0.55.2 still supports `.ptx`).~~
~~However, it fails for `numba 0.56.0` due to another error:~~

```
Failed in cuda mode pipeline (step: nopython frontend)
No implementation of function Function(<function ol_array_real at 0x7fd22405bc70>) found for signature:
 
 >>> ol_array_real(array(complex128, 2d, C))
 
There are 2 candidate implementations:
      - Of which 2 did not match due to:
      Overload in function 'ol_array_real': File: numba/np/arrayobj.py: Line 2620.
        With argument(s): '(array(complex128, 2d, C))':
       Rejected as the implementation raised a specific error:
         NumbaTypeError: Failed in nopython mode pipeline (step: nopython frontend)
       Only accept returning of array passed into the function as argument
  raised from /home/rlehe/miniconda3/envs/fbpic-new/lib/python3.10/site-packages/numba/core/typed_passes.py:150

During: typing of get attribute at /home/rlehe/Documents/codes/fbpic/fbpic/particles/deposition/cuda_methods.py (182)

File "../../../fbpic/particles/deposition/cuda_methods.py", line 182:
def deposit_rho_gpu_linear(x, y, z, w, q,
    <source elided>
            # Mode 0
            cuda.atomic.add(rho_m0.real, (iz0, ir0), R_m0_00.real)
            ^
```