### PR TITLE
[WIP] Monte-Carlo collision scheme

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -468,7 +468,7 @@ class Simulation(object):
             for collision in self.collisions:
                 if self.iteration % collision.period == 0 \
                     and self.iteration >= collision.start:
-                    collision.handle_collisions( fld, 0.5*dt )
+                    collision.handle_collisions( fld, dt )
             # Cell quantities need to be recalculated
             for species in ptcl:
                 species.calc = False

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -339,6 +339,8 @@ class Simulation(object):
         self.laser_antennas = []
         # Initialize an empty list of mirrors
         self.mirrors = []
+        # Initialize an empty list of collisions
+        self.collisions = []
 
         # Print simulation setup
         print_simulation_setup( self, verbose_level=verbose_level )
@@ -438,6 +440,7 @@ class Simulation(object):
                 # continuous injection of new particles by the moving window.
                 # (In the case of single-proc periodic simulations, particles
                 # are shifted by one box length, so they remain inside the box)
+
                 for species in self.ptcl:
                     self.comm.exchange_particles(species, fld, self.time)
                 for antenna in self.laser_antennas:
@@ -501,6 +504,10 @@ class Simulation(object):
             # (e.g. ionization, Compton scattering, ...)
             for species in ptcl:
                 species.handle_elementary_processes( self.time + 0.5*dt )
+
+            # Handle collisions
+            for collision in self.collisions:
+                collision.handle_collisions( fld, 0.5*dt )
 
             # Fields are not used beyond this point ; no need to keep sorted
             for species in ptcl:

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -507,7 +507,9 @@ class Simulation(object):
 
             # Handle collisions
             for collision in self.collisions:
-                collision.handle_collisions( fld, 0.5*dt )
+                if self.iteration % collision.collision_period == 0 \
+                    and self.iteration > collision.start:
+                    collision.handle_collisions( fld, 0.5*dt )
 
             # Fields are not used beyond this point ; no need to keep sorted
             for species in ptcl:

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -466,9 +466,12 @@ class Simulation(object):
 
             # Handle collisions
             for collision in self.collisions:
-                if self.iteration % collision.collision_period == 0 \
-                    and self.iteration > collision.start:
+                if self.iteration % collision.period == 0 \
+                    and self.iteration >= collision.start:
                     collision.handle_collisions( fld, 0.5*dt )
+            # Cell quantities need to be recalculated
+            for species in ptcl:
+                species.calc = False
 
             # Keep field arrays sorted throughout gathering+push
             for species in ptcl:

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -469,9 +469,6 @@ class Simulation(object):
                 if self.iteration % collision.period == 0 \
                     and self.iteration >= collision.start:
                     collision.handle_collisions( fld, dt )
-            # Cell quantities need to be recalculated
-            for species in ptcl:
-                species.calc = False
 
             # Keep field arrays sorted throughout gathering+push
             for species in ptcl:

--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -464,6 +464,12 @@ class Simulation(object):
             # Main PIC iteration
             # ------------------
 
+            # Handle collisions
+            for collision in self.collisions:
+                if self.iteration % collision.collision_period == 0 \
+                    and self.iteration > collision.start:
+                    collision.handle_collisions( fld, 0.5*dt )
+
             # Keep field arrays sorted throughout gathering+push
             for species in ptcl:
                 species.keep_fields_sorted = True
@@ -504,12 +510,6 @@ class Simulation(object):
             # (e.g. ionization, Compton scattering, ...)
             for species in ptcl:
                 species.handle_elementary_processes( self.time + 0.5*dt )
-
-            # Handle collisions
-            for collision in self.collisions:
-                if self.iteration % collision.collision_period == 0 \
-                    and self.iteration > collision.start:
-                    collision.handle_collisions( fld, 0.5*dt )
 
             # Fields are not used beyond this point ; no need to keep sorted
             for species in ptcl:

--- a/fbpic/particles/elementary_process/collisions/__init__.py
+++ b/fbpic/particles/elementary_process/collisions/__init__.py
@@ -1,0 +1,7 @@
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It imports the MCCollision object
+"""
+
+from .collisions import MCCollisions
+__all__ = ['MCCollisions']

--- a/fbpic/particles/elementary_process/collisions/collisions.py
+++ b/fbpic/particles/elementary_process/collisions/collisions.py
@@ -51,7 +51,7 @@ class MCCollisions(object):
         self.coulomb_log = coulomb_log
         
         # Particle pairs are processed in batches of size `batch_size`
-        self.batch_size = 16
+        self.batch_size = 10
 
         self.use_cuda = use_cuda
 
@@ -205,8 +205,10 @@ class MCCollisions(object):
             random_states = create_xoroshiro128p_states( N_batch, seed )
 
             bpg, tpg = cuda_tpb_bpg_1d( N_batch )
-            perform_collisions_cuda[ bpg, tpg ]( prefix_sum1, prefix_sum2,
-                        cell_idx, npart1, npart2, npairs_tot,
+            perform_collisions_cuda[ bpg, tpg ]( N_batch, 
+                        self.batch_size, npairs_tot,
+                        prefix_sum1, prefix_sum2,
+                        cell_idx, npart1, npart2,
                         n1, n2, n12, m1, m2,
                         q1, q2, w1, w2,
                         ux1, uy1, uz1,
@@ -214,6 +216,7 @@ class MCCollisions(object):
                         dt, self.coulomb_log,
                         temperature1, temperature2,
                         random_states )
+
 
             if cupy.any(cupy.isnan(ux1)) == True or \
                 cupy.any(cupy.isnan(uy1)) == True or \

--- a/fbpic/particles/elementary_process/collisions/collisions.py
+++ b/fbpic/particles/elementary_process/collisions/collisions.py
@@ -180,18 +180,6 @@ class MCCollisions(object):
                                 prefix_sum2, m2,
                                 ux2, uy2, uz2 )
 
-            mean_T1 = (k / e) * cupy.sum( temperature1 ) / N_cells
-            mean_T2 = (k / e) * cupy.sum( temperature2 ) / N_cells
-            mean_n1 = cupy.sum( n1 ) / N_cells
-            mean_n2 = cupy.sum( n2 ) / N_cells
-            mean_n12 = cupy.sum( n12 ) / N_cells
-            
-            print("\n mean_T1 eV = ", mean_T1)
-            print("mean_T2 eV = ", mean_T2)
-            print("mean_n1 = ", mean_n1)
-            print("mean_n2 = ", mean_n2)
-            print("mean_n12 = ", mean_n12)
-
             # Total number of pairs
             npairs_tot = int( cupy.sum( npairs ) )
             print("\n Total number of pairs = ", npairs_tot)
@@ -203,6 +191,20 @@ class MCCollisions(object):
             cell_idx = cupy.empty(npairs_tot, dtype=np.int64)
             dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( N_cells )
             get_cell_idx_per_pair[dim_grid_1d, dim_block_1d](N_cells, cell_idx, npairs, prefix_sum_pair)
+
+            # Diagnostics
+            N_cells_plasma = cell_idx[-1] - cell_idx[0]
+            mean_T1 = (k / e) * cupy.sum( temperature1 ) / N_cells_plasma
+            mean_T2 = (k / e) * cupy.sum( temperature2 ) / N_cells_plasma
+            mean_n1 = cupy.sum( n1 ) / N_cells_plasma
+            mean_n2 = cupy.sum( n2 ) / N_cells_plasma
+            mean_n12 = cupy.sum( n12 ) / N_cells_plasma
+            
+            print("\n <T1> = ", mean_T1, " eV")
+            print("<T2> = ", mean_T2, " eV")
+            print("<n1> = ", mean_n1)
+            print("<n2> = ", mean_n2)
+            print("<n12> = ", mean_n12)
 
             # The particles need to be shuffled, in each cell, in non-repeating order
             # so that particles are randomly paired once

--- a/fbpic/particles/elementary_process/collisions/collisions.py
+++ b/fbpic/particles/elementary_process/collisions/collisions.py
@@ -215,7 +215,7 @@ class MCCollisions(object):
                         ux1, uy1, uz1,
                         ux2, uy2, uz2,
                         dt, self.coulomb_log,
-                        random_states, self.debug,
+                        random_states, self.period, self.debug,
                         param_s, param_logL)
 
             if self.debug:
@@ -224,10 +224,15 @@ class MCCollisions(object):
                 mean_T2 = cupy.sum( self.species2.temperature ) / N_cells_plasma
                 max_T1 = cupy.max( self.species1.temperature )
                 max_T2 = cupy.max( self.species2.temperature )
+                min_T1 = cupy.min( self.species1.temperature )
+                min_T2 = cupy.min( self.species2.temperature )
 
                 print("\n<T1> = ", (k / e) * mean_T1, " eV")
-                print("<T2> = ", (k / e) * mean_T2, " eV")
+                print("min(T1) = ", (k / e) * min_T1, " eV")
                 print("max(T1) = ", (k / e) * max_T1, " eV")
+
+                print("<T2> = ", (k / e) * mean_T2, " eV")
+                print("min(T2) = ", (k / e) * min_T2, " eV")
                 print("max(T2) = ", (k / e) * max_T2, " eV")
 
                 print("<s> = ", cupy.sum( param_s ) / npairs_tot)

--- a/fbpic/particles/elementary_process/collisions/collisions.py
+++ b/fbpic/particles/elementary_process/collisions/collisions.py
@@ -1,0 +1,232 @@
+# Copyright 2017, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FBPIC)
+It defines the class that performs calculation of Monte-Carlo collisions.
+"""
+import numpy as np
+import time
+import math as m
+import cupy
+from scipy.constants import c, k, epsilon_0
+
+# Check if CUDA is available, then import CUDA functions
+from fbpic.utils.cuda import cuda_installed, cupy_installed
+from fbpic.utils.printing import catch_gpu_memory_error
+from ..cuda_numba_utils import allocate_empty
+
+if cupy_installed:
+    from fbpic.utils.cuda import cuda_tpb_bpg_1d
+    from numba.cuda.random import create_xoroshiro128p_states
+    from .cuda_methods import perform_collisions_cuda, \
+        density_per_cell_cuda, n12_per_cell_cuda, \
+        temperature_per_cell_cuda, pairs_per_cell_cuda, \
+        get_cell_idx_per_pair
+
+class MCCollisions(object):
+    """
+    Simulate Monte-Carlo (MC) collisions. The calculations randomly
+    pair all particles in a cell and perform collisions
+    """
+    def __init__( self, species1, species2, use_cuda=False,
+                coulomb_log = 0. ):
+        """
+        Initialize Monte-Carlo collisions
+
+        Parameters
+        ----------
+        species1 : an fbpic Particles object
+
+        species2 : an fbpic Particles object
+
+        use_cuda : bool
+        Whether the simulation is set up to use CUDA
+
+        coulomb_log: float, optional
+        """
+        self.species1 = species1
+        self.species2 = species2
+
+        self.coulomb_log = coulomb_log
+        
+        # Particle pairs are processed in batches of size `batch_size`
+        self.batch_size = 16
+
+        self.use_cuda = use_cuda
+
+    def handle_collisions( self, fld, dt ):
+        """
+        Handle collisions
+
+        Parameters:
+        -----------
+        fld :`Fields` object which contains the field information
+
+        dt : The simulation timestep
+        """
+        if self.use_cuda:
+            self.handle_collisions_gpu( fld, dt )
+
+    @catch_gpu_memory_error
+    def handle_collisions_gpu( self, fld, dt ):
+            """
+            Handle collisions on GPU
+
+            Parameters:
+            -----------
+            fld :`Fields` object which contains the field information
+
+            dt : The simulation timestep
+            """
+            if self.species1.sorted == False:
+                self.species1.sort_particles(fld = fld)
+                self.species1.sorted = True
+            if self.species2.sorted == False:
+                self.species2.sort_particles(fld = fld)
+                self.species2.sorted = True
+
+            assert self.species1.sorted == True
+            assert self.species2.sorted == True
+
+            # Short-cut for use_cuda
+            use_cuda = self.use_cuda
+
+            prefix_sum1 = self.species1.prefix_sum
+            prefix_sum2 = self.species2.prefix_sum
+
+            Nz = fld.Nz
+
+            d_invvol = fld.interp[0].d_invvol
+
+            ux1 = getattr( self.species1, 'ux')
+            uy1 = getattr( self.species1, 'uy')
+            uz1 = getattr( self.species1, 'uz')
+            w1 = getattr( self.species1, 'w')
+
+            ux2 = getattr( self.species2, 'ux')
+            uy2 = getattr( self.species2, 'uy')
+            uz2 = getattr( self.species2, 'uz')
+            w2 = getattr( self.species2, 'w')
+
+            m1 = self.species1.m
+            m2 = self.species2.m
+            q1 = self.species1.q
+            q2 = self.species2.q
+
+            assert cupy.any(cupy.isnan(ux1)) == False
+            assert cupy.any(cupy.isnan(uy1)) == False
+            assert cupy.any(cupy.isnan(uz1)) == False
+            assert cupy.any(cupy.isnan(ux2)) == False
+            assert cupy.any(cupy.isnan(uy2)) == False
+            assert cupy.any(cupy.isnan(uz2)) == False
+            assert cupy.any(cupy.isnan(w1)) == False
+            assert cupy.any(cupy.isnan(w2)) == False
+
+            N_cells = int( prefix_sum1.shape[0] )
+            npart1 = allocate_empty(N_cells, use_cuda, dtype=np.int32)
+            npart2 = allocate_empty(N_cells, use_cuda, dtype=np.int32)
+
+            # Calculate number of particles in cell
+            npart1[0] = prefix_sum1[0]
+            npart1[1:] = prefix_sum1[1:] - prefix_sum1[:-1]
+            npart2[0] = prefix_sum2[0]
+            npart2[1:] = prefix_sum2[1:] - prefix_sum2[:-1]
+
+            assert cupy.any(cupy.isnan(npart1)) == False
+            assert cupy.any(cupy.isnan(npart2)) == False
+
+            assert cupy.sum( npart1 ) > 0
+            assert cupy.sum( npart2 ) > 0
+
+            # Calculate number of pairs in cell
+            npairs = allocate_empty(N_cells, use_cuda, dtype=np.int32)
+            bpg, tpg = cuda_tpb_bpg_1d( N_cells )
+            pairs_per_cell_cuda[ bpg, tpg ](N_cells, npart1, npart2, npairs)
+
+            # Calculate density of species 1 in each cell
+            n1 = allocate_empty(N_cells, use_cuda, dtype=np.float64)
+            density_per_cell_cuda[ bpg, tpg ]( N_cells, n1, w1,
+                                npart1, prefix_sum1,
+                                d_invvol, Nz )
+            
+            # Calculate density of species 2 in each cell
+            n2 = allocate_empty(N_cells, use_cuda, dtype=np.float64)
+            density_per_cell_cuda[ bpg, tpg ]( N_cells, n2, w2,
+                                npart2, prefix_sum2,
+                                d_invvol, Nz )
+            
+            # Calculate sum of minimum weights in each cell
+            n12 = allocate_empty(N_cells, use_cuda, dtype=np.float64)
+            n12_per_cell_cuda[ bpg, tpg ]( N_cells, n12, w1, w2, npart1,
+                                            prefix_sum1, prefix_sum2 )
+
+            # Calculate temperature in each cell
+            temperature1 = allocate_empty(N_cells, use_cuda, dtype=np.float64)
+            temperature_per_cell_cuda[ bpg, tpg ]( N_cells, temperature1, npart1,
+                                prefix_sum1, m1,
+                                ux1, uy1, uz1 )
+
+            temperature2 = allocate_empty(N_cells, use_cuda, dtype=np.float64)
+            temperature_per_cell_cuda[ bpg, tpg ]( N_cells, temperature2, npart2,
+                                prefix_sum2, m2,
+                                ux2, uy2, uz2 )
+
+            mean_T1 = cupy.sum( temperature1 ) / N_cells
+            mean_T2 = cupy.sum( temperature2 ) / N_cells
+            mean_n1 = cupy.sum( n1 ) / N_cells
+            mean_n2 = cupy.sum( n2 ) / N_cells
+            mean_n12 = cupy.sum( n12 ) / N_cells
+
+            print("\n mean_T1 = ", mean_T1)
+            print("mean_T2 = ", mean_T2)
+            print("mean_n1 = ", mean_n1)
+            print("mean_n2 = ", mean_n2)
+            print("mean_n12 = ", mean_n12)
+
+            # Total number of pairs
+            npairs_tot = int( cupy.sum( npairs ) )
+            print("\n Total number of pairs = ", npairs_tot)
+
+            # Cumulative prefix sum of pairs
+            prefix_sum_pair = cupy.cumsum(npairs)
+
+            # Cell index of pair
+            cell_idx = cupy.empty(npairs_tot, dtype=np.int64)
+            dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( N_cells )
+            get_cell_idx_per_pair[dim_grid_1d, dim_block_1d](N_cells, cell_idx, npairs, prefix_sum_pair)
+
+            # The particles need to be shuffled, in each cell, in non-repeating order
+            # so that particles are randomly paired once
+            
+            # Process particle pairs in batches
+            N_batch = int( npairs_tot  / self.batch_size ) + 1
+            seed = np.random.randint( 256 )
+            random_states = create_xoroshiro128p_states( N_batch, seed )
+
+            bpg, tpg = cuda_tpb_bpg_1d( N_batch )
+            perform_collisions_cuda[ bpg, tpg ]( prefix_sum1, prefix_sum2,
+                        cell_idx, npart1, npart2, npairs_tot,
+                        n1, n2, n12, m1, m2,
+                        q1, q2, w1, w2,
+                        ux1, uy1, uz1,
+                        ux2, uy2, uz2,
+                        dt, self.coulomb_log,
+                        temperature1, temperature2,
+                        random_states )
+
+            if cupy.any(cupy.isnan(ux1)) == True or \
+                cupy.any(cupy.isnan(uy1)) == True or \
+                cupy.any(cupy.isnan(uz1)) == True or \
+                cupy.any(cupy.isnan(ux2)) == True or \
+                cupy.any(cupy.isnan(uy2)) == True or \
+                cupy.any(cupy.isnan(uz2)) == True:
+                print("\n NaN solution.")
+                return
+            else:
+                setattr(self.species1.ux, 'ux', ux1)
+                setattr(self.species1.uy, 'uy', uy1)
+                setattr(self.species1.uz, 'uz', uz1)
+                setattr(self.species2.ux, 'ux', ux2)
+                setattr(self.species2.uy, 'uy', uy2)
+                setattr(self.species2.uz, 'uz', uz2)

--- a/fbpic/particles/elementary_process/collisions/collisions.py
+++ b/fbpic/particles/elementary_process/collisions/collisions.py
@@ -9,7 +9,7 @@ import numpy as np
 import time
 import math as m
 import cupy
-from scipy.constants import c, k, epsilon_0
+from scipy.constants import c, k, epsilon_0, e
 
 # Check if CUDA is available, then import CUDA functions
 from fbpic.utils.cuda import cuda_installed, cupy_installed
@@ -99,6 +99,14 @@ class MCCollisions(object):
 
             d_invvol = fld.interp[0].d_invvol
 
+            x1 = getattr( self.species1, 'x')
+            y1 = getattr( self.species1, 'y')
+            z1 = getattr( self.species1, 'z')
+
+            x2 = getattr( self.species1, 'x')
+            y2 = getattr( self.species1, 'y')
+            z2 = getattr( self.species1, 'z')
+
             ux1 = getattr( self.species1, 'ux')
             uy1 = getattr( self.species1, 'uy')
             uz1 = getattr( self.species1, 'uz')
@@ -172,14 +180,14 @@ class MCCollisions(object):
                                 prefix_sum2, m2,
                                 ux2, uy2, uz2 )
 
-            mean_T1 = cupy.sum( temperature1 ) / N_cells
-            mean_T2 = cupy.sum( temperature2 ) / N_cells
+            mean_T1 = (k / e) * cupy.sum( temperature1 ) / N_cells
+            mean_T2 = (k / e) * cupy.sum( temperature2 ) / N_cells
             mean_n1 = cupy.sum( n1 ) / N_cells
             mean_n2 = cupy.sum( n2 ) / N_cells
             mean_n12 = cupy.sum( n12 ) / N_cells
-
-            print("\n mean_T1 = ", mean_T1)
-            print("mean_T2 = ", mean_T2)
+            
+            print("\n mean_T1 eV = ", mean_T1)
+            print("mean_T2 eV = ", mean_T2)
             print("mean_n1 = ", mean_n1)
             print("mean_n2 = ", mean_n2)
             print("mean_n12 = ", mean_n12)
@@ -213,6 +221,8 @@ class MCCollisions(object):
                         q1, q2, w1, w2,
                         ux1, uy1, uz1,
                         ux2, uy2, uz2,
+                        x1, y1, z1,
+                        x2, y2, z2,
                         dt, self.coulomb_log,
                         temperature1, temperature2,
                         random_states )

--- a/fbpic/particles/elementary_process/collisions/collisions.py
+++ b/fbpic/particles/elementary_process/collisions/collisions.py
@@ -22,8 +22,7 @@ if cupy_installed:
     from .cuda_methods import perform_collisions_cuda, \
         density_per_cell_cuda, n12_per_cell_cuda, \
         temperature_per_cell_cuda, pairs_per_cell_cuda, \
-        get_cell_idx_per_pair_cuda, get_shuffled_idx_per_particle_cuda, \
-        alt_n12_per_cell_cuda
+        get_cell_idx_per_pair_cuda, get_shuffled_idx_per_particle_cuda
 
 class MCCollisions(object):
     """
@@ -74,222 +73,6 @@ class MCCollisions(object):
         if self.use_cuda:
             self.handle_collisions_gpu( fld, dt )
 
-    def test_perform_collisions_cuda(self, N_batch, batch_size, npairs_tot,
-                        	prefix_sum1, prefix_sum2,
-                            shuffled_idx1, shuffled_idx2, cell_idx,
-                            n1, n2, n12, m1, m2,
-                            q1, q2, w1, w2,
-                            ux1, uy1, uz1,
-                            ux2, uy2, uz2,
-							x1, y1, z1,
-                        	x2, y2, z2,
-                            dt, coulomb_log,
-                            T1, T2,
-                            random_states):
-        """
-        Perform collisions between all pairs in each cell
-        """
-        # Loop over batch of particle pairs and perform collision
-        for i in range (N_batch):
-            # Loop through the batch
-            N_max = min( (i+1)*batch_size, npairs_tot )
-            for ip in range( i*batch_size, N_max ):
-                cell = cell_idx[ip]
-
-                if cell > 0:
-                    si1 = int( shuffled_idx1[ip] + prefix_sum1[cell-1] )
-                    si2 = int( shuffled_idx2[ip] + prefix_sum2[cell-1] )
-                else:
-                    si1 = int( shuffled_idx1[ip] )
-                    si2 = int( shuffled_idx2[ip] )
-
-                r1 = m.sqrt( x1[si1]**2 + y1[si1]**2 )
-
-                r2 = m.sqrt( x2[si2]**2 + y2[si2]**2 )
-
-                distance = m.sqrt( (r1 - r2)**2 + (z1[si1] - z2[si2])**2 )
-                
-                Debye2 = (epsilon_0 * k / e**2) / (n1[cell] / T1[cell] + n1[cell] / T2[cell])
-
-                # Choose to collide pairs that are within a Debye sphere
-                #if distance < m.sqrt(Debye2):
-                if distance < 0.1:
-                    # Effective time interval for the collisions
-                    corr_dt = dt * n12[cell] / n1[cell]
-
-                    px1 = ux1[si1] * (m1 * c)
-                    py1 = uy1[si1] * (m1 * c) 
-                    pz1 = uz1[si1] * (m1 * c)
-
-                    print("px1", px1)
-                    print("py1", py1)
-                    print("pz1", pz1)
-
-
-                    px2 = ux2[si2] * (m2 * c)
-                    py2 = uy2[si2] * (m2 * c) 
-                    pz2 = uz2[si2] * (m2 * c)
-
-                    print("px2", px2)
-                    print("py2", py2)
-                    print("pz2", pz2)
-
-                    inv_m1 = 1. / m1
-                    vx1 = px1 * inv_m1
-                    vy1 = py1 * inv_m1
-                    vz1 = pz1 * inv_m1
-
-                    inv_m2 = 1. / m2
-                    vx2 = px2 * inv_m2
-                    vy2 = py2 * inv_m2
-                    vz2 = pz2 * inv_m2
-
-                    print("vx1", vx1)
-                    print("vy1", vy1)
-                    print("vz1", vz1)
-
-                    print("vx2", vx2)
-                    print("vy2", vy2)
-                    print("vz2", vz2)
-
-                    print((vx1**2 + vy1**2 + vz1**2) / c**2)
-                    print((vx2**2 + vy2**2 + vz2**2) / c**2)
-
-                    # Calculate Lorentz factor
-                    gamma1 = m.sqrt(1. + (vx1**2 + vy1**2 + vz1**2) / c**2)
-                    gamma2 = m.sqrt(1. + (vx2**2 + vy2**2 + vz2**2) / c**2)
-
-
-                    g12 = m1 * gamma1 + m2 * gamma2
-                    inv_g12 = 1. / g12
-
-                    gamma12 = m1 * gamma1 * m2 * gamma2
-                    invgamma12 = 1. / gamma12
-
-                    # Center of mass (COM) velocity
-                    COM_vx = (px1 + px2) * inv_g12
-                    COM_vy = (py1 + py2) * inv_g12
-                    COM_vz = (pz1 + pz2) * inv_g12
-
-                    COM_v_v1 = (COM_vx * vx1 + COM_vy * vy1 + COM_vz * vz1)
-                    COM_v_v2 = (COM_vx * vx2 + COM_vy * vy2 + COM_vz * vz2)
-
-                    COM_v2 = COM_vx**2 + COM_vy**2 + COM_vz**2
-                    COM_gamma = 1. / m.sqrt(1. - COM_v2 / c**2)
-
-                    # momenta in COM
-                    px_COM = px1 + ((COM_gamma - 1.) * COM_v_v1 / COM_v2
-                                            - COM_gamma) * m1 * gamma1 * COM_vx
-                    py_COM = py1 + ((COM_gamma - 1.) * COM_v_v1 / COM_v2
-                                            - COM_gamma) * m1 * gamma1 * COM_vy
-                    pz_COM = pz1 + ((COM_gamma - 1.) * COM_v_v1 / COM_v2
-                                            - COM_gamma) * m1 * gamma1 * COM_vz
-
-                    p_COM = m.sqrt(px_COM**2 + py_COM**2 + pz_COM**2)
-                    invp_COM = 1. / p_COM
-                    invp_COM2 = 1. / p_COM**2
-
-                    # Lorentz transforms
-                    gamma1_COM = (1 - COM_v_v1 / c**2) * COM_gamma * gamma1
-                    gamma2_COM = (1 - COM_v_v2 / c**2) * COM_gamma * gamma2
-
-                    # Calculate coulomb log if not user-defined
-                    qq = q1 * q2
-                    qq2 = qq**2
-                    if coulomb_log <= 0.:
-                        coeff = 1. / (4 * m.pi * epsilon_0 * c**2)
-                        b0 = coeff * qq * COM_gamma * inv_g12 * \
-                            (m1 * gamma1_COM * m2 * gamma2_COM * invp_COM2 * c**2 + 1.)**2
-                        bmin = max(0.5 * h * invp_COM, b0)
-                        coulomb_log = 0.5 * m.log(1. + Debye2 / bmin**2)
-                        if coulomb_log < 2.:
-                            coulomb_log = 2.
-
-                    term1 = n1[cell] * n2[cell] / n12[cell]
-                    term2 = corr_dt * coulomb_log * qq2 * \
-                        invgamma12 / (4. * m.pi * epsilon_0**2 * c**4)
-                    term3 = gamma2_COM * p_COM * inv_g12 * \
-                        (m1 * gamma1_COM * m2 * gamma2_COM * invp_COM2 * c**2 + 1.)**2
-
-                    # Calculate the collision parameter s12
-                    s12 = term1 * term2 * term3
-
-                    # Low temperature correction
-                    v_rel = m.sqrt((vx1 - vx2)**2
-                                + (vy1 - vy2)**2
-                                + (vz1 - vz2)**2)
-                    s_prime = (4.*m.pi/3)**(1/3) * term1 * corr_dt * \
-                        ((m1 + m2) / max(m1 * n1[cell]**(2/3), m2 * n2[cell]**(2/3))) * \
-                        v_rel
-
-                    s = min(s12, s_prime)
-
-                    # Random azimuthal angle
-                    phi = random.random()*2.0 * m.pi
-                    #phi = xoroshiro128p_uniform_float64(random_states, i) * 2.0 * m.pi
-
-                    # Calculate the deflection angle
-                    U = random.random()
-                    #U = xoroshiro128p_uniform_float64(
-                    #    random_states, i)    # random float [0,1]
-                    if s12 < 4:
-                        a = 0.37 * s - 0.005 * s**2 - 0.0064 * s**3
-                        sin2X2 = a * U / m.sqrt(1 - U + a**2 * U)
-                        cosX = 1. - 2. * sin2X2
-                        sinX = 2. * m.sqrt(sin2X2 * (1. - sin2X2))
-                    else:
-                        cosX = 2. * U - 1.
-                        sinX = m.sqrt(1. - cosX * cosX)
-                    sinXcosPhi = sinX * m.cos(phi)
-                    sinXsinPhi = sinX * m.sin(phi)
-
-                    p_perp_COM = m.sqrt(px_COM**2 + py_COM**2)
-                    invp = 1. / p_perp_COM
-
-                    # Resulting momentum in COM frame
-                    if (p_perp_COM > 1.e-10 * p_COM):
-                        pxf1_COM = (px_COM * pz_COM * invp * sinXcosPhi
-                                    - py_COM * p_COM * invp * sinXsinPhi
-                                    + px_COM * cosX)
-                        pyf1_COM = (py_COM * pz_COM * invp * sinXcosPhi
-                                    + px_COM * p_COM * invp * sinXsinPhi
-                                    + py_COM * cosX)
-                        pzf1_COM = (-p_perp_COM * sinXcosPhi
-                                    + pz_COM * cosX)
-                    else:
-                        pxf1_COM = p_COM * sinXcosPhi
-                        pyf1_COM = p_COM * sinXsinPhi
-                        pzf1_COM = p_COM * cosX
-
-                    vC_pfCOM = (COM_vx * pxf1_COM
-                                + COM_vy * pyf1_COM
-                                + COM_vz * pzf1_COM)
-
-                    # Resulting momentum in lab frame
-                    pxf1 = pxf1_COM + COM_vx * \
-                        ((COM_gamma - 1.) * vC_pfCOM / COM_v2 + m1 * gamma1_COM * COM_gamma)
-                    pyf1 = pyf1_COM + COM_vy * \
-                        ((COM_gamma - 1.) * vC_pfCOM / COM_v2 + m1 * gamma1_COM * COM_gamma)
-                    pzf1 = pzf1_COM + COM_vz * \
-                        ((COM_gamma - 1.) * vC_pfCOM / COM_v2 + m1 * gamma1_COM * COM_gamma)
-
-                    U1 = random.random()
-                    #U1 = xoroshiro128p_uniform_float64(
-                    #    random_states, i)    # random float [0,1]
-                    if U1 * w1[si1] < w2[si2]:
-                        # Deflect particle 1
-                        inv_norm1 = 1. / (m1 * c)
-                        ux1[si1] = pxf1 * inv_norm1
-                        uy1[si1] = pyf1 * inv_norm1
-                        uz1[si1] = pzf1 * inv_norm1
-
-                    if U1 * w2[si2] < w1[si1]:
-                        # Deflect particle 2 (pf2 = -pf1)
-                        inv_norm2 = 1. / (m2 * c)
-                        ux2[si2] = -pxf1 * inv_norm2
-                        uy2[si2] = -pyf1 * inv_norm2
-                        uz2[si2] = -pzf1 * inv_norm2
-
     @catch_gpu_memory_error
     def handle_collisions_gpu( self, fld, dt ):
             """
@@ -318,14 +101,6 @@ class MCCollisions(object):
             Nz = fld.Nz
 
             d_invvol = fld.interp[0].d_invvol
-
-            x1 = getattr( self.species1, 'x')
-            y1 = getattr( self.species1, 'y')
-            z1 = getattr( self.species1, 'z')
-
-            x2 = getattr( self.species2, 'x')
-            y2 = getattr( self.species2, 'y')
-            z2 = getattr( self.species2, 'z')
 
             ux1 = getattr( self.species1, 'ux')
             uy1 = getattr( self.species1, 'uy')
@@ -372,12 +147,13 @@ class MCCollisions(object):
                                 npart2, prefix_sum2,
                                 d_invvol, Nz )
             
-            # Calculate temperature in each cell
+            # Calculate temperature of species 1 in each cell
             temperature1 = allocate_empty(N_cells, use_cuda, dtype=np.float64)
             temperature_per_cell_cuda[ bpg, tpg ]( N_cells, temperature1, npart1,
                                 prefix_sum1, m1,
                                 ux1, uy1, uz1 )
 
+            # Calculate temperature of species 2 in each cell
             temperature2 = allocate_empty(N_cells, use_cuda, dtype=np.float64)
             temperature_per_cell_cuda[ bpg, tpg ]( N_cells, temperature2, npart2,
                                 prefix_sum2, m2,
@@ -412,10 +188,7 @@ class MCCollisions(object):
 
             # Calculate sum of minimum weights in each cell
             n12 = allocate_empty(N_cells, use_cuda, dtype=np.float64)
-            #n12_per_cell_cuda[ bpg, tpg ]( N_cells, n12, w1, w2, npart1,
-            #                                prefix_sum1, prefix_sum2 )
-
-            alt_n12_per_cell_cuda[ bpg, tpg ]( N_cells, n12, w1, w2,
+            n12_per_cell_cuda[ bpg, tpg ]( N_cells, n12, w1, w2,
                       npairs, shuffled_idx1, shuffled_idx2,
 					  prefix_sum_pair, prefix_sum1, prefix_sum2 )
 
@@ -452,22 +225,6 @@ class MCCollisions(object):
             N_batch = int( npairs_tot  / self.batch_size ) + 1
             seed = np.random.randint( 256 )
             random_states = create_xoroshiro128p_states( N_batch, seed )
-            """
-            print("shuffled_idx1: ", cupy.max(shuffled_idx1))
-            print("shuffled_idx2: ", cupy.max(shuffled_idx2))
-            print("cell_idx: ", cupy.max(cell_idx))
-            print("temperature1: ", cupy.max(temperature1))
-            print("temperature2: ", cupy.max(temperature2))
-            print("n1: ", cupy.max(n1))
-            print("n2: ", cupy.max(n2))
-            print("n12: ", cupy.max(n12))
-            print("ux1: ", cupy.max(ux1))
-            print("uy1: ", cupy.max(uy1))
-            print("uz1: ", cupy.max(uz1))
-            print("ux2: ", cupy.max(ux2))
-            print("uy2: ", cupy.max(uy2))
-            print("uz2: ", cupy.max(uz2))
-            """
             bpg, tpg = cuda_tpb_bpg_1d( N_batch )
             perform_collisions_cuda[ bpg, tpg ]( N_batch, 
                         self.batch_size, npairs_tot,
@@ -477,34 +234,10 @@ class MCCollisions(object):
                         q1, q2, w1, w2,
                         ux1, uy1, uz1,
                         ux2, uy2, uz2,
-                        x1, y1, z1,
-                        x2, y2, z2,
-                        dt, self.coulomb_log,
-                        temperature1, temperature2,
-                        random_states )
-            
-            """
-            self.test_perform_collisions_cuda( N_batch, 
-                        self.batch_size, npairs_tot,
-                        prefix_sum1, prefix_sum2,
-                        shuffled_idx1, shuffled_idx2, cell_idx,
-                        n1, n2, n12, m1, m2,
-                        q1, q2, w1, w2,
-                        ux1, uy1, uz1,
-                        ux2, uy2, uz2,
-                        x1, y1, z1,
-                        x2, y2, z2,
                         dt, self.coulomb_log,
                         temperature1, temperature2,
                         random_states )
 
-            print("sol ux1: ", cupy.max(ux1))
-            print("sol uy1: ", cupy.max(uy1))
-            print("sol uz1: ", cupy.max(uz1))
-            print("sol ux2: ", cupy.max(ux2))
-            print("sol uy2: ", cupy.max(uy2))
-            print("sol uz2: ", cupy.max(uz2))
-            """
             setattr(self.species1.ux, 'ux', ux1)
             setattr(self.species1.uy, 'uy', uy1)
             setattr(self.species1.uz, 'uz', uz1)

--- a/fbpic/particles/elementary_process/collisions/collisions.py
+++ b/fbpic/particles/elementary_process/collisions/collisions.py
@@ -193,7 +193,8 @@ class MCCollisions(object):
             n12 = allocate_empty(N_cells, use_cuda, dtype=np.float64)
             n12_per_cell_cuda[ bpg, tpg ](N_cells, n12, w1, w2,
                       npairs, shuffled_idx1, shuffled_idx2,
-					  prefix_sum_pair, prefix_sum1, prefix_sum2)
+					  prefix_sum_pair, prefix_sum1, prefix_sum2,
+                      d_invvol, Nz)
             
             param_s = allocate_empty(npairs_tot, use_cuda, dtype=np.float64)
             param_logL = allocate_empty(npairs_tot, use_cuda, dtype=np.float64)

--- a/fbpic/particles/elementary_process/collisions/collisions.py
+++ b/fbpic/particles/elementary_process/collisions/collisions.py
@@ -6,6 +6,7 @@ This file is part of the Fourier-Bessel Particle-In-Cell code (FBPIC)
 It defines the class that performs calculation of Monte-Carlo collisions.
 """
 import numpy as np
+import random
 import math as m
 import cupy
 from scipy.constants import c, k, epsilon_0, e
@@ -72,6 +73,222 @@ class MCCollisions(object):
         if self.use_cuda:
             self.handle_collisions_gpu( fld, dt )
 
+    def test_perform_collisions_cuda(self, N_batch, batch_size, npairs_tot,
+                        	prefix_sum1, prefix_sum2,
+                            shuffled_idx1, shuffled_idx2, cell_idx,
+                            n1, n2, n12, m1, m2,
+                            q1, q2, w1, w2,
+                            ux1, uy1, uz1,
+                            ux2, uy2, uz2,
+							x1, y1, z1,
+                        	x2, y2, z2,
+                            dt, coulomb_log,
+                            T1, T2,
+                            random_states):
+        """
+        Perform collisions between all pairs in each cell
+        """
+        # Loop over batch of particle pairs and perform collision
+        for i in range (N_batch):
+            # Loop through the batch
+            N_max = min( (i+1)*batch_size, npairs_tot )
+            for ip in range( i*batch_size, N_max ):
+                cell = cell_idx[ip]
+
+                if cell > 0:
+                    si1 = int( shuffled_idx1[ip] + prefix_sum1[cell-1] )
+                    si2 = int( shuffled_idx2[ip] + prefix_sum2[cell-1] )
+                else:
+                    si1 = int( shuffled_idx1[ip] )
+                    si2 = int( shuffled_idx2[ip] )
+
+                r1 = m.sqrt( x1[si1]**2 + y1[si1]**2 )
+
+                r2 = m.sqrt( x2[si2]**2 + y2[si2]**2 )
+
+                distance = m.sqrt( (r1 - r2)**2 + (z1[si1] - z2[si2])**2 )
+                
+                Debye2 = (epsilon_0 * k / e**2) / (n1[cell] / T1[cell] + n1[cell] / T2[cell])
+
+                # Choose to collide pairs that are within a Debye sphere
+                #if distance < m.sqrt(Debye2):
+                if distance < 0.1:
+                    # Effective time interval for the collisions
+                    corr_dt = dt * n12[cell] / n1[cell]
+
+                    px1 = ux1[si1] * (m1 * c)
+                    py1 = uy1[si1] * (m1 * c) 
+                    pz1 = uz1[si1] * (m1 * c)
+
+                    print("px1", px1)
+                    print("py1", py1)
+                    print("pz1", pz1)
+
+
+                    px2 = ux2[si2] * (m2 * c)
+                    py2 = uy2[si2] * (m2 * c) 
+                    pz2 = uz2[si2] * (m2 * c)
+
+                    print("px2", px2)
+                    print("py2", py2)
+                    print("pz2", pz2)
+
+                    inv_m1 = 1. / m1
+                    vx1 = px1 * inv_m1
+                    vy1 = py1 * inv_m1
+                    vz1 = pz1 * inv_m1
+
+                    inv_m2 = 1. / m2
+                    vx2 = px2 * inv_m2
+                    vy2 = py2 * inv_m2
+                    vz2 = pz2 * inv_m2
+
+                    print("vx1", vx1)
+                    print("vy1", vy1)
+                    print("vz1", vz1)
+
+                    print("vx2", vx2)
+                    print("vy2", vy2)
+                    print("vz2", vz2)
+
+                    print((vx1**2 + vy1**2 + vz1**2) / c**2)
+                    print((vx2**2 + vy2**2 + vz2**2) / c**2)
+
+                    # Calculate Lorentz factor
+                    gamma1 = m.sqrt(1. + (vx1**2 + vy1**2 + vz1**2) / c**2)
+                    gamma2 = m.sqrt(1. + (vx2**2 + vy2**2 + vz2**2) / c**2)
+
+
+                    g12 = m1 * gamma1 + m2 * gamma2
+                    inv_g12 = 1. / g12
+
+                    gamma12 = m1 * gamma1 * m2 * gamma2
+                    invgamma12 = 1. / gamma12
+
+                    # Center of mass (COM) velocity
+                    COM_vx = (px1 + px2) * inv_g12
+                    COM_vy = (py1 + py2) * inv_g12
+                    COM_vz = (pz1 + pz2) * inv_g12
+
+                    COM_v_v1 = (COM_vx * vx1 + COM_vy * vy1 + COM_vz * vz1)
+                    COM_v_v2 = (COM_vx * vx2 + COM_vy * vy2 + COM_vz * vz2)
+
+                    COM_v2 = COM_vx**2 + COM_vy**2 + COM_vz**2
+                    COM_gamma = 1. / m.sqrt(1. - COM_v2 / c**2)
+
+                    # momenta in COM
+                    px_COM = px1 + ((COM_gamma - 1.) * COM_v_v1 / COM_v2
+                                            - COM_gamma) * m1 * gamma1 * COM_vx
+                    py_COM = py1 + ((COM_gamma - 1.) * COM_v_v1 / COM_v2
+                                            - COM_gamma) * m1 * gamma1 * COM_vy
+                    pz_COM = pz1 + ((COM_gamma - 1.) * COM_v_v1 / COM_v2
+                                            - COM_gamma) * m1 * gamma1 * COM_vz
+
+                    p_COM = m.sqrt(px_COM**2 + py_COM**2 + pz_COM**2)
+                    invp_COM = 1. / p_COM
+                    invp_COM2 = 1. / p_COM**2
+
+                    # Lorentz transforms
+                    gamma1_COM = (1 - COM_v_v1 / c**2) * COM_gamma * gamma1
+                    gamma2_COM = (1 - COM_v_v2 / c**2) * COM_gamma * gamma2
+
+                    # Calculate coulomb log if not user-defined
+                    qq = q1 * q2
+                    qq2 = qq**2
+                    if coulomb_log <= 0.:
+                        coeff = 1. / (4 * m.pi * epsilon_0 * c**2)
+                        b0 = coeff * qq * COM_gamma * inv_g12 * \
+                            (m1 * gamma1_COM * m2 * gamma2_COM * invp_COM2 * c**2 + 1.)**2
+                        bmin = max(0.5 * h * invp_COM, b0)
+                        coulomb_log = 0.5 * m.log(1. + Debye2 / bmin**2)
+                        if coulomb_log < 2.:
+                            coulomb_log = 2.
+
+                    term1 = n1[cell] * n2[cell] / n12[cell]
+                    term2 = corr_dt * coulomb_log * qq2 * \
+                        invgamma12 / (4. * m.pi * epsilon_0**2 * c**4)
+                    term3 = gamma2_COM * p_COM * inv_g12 * \
+                        (m1 * gamma1_COM * m2 * gamma2_COM * invp_COM2 * c**2 + 1.)**2
+
+                    # Calculate the collision parameter s12
+                    s12 = term1 * term2 * term3
+
+                    # Low temperature correction
+                    v_rel = m.sqrt((vx1 - vx2)**2
+                                + (vy1 - vy2)**2
+                                + (vz1 - vz2)**2)
+                    s_prime = (4.*m.pi/3)**(1/3) * term1 * corr_dt * \
+                        ((m1 + m2) / max(m1 * n1[cell]**(2/3), m2 * n2[cell]**(2/3))) * \
+                        v_rel
+
+                    s = min(s12, s_prime)
+
+                    # Random azimuthal angle
+                    phi = random.random()*2.0 * m.pi
+                    #phi = xoroshiro128p_uniform_float64(random_states, i) * 2.0 * m.pi
+
+                    # Calculate the deflection angle
+                    U = random.random()
+                    #U = xoroshiro128p_uniform_float64(
+                    #    random_states, i)    # random float [0,1]
+                    if s12 < 4:
+                        a = 0.37 * s - 0.005 * s**2 - 0.0064 * s**3
+                        sin2X2 = a * U / m.sqrt(1 - U + a**2 * U)
+                        cosX = 1. - 2. * sin2X2
+                        sinX = 2. * m.sqrt(sin2X2 * (1. - sin2X2))
+                    else:
+                        cosX = 2. * U - 1.
+                        sinX = m.sqrt(1. - cosX * cosX)
+                    sinXcosPhi = sinX * m.cos(phi)
+                    sinXsinPhi = sinX * m.sin(phi)
+
+                    p_perp_COM = m.sqrt(px_COM**2 + py_COM**2)
+                    invp = 1. / p_perp_COM
+
+                    # Resulting momentum in COM frame
+                    if (p_perp_COM > 1.e-10 * p_COM):
+                        pxf1_COM = (px_COM * pz_COM * invp * sinXcosPhi
+                                    - py_COM * p_COM * invp * sinXsinPhi
+                                    + px_COM * cosX)
+                        pyf1_COM = (py_COM * pz_COM * invp * sinXcosPhi
+                                    + px_COM * p_COM * invp * sinXsinPhi
+                                    + py_COM * cosX)
+                        pzf1_COM = (-p_perp_COM * sinXcosPhi
+                                    + pz_COM * cosX)
+                    else:
+                        pxf1_COM = p_COM * sinXcosPhi
+                        pyf1_COM = p_COM * sinXsinPhi
+                        pzf1_COM = p_COM * cosX
+
+                    vC_pfCOM = (COM_vx * pxf1_COM
+                                + COM_vy * pyf1_COM
+                                + COM_vz * pzf1_COM)
+
+                    # Resulting momentum in lab frame
+                    pxf1 = pxf1_COM + COM_vx * \
+                        ((COM_gamma - 1.) * vC_pfCOM / COM_v2 + m1 * gamma1_COM * COM_gamma)
+                    pyf1 = pyf1_COM + COM_vy * \
+                        ((COM_gamma - 1.) * vC_pfCOM / COM_v2 + m1 * gamma1_COM * COM_gamma)
+                    pzf1 = pzf1_COM + COM_vz * \
+                        ((COM_gamma - 1.) * vC_pfCOM / COM_v2 + m1 * gamma1_COM * COM_gamma)
+
+                    U1 = random.random()
+                    #U1 = xoroshiro128p_uniform_float64(
+                    #    random_states, i)    # random float [0,1]
+                    if U1 * w1[si1] < w2[si2]:
+                        # Deflect particle 1
+                        inv_norm1 = 1. / (m1 * c)
+                        ux1[si1] = pxf1 * inv_norm1
+                        uy1[si1] = pyf1 * inv_norm1
+                        uz1[si1] = pzf1 * inv_norm1
+
+                    if U1 * w2[si2] < w1[si1]:
+                        # Deflect particle 2 (pf2 = -pf1)
+                        inv_norm2 = 1. / (m2 * c)
+                        ux2[si2] = -pxf1 * inv_norm2
+                        uy2[si2] = -pyf1 * inv_norm2
+                        uz2[si2] = -pzf1 * inv_norm2
+
     @catch_gpu_memory_error
     def handle_collisions_gpu( self, fld, dt ):
             """
@@ -105,9 +322,9 @@ class MCCollisions(object):
             y1 = getattr( self.species1, 'y')
             z1 = getattr( self.species1, 'z')
 
-            x2 = getattr( self.species1, 'x')
-            y2 = getattr( self.species1, 'y')
-            z2 = getattr( self.species1, 'z')
+            x2 = getattr( self.species2, 'x')
+            y2 = getattr( self.species2, 'y')
+            z2 = getattr( self.species2, 'z')
 
             ux1 = getattr( self.species1, 'ux')
             uy1 = getattr( self.species1, 'uy')
@@ -229,7 +446,22 @@ class MCCollisions(object):
             N_batch = int( npairs_tot  / self.batch_size ) + 1
             seed = np.random.randint( 256 )
             random_states = create_xoroshiro128p_states( N_batch, seed )
-
+            """
+            print("shuffled_idx1: ", cupy.max(shuffled_idx1))
+            print("shuffled_idx2: ", cupy.max(shuffled_idx2))
+            print("cell_idx: ", cupy.max(cell_idx))
+            print("temperature1: ", cupy.max(temperature1))
+            print("temperature2: ", cupy.max(temperature2))
+            print("n1: ", cupy.max(n1))
+            print("n2: ", cupy.max(n2))
+            print("n12: ", cupy.max(n12))
+            print("ux1: ", cupy.max(ux1))
+            print("uy1: ", cupy.max(uy1))
+            print("uz1: ", cupy.max(uz1))
+            print("ux2: ", cupy.max(ux2))
+            print("uy2: ", cupy.max(uy2))
+            print("uz2: ", cupy.max(uz2))
+            """
             bpg, tpg = cuda_tpb_bpg_1d( N_batch )
             perform_collisions_cuda[ bpg, tpg ]( N_batch, 
                         self.batch_size, npairs_tot,
@@ -244,7 +476,29 @@ class MCCollisions(object):
                         dt, self.coulomb_log,
                         temperature1, temperature2,
                         random_states )
+            
+            """
+            self.test_perform_collisions_cuda( N_batch, 
+                        self.batch_size, npairs_tot,
+                        prefix_sum1, prefix_sum2,
+                        shuffled_idx1, shuffled_idx2, cell_idx,
+                        n1, n2, n12, m1, m2,
+                        q1, q2, w1, w2,
+                        ux1, uy1, uz1,
+                        ux2, uy2, uz2,
+                        x1, y1, z1,
+                        x2, y2, z2,
+                        dt, self.coulomb_log,
+                        temperature1, temperature2,
+                        random_states )
 
+            print("sol ux1: ", cupy.max(ux1))
+            print("sol uy1: ", cupy.max(uy1))
+            print("sol uz1: ", cupy.max(uz1))
+            print("sol ux2: ", cupy.max(ux2))
+            print("sol uy2: ", cupy.max(uy2))
+            print("sol uz2: ", cupy.max(uz2))
+            """
             setattr(self.species1.ux, 'ux', ux1)
             setattr(self.species1.uy, 'uy', uy1)
             setattr(self.species1.uz, 'uz', uz1)

--- a/fbpic/particles/elementary_process/collisions/collisions.py
+++ b/fbpic/particles/elementary_process/collisions/collisions.py
@@ -214,14 +214,6 @@ class MCCollisions(object):
                         dt, self.coulomb_log,
                         random_states, self.period, self.debug,
                         param_s, param_logL)
-
-            cupy.cuda.runtime.deviceSynchronize()
-
-            print("first s:", param_s[0])
-            print("last s:", param_s[-1])
-
-            print("first logL:", param_logL[0])
-            print("last logL:", param_logL[-1])
             
             if self.debug:
                 Ncp_1 = np.count_nonzero(self.species1.temperature)

--- a/fbpic/particles/elementary_process/collisions/cuda_methods.py
+++ b/fbpic/particles/elementary_process/collisions/cuda_methods.py
@@ -49,101 +49,74 @@ def density_per_cell_cuda(N_batch, density, weights, npart,
         density[i] = sum * invvol
 
 
-
-
-@compile_cupy
-def alt_n12_per_cell_cuda(N_batch, n12, w1, w2,
-                    npairs, shuffled_idx1, shuffled_idx2,
-					prefix_sum_pair, prefix_sum1, prefix_sum2):
-	"""
-	Calculate n12 of species per cell
-	n12 is the sum of minimum species weights
-	"""
-	# Loop over cells
-	i = cuda.grid(1)
-	# Loop over batch of particle pairs and perform collision
-	if i < N_batch:
-		# Loop through the batch
-		if i > 0:
-			i_min1 = int( prefix_sum1[i-1] )
-			i_min2 = int( prefix_sum2[i-1] )
-			p_min = int( prefix_sum_pair[i-1] )
-		else:
-			i_min1 = 0
-			i_min2 = 0
-			p_min = 0
-		sum = 0.
-		for j in range(int(npairs[i])):
-			si1 = shuffled_idx1[p_min + j]
-			si2 = shuffled_idx2[p_min + j]
-			if w1[i_min1+si1] < w2[i_min2+si2]:
-				sum += w1[i_min1+si1]
-			else:
-				sum += w2[i_min2+si2]
-		n12[i] = sum
-
 @compile_cupy
 def n12_per_cell_cuda(N_batch, n12, w1, w2,
-                      npart1, prefix_sum1, prefix_sum2):
+                      npairs, shuffled_idx1, shuffled_idx2,
+                      prefix_sum_pair, prefix_sum1, prefix_sum2):
     """
     Calculate n12 of species per cell
-	n12 is the sum of minimum species weights
+    n12 is the sum of minimum species weights
     """
+    # Loop over cells
     i = cuda.grid(1)
+    # Loop over batch of particle pairs and perform collision
     if i < N_batch:
-        if npart1[i] == 0:
-            n12[i] = 0.
+        # Loop through the batch
+        if i > 0:
+            i_min1 = int(prefix_sum1[i-1])
+            i_min2 = int(prefix_sum2[i-1])
+            p_min = int(prefix_sum_pair[i-1])
         else:
-            if i > 0:
-                i_min1 = int(prefix_sum1[i-1])
-                i_min2 = int(prefix_sum2[i-1])
+            i_min1 = 0
+            i_min2 = 0
+            p_min = 0
+        sum = 0.
+        for j in range(int(npairs[i])):
+            si1 = shuffled_idx1[p_min + j]
+            si2 = shuffled_idx2[p_min + j]
+            if w1[i_min1+si1] < w2[i_min2+si2]:
+                sum += w1[i_min1+si1]
             else:
-                i_min1 = 0
-                i_min2 = 0
-            sum = 0.
-            for j in range(int(npart1[i])):
-                if w1[i_min1+j] < w2[i_min2+j]:
-                    sum += w1[i_min1+j]
-                else:
-                    sum += w2[i_min2+j]
-                n12[i] = sum
+                sum += w2[i_min2+si2]
+        n12[i] = sum
 
 
 @compile_cupy
 def temperature_per_cell_cuda(N_batch, T, npart,
                               prefix_sum, mass,
                               ux, uy, uz):
-	"""
-	Calculate temperature of species in cell
-	"""
-	i = cuda.grid(1)
-	if i < N_batch:
-		if npart[i] == 0:
-			T[i] = 0.
-		else:
-			if i > 0:
-				i_min = int(prefix_sum[i-1])
-			else:
-				i_min = 0
+    """
+    Calculate temperature of species in cell
+    """
+    i = cuda.grid(1)
+    if i < N_batch:
+        if npart[i] == 0:
+            T[i] = 0.
+        else:
+            if i > 0:
+                i_min = int(prefix_sum[i-1])
+            else:
+                i_min = 0
 
-			vx_mean = 0.
-			vy_mean = 0.
-			vz_mean = 0.
-			v2 = 0.
-			for j in range(int(npart[i])):
-				vx_mean += ux[i_min + j] * c
-				vy_mean += uy[i_min + j] * c
-				vz_mean += uz[i_min + j] * c
+            vx_mean = 0.
+            vy_mean = 0.
+            vz_mean = 0.
+            v2 = 0.
+            for j in range(int(npart[i])):
+                vx_mean += ux[i_min + j] * c
+                vy_mean += uy[i_min + j] * c
+                vz_mean += uz[i_min + j] * c
 
-				v2 += (ux[i_min + j]**2 + uy[i_min + j]**2 + uz[i_min + j]**2) * c**2
+                v2 += (ux[i_min + j]**2 + uy[i_min + j]
+                       ** 2 + uz[i_min + j]**2) * c**2
 
-			invNp = (1. / npart[i])
-			v2 *= invNp
-			vx_mean *= invNp
-			vy_mean *= invNp
-			vz_mean *= invNp
-			u_mean2 = vx_mean**2 + vy_mean**2 + vz_mean**2
-			T[i] = ( mass / (3. * k ) ) * (v2 - u_mean2)
+            invNp = (1. / npart[i])
+            v2 *= invNp
+            vx_mean *= invNp
+            vy_mean *= invNp
+            vz_mean *= invNp
+            u_mean2 = vx_mean**2 + vy_mean**2 + vz_mean**2
+            T[i] = (mass / (3. * k)) * (v2 - u_mean2)
 
 
 @compile_cupy
@@ -156,14 +129,14 @@ def get_cell_idx_per_pair_cuda(N_batch, cell_idx, npair, prefix_sum_pair):
     Parameters
     ----------
     cell_idx : 1darray of integers
-            	The cell index of the pair
+                The cell index of the pair
 
     npair : 1darray of integers
-            	The particle pair array
+                The particle pair array
 
-	prefix_sum_pair : 1darray of integers
-				Cumulative prefix sum of
-				the particle pair array		
+        prefix_sum_pair : 1darray of integers
+                                Cumulative prefix sum of
+                                the particle pair array		
     """
     i = cuda.grid(1)
     if i < N_batch:
@@ -177,230 +150,229 @@ def get_cell_idx_per_pair_cuda(N_batch, cell_idx, npair, prefix_sum_pair):
             cell_idx[s+k] = i
             k += 1
 
+
 @cuda.jit
 def get_shuffled_idx_per_particle_cuda(N_batch, shuffled_idx, npart,
-										npair, prefix_sum_pair, random_states):
-	"""
-	Get the shuffled index of each particle in the array of pairs.
-	The particles are shuffled with a linear congruential generator
-	that is cyclic and non-repeating.
+                                       npair, prefix_sum_pair, random_states):
+    """
+    Get the shuffled index of each particle in the array of pairs.
+    The particles are shuffled with a linear congruential generator
+    that is cyclic and non-repeating.
 
-	Parameters
-	----------
-	shuffled_idx : 1darray of integers
-				The shuffled particle index of the particle
+    Parameters
+    ----------
+    shuffled_idx : 1darray of integers
+                            The shuffled particle index of the particle
 
-	npart : 1darray of integers
-				The particle array
-	
-	npair : 1darray of integers
-				The particle pair array
+    npart : 1darray of integers
+                            The particle array
 
-	prefix_sum_pair : 1darray of integers
-				Cumulative prefix sum of
-				the pair array	
-	
-	random_states : random states of the random generator
-	"""
-	i = cuda.grid(1)
-	if i < N_batch:
-		if i > 0:
-			s = prefix_sum_pair[i-1]
-		else:
-			s = 0
-		p = npart[i]
+    npair : 1darray of integers
+                            The particle pair array
 
-		value = int(xoroshiro128p_uniform_float64(random_states, i) * p)
+    prefix_sum_pair : 1darray of integers
+                            Cumulative prefix sum of
+                            the pair array	
 
-		offset = int(xoroshiro128p_uniform_float64(random_states, i) * p) * 2 + 1
-		multiplier = 4*(p//4) + 1
-		modulus = int( 2**(m.ceil(m.log2(p))) )
+    random_states : random states of the random generator
+    """
+    i = cuda.grid(1)
+    if i < N_batch:
+        if i > 0:
+            s = prefix_sum_pair[i-1]
+        else:
+            s = 0
+        p = npart[i]
 
-		k = 0
-		while k < npair[i]:
-			if k < p:
-				if value < p:
-					shuffled_idx[s+k] = value
-					k += 1
-				# Calculate the next value in the sequence.
-				value = (value*multiplier + offset) % modulus
-			else:
-				shuffled_idx[s+k] = shuffled_idx[s+k-p]
-				k += 1
+        value = int(xoroshiro128p_uniform_float64(random_states, i) * p)
+
+        offset = int(xoroshiro128p_uniform_float64(
+            random_states, i) * p) * 2 + 1
+        multiplier = 4*(p//4) + 1
+        modulus = int(2**(m.ceil(m.log2(p))))
+
+        k = 0
+        while k < npair[i]:
+            if k < p:
+                if value < p:
+                    shuffled_idx[s+k] = value
+                    k += 1
+                # Calculate the next value in the sequence.
+                value = (value*multiplier + offset) % modulus
+            else:
+                shuffled_idx[s+k] = shuffled_idx[s+k-p]
+                k += 1
+
+
 @cuda.jit
 def perform_collisions_cuda(N_batch, batch_size, npairs_tot,
-                        	prefix_sum1, prefix_sum2,
+                            prefix_sum1, prefix_sum2,
                             shuffled_idx1, shuffled_idx2, cell_idx,
                             n1, n2, n12, m1, m2,
                             q1, q2, w1, w2,
                             ux1, uy1, uz1,
                             ux2, uy2, uz2,
-							x1, y1, z1,
-                        	x2, y2, z2,
                             dt, coulomb_log,
                             T1, T2,
                             random_states):
-	"""
-	Perform collisions between all pairs in each cell
-	"""
-	# Loop over cells
-	i = cuda.grid(1)
-	# Loop over batch of particle pairs and perform collision
-	if i < N_batch:
-		# Loop through the batch
-		N_max = min( (i+1)*batch_size, npairs_tot )
-		for ip in range( i*batch_size, N_max ):
-			cell = cell_idx[ip]
+    """
+    Perform collisions between all pairs in each cell
+    """
+    # Loop over cells
+    i = cuda.grid(1)
+    # Loop over batch of particle pairs and perform collision
+    if i < N_batch:
+        # Loop through the batch
+        N_max = min((i+1)*batch_size, npairs_tot)
+        for ip in range(i*batch_size, N_max):
+            # The particles are randomly paired in each cell
+            # with a linear congruential generator which
+            # shuffles the particles in a non-repeating manner.
+            # Note: plasma heating due to collisions can
+            # be reduced in certain cases with a 'nearest neighbor'
+            # pairing. This can be achieved with a finer
+            # grid in the particle sorting.
+            cell = cell_idx[ip]
+            if cell > 0:
+                si1 = int(shuffled_idx1[ip] + prefix_sum1[cell-1])
+                si2 = int(shuffled_idx2[ip] + prefix_sum2[cell-1])
+            else:
+                si1 = int(shuffled_idx1[ip])
+                si2 = int(shuffled_idx2[ip])
 
-			if cell > 0:
-				si1 = int( shuffled_idx1[ip] + prefix_sum1[cell-1] )
-				si2 = int( shuffled_idx2[ip] + prefix_sum2[cell-1] )
-			else:
-				si1 = int( shuffled_idx1[ip] )
-				si2 = int( shuffled_idx2[ip] )
+            # Calculate Lorentz factor
+            gamma1 = m.sqrt(1. + (ux1[si1]**2 + uy1[si1]**2 + uz1[si1]**2))
+            gamma2 = m.sqrt(1. + (ux2[si2]**2 + uy2[si2]**2 + uz2[si2]**2))
 
-			r1 = m.sqrt( x1[si1]**2 + y1[si1]**2 )
+            m12 = m1 / m2
 
-			r2 = m.sqrt( x2[si2]**2 + y2[si2]**2 )
+            g12 = m12 * gamma1 + gamma2
+            inv_g12 = 1. / g12
 
-			distance = m.sqrt( (r1 - r2)**2 + (z1[si1] - z2[si2])**2 )
-			
-			Debye2 = (epsilon_0 * k / e**2) / (n1[cell] / T1[cell] + n1[cell] / T2[cell])
+            gamma12 = gamma1 * gamma2
+            invgamma12 = 1. / gamma12
 
-			# Choose to collide pairs that are within a Debye sphere
-			#if distance < m.sqrt(Debye2):
-			if distance < 1.e-4:	
-			#if distance < 0.1:
+            # Center of mass (COM) velocity
+            COM_vx = (m12 * ux1[si1] + ux2[si2]) * inv_g12
+            COM_vy = (m12 * uy1[si1] + uy2[si2]) * inv_g12
+            COM_vz = (m12 * uz1[si1] + uz2[si2]) * inv_g12
 
-				# Calculate Lorentz factor
-				gamma1 = m.sqrt(1. + (ux1[si1]**2 + uy1[si1]**2 + uz1[si1]**2))
-				gamma2 = m.sqrt(1. + (ux2[si2]**2 + uy2[si2]**2 + uz2[si2]**2))
+            COM_v_u1 = (COM_vx * ux1[si1] + COM_vy *
+                        uy1[si1] + COM_vz * uz1[si1])
+            COM_v_u2 = (COM_vx * ux2[si2] + COM_vy *
+                        uy2[si2] + COM_vz * uz2[si2])
 
-				m12 = m1 / m2
+            COM_v2 = COM_vx**2 + COM_vy**2 + COM_vz**2
+            COM_gamma = 1. / m.sqrt(1. - COM_v2)
 
-				g12 = m12 * gamma1 + gamma2
-				inv_g12 = 1. / g12
+            # momenta in COM
+            ux_COM = ux1[si1] + ((COM_gamma - 1.) * COM_v_u1 / COM_v2
+                                 - COM_gamma * gamma1) * COM_vx
+            uy_COM = uy1[si1] + ((COM_gamma - 1.) * COM_v_u1 / COM_v2
+                                 - COM_gamma * gamma1) * COM_vy
+            uz_COM = uz1[si1] + ((COM_gamma - 1.) * COM_v_u1 / COM_v2
+                                 - COM_gamma * gamma1) * COM_vz
 
-				gamma12 = gamma1 * gamma2
-				invgamma12 = 1. / gamma12
+            u2_COM = ux_COM**2 + uy_COM**2 + uz_COM**2
+            u_COM = m.sqrt(u2_COM)
+            invu_COM = 1. / u_COM
+            invu_COM2 = 1. / u2_COM
 
-				# Center of mass (COM) velocity
-				COM_vx = (m12 * ux1[si1] + ux2[si2]) * inv_g12
-				COM_vy = (m12 * uy1[si1] + uy2[si2]) * inv_g12
-				COM_vz = (m12 * uz1[si1] + uz2[si2]) * inv_g12
+            # Lorentz transforms
+            gamma1_COM = (gamma1 - COM_v_u1) * COM_gamma
+            gamma2_COM = (gamma2 - COM_v_u2) * COM_gamma
 
-				COM_v_u1 = (COM_vx * ux1[si1] + COM_vy * uy1[si1] + COM_vz * uz1[si1])
-				COM_v_u2 = (COM_vx * ux2[si2] + COM_vy * uy2[si2] + COM_vz * uz2[si2])
+            # Calculate coulomb log if not user-defined
+            qqm = q1 * q2 / m1
+            qqm2 = qqm**2
+            if coulomb_log <= 0.:
+                coeff = 1. / (4 * m.pi * epsilon_0 * c**2)
+                b0 = abs(coeff * q1 * q2 * COM_gamma * inv_g12 *
+                         (m1 * gamma1_COM * m2 * gamma2_COM * invu_COM2 + 1.))
+                bmin = max(0.5 * h * invu_COM, b0)
+                Debye2 = (epsilon_0 * k / e**2) / \
+                    (n1[cell] / T1[cell] + n1[cell] / T2[cell])
+                coulomb_log = 0.5 * m.log(1. + Debye2 / bmin**2)
+                if coulomb_log < 2.:
+                    coulomb_log = 2.
 
-				COM_v2 = COM_vx**2 + COM_vy**2 + COM_vz**2
-				COM_gamma = 1. / m.sqrt(1. - COM_v2)
+            coeff1 = 1. / (4. * m.pi * epsilon_0**2 * c**3)
+            term1 = n1[cell] * n2[cell] * dt / n12[cell]
+            term2 = coeff1 * qqm2 * invgamma12
+            term3 = COM_gamma * inv_g12 * u_COM
+            term4 = (gamma1_COM * gamma2_COM * invu_COM2 + m12)
 
-				# momenta in COM
-				px_COM = ux1[si1] + ((COM_gamma - 1.) * COM_v_u1 / COM_v2
-										- COM_gamma * gamma1 ) * COM_vx
-				py_COM = uy1[si1] + ((COM_gamma - 1.) * COM_v_u1 / COM_v2
-										- COM_gamma * gamma1) * COM_vy
-				pz_COM = uz1[si1] + ((COM_gamma - 1.) * COM_v_u1 / COM_v2
-										- COM_gamma * gamma1) * COM_vz
+            # Calculate the collision parameter s12
+            s12 = coulomb_log * term1 * term2 * term3 * term4 * term4
 
-				p2_COM = px_COM**2 + py_COM**2 + pz_COM**2
-				p_COM = m.sqrt(p2_COM)
-				invp_COM = 1. / p_COM
-				invp_COM2 = 1. / p2_COM
+            # Low temperature correction
+            v_rel = m.sqrt((ux1[si1] - ux2[si2])**2
+                           + (uy1[si1] - uy2[si2])**2
+                           + (uz1[si1] - uz2[si2])**2)
+            s_prime = (4.*m.pi/3)**(1/3) * term1 * \
+                ((m1 + m2) / max(m1 * n1[cell]**(2/3), m2 * n2[cell]**(2/3))) * \
+                v_rel
 
-				# Lorentz transforms
-				gamma1_COM = (gamma1 - COM_v_u1) * COM_gamma
-				gamma2_COM = (gamma2 - COM_v_u2) * COM_gamma
+            s = min(s12, s_prime)
 
-				# Calculate coulomb log if not user-defined
-				qqm = q1 * q2 / m1
-				qqm2 = qqm**2
-				if coulomb_log <= 0.:
-					coeff = 1. / (4 * m.pi * epsilon_0 * c**2)
-					b0 = abs(coeff * q1 * q2 * COM_gamma * inv_g12 * \
-						(m1 * gamma1_COM * m2 * gamma2_COM * invp_COM2 + 1.))
-					bmin = max(0.5 * h * invp_COM, b0)
-					coulomb_log = 0.5 * m.log(1. + Debye2 / bmin**2)
-					if coulomb_log < 2.:
-						coulomb_log = 2.
+            # Random azimuthal angle
+            phi = xoroshiro128p_uniform_float64(random_states, i) * 2.0 * m.pi
 
-				coeff1 = 1. / (4. * m.pi * epsilon_0**2 * c**3)
-				term1 = n1[cell] * n2[cell] * dt / n12[cell]
-				term2 = coeff1 * qqm2 * invgamma12
-				term3 = COM_gamma * inv_g12 * p_COM
-				term4 = (gamma1_COM * gamma2_COM * invp_COM2  + m12)
+            # Calculate the deflection angle
+            U = xoroshiro128p_uniform_float64(
+                random_states, i)    # random float [0,1]
+            if s12 < 4:
+                a = 0.37 * s - 0.005 * s**2 - 0.0064 * s**3
+                sin2X2 = a * U / m.sqrt(1 - U + a**2 * U)
+                cosX = 1. - 2. * sin2X2
+                sinX = 2. * m.sqrt(sin2X2 * (1. - sin2X2))
+            else:
+                cosX = 2. * U - 1.
+                sinX = m.sqrt(1. - cosX * cosX)
+            sinXcosPhi = sinX * m.cos(phi)
+            sinXsinPhi = sinX * m.sin(phi)
 
-				# Calculate the collision parameter s12
-				s12 = coulomb_log * term1 * term2 * term3 * term4 * term4
+            u_perp_COM = m.sqrt(ux_COM**2 + uy_COM**2)
+            invu = 1. / u_perp_COM
 
-				# Low temperature correction
-				v_rel = m.sqrt((ux1[si1] - ux2[si2])**2
-							+ (uy1[si1] - uy2[si2])**2
-							+ (uz1[si1] - uz2[si2])**2)
-				s_prime = (4.*m.pi/3)**(1/3) * term1 * \
-					((m1 + m2) / max(m1 * n1[cell]**(2/3), m2 * n2[cell]**(2/3))) * \
-					v_rel
+            # Resulting momentum in COM frame
+            if (u_perp_COM > 1.e-10 * u_COM):
+                uxf1_COM = (ux_COM * uz_COM * invu * sinXcosPhi
+                            - uy_COM * u_COM * invu * sinXsinPhi
+                            + ux_COM * cosX)
+                uyf1_COM = (uy_COM * uz_COM * invu * sinXcosPhi
+                            + ux_COM * u_COM * invu * sinXsinPhi
+                            + uy_COM * cosX)
+                uzf1_COM = (-u_perp_COM * sinXcosPhi
+                            + uz_COM * cosX)
+            else:
+                uxf1_COM = u_COM * sinXcosPhi
+                uyf1_COM = u_COM * sinXsinPhi
+                uzf1_COM = u_COM * cosX
 
-				s = min(s12, s_prime)
+            vC_ufCOM = (COM_vx * uxf1_COM
+                        + COM_vy * uyf1_COM
+                        + COM_vz * uzf1_COM)
 
-				# Random azimuthal angle
-				phi = xoroshiro128p_uniform_float64(random_states, i) * 2.0 * m.pi
+            U1 = xoroshiro128p_uniform_float64(
+                random_states, i)    # random float [0,1]
+            if U1 * w1[si1] < w2[si2]:
+                # Deflect particle 1
+                ux1[si1] = uxf1_COM + COM_vx * \
+                    ((COM_gamma - 1.) * vC_ufCOM / COM_v2 + gamma1_COM * COM_gamma)
+                uy1[si1] = uyf1_COM + COM_vy * \
+                    ((COM_gamma - 1.) * vC_ufCOM / COM_v2 + gamma1_COM * COM_gamma)
+                uz1[si1] = uzf1_COM + COM_vz * \
+                    ((COM_gamma - 1.) * vC_ufCOM / COM_v2 + gamma1_COM * COM_gamma)
 
-				# Calculate the deflection angle
-				U = xoroshiro128p_uniform_float64(
-					random_states, i)    # random float [0,1]
-				if s12 < 4:
-					a = 0.37 * s - 0.005 * s**2 - 0.0064 * s**3
-					sin2X2 = a * U / m.sqrt(1 - U + a**2 * U)
-					cosX = 1. - 2. * sin2X2
-					sinX = 2. * m.sqrt(sin2X2 * (1. - sin2X2))
-				else:
-					cosX = 2. * U - 1.
-					sinX = m.sqrt(1. - cosX * cosX)
-				sinXcosPhi = sinX * m.cos(phi)
-				sinXsinPhi = sinX * m.sin(phi)
-
-				p_perp_COM = m.sqrt(px_COM**2 + py_COM**2)
-				invp = 1. / p_perp_COM
-
-				# Resulting momentum in COM frame
-				if (p_perp_COM > 1.e-10 * p_COM):
-					pxf1_COM = (px_COM * pz_COM * invp * sinXcosPhi
-								- py_COM * p_COM * invp * sinXsinPhi
-								+ px_COM * cosX)
-					pyf1_COM = (py_COM * pz_COM * invp * sinXcosPhi
-								+ px_COM * p_COM * invp * sinXsinPhi
-								+ py_COM * cosX)
-					pzf1_COM = (-p_perp_COM * sinXcosPhi
-								+ pz_COM * cosX)
-				else:
-					pxf1_COM = p_COM * sinXcosPhi
-					pyf1_COM = p_COM * sinXsinPhi
-					pzf1_COM = p_COM * cosX
-
-				vC_pfCOM = (COM_vx * pxf1_COM
-							+ COM_vy * pyf1_COM
-							+ COM_vz * pzf1_COM)
-
-				U1 = xoroshiro128p_uniform_float64(
-					random_states, i)    # random float [0,1]
-				if U1 * w1[si1] < w2[si2]:
-					# Deflect particle 1
-					ux1[si1] = pxf1_COM + COM_vx * \
-								((COM_gamma - 1.) * vC_pfCOM / COM_v2 + gamma1_COM * COM_gamma)
-					uy1[si1] = pyf1_COM + COM_vy * \
-								((COM_gamma - 1.) * vC_pfCOM / COM_v2 + gamma1_COM * COM_gamma)
-					uz1[si1] = pzf1_COM + COM_vz * \
-								((COM_gamma - 1.) * vC_pfCOM / COM_v2 + gamma1_COM * COM_gamma)
-
-				if U1 * w2[si2] < w1[si1]:
-					# Deflect particle 2 (pf2 = -pf1)
-					ux2[si2] = -pxf1_COM * m12 + COM_vx * \
-								(-(COM_gamma - 1.) * m12 * vC_pfCOM / COM_v2 \
-								+ gamma2_COM * COM_gamma)
-					uy2[si2] = -pyf1_COM * m12 + COM_vy * \
-								(-(COM_gamma - 1.) * m12 * vC_pfCOM / COM_v2\
-								+ gamma2_COM * COM_gamma)
-					uz2[si2] = -pzf1_COM * m12 + COM_vz * \
-								(-(COM_gamma - 1.) * m12 * vC_pfCOM / COM_v2\
-								+ gamma2_COM * COM_gamma)
+            if U1 * w2[si2] < w1[si1]:
+                # Deflect particle 2 (pf2 = -pf1)
+                ux2[si2] = -uxf1_COM * m12 + COM_vx * \
+                    (-(COM_gamma - 1.) * m12 * vC_ufCOM / COM_v2
+                     + gamma2_COM * COM_gamma)
+                uy2[si2] = -uyf1_COM * m12 + COM_vy * \
+                    (-(COM_gamma - 1.) * m12 * vC_ufCOM / COM_v2
+                     + gamma2_COM * COM_gamma)
+                uz2[si2] = -uzf1_COM * m12 + COM_vz * \
+                    (-(COM_gamma - 1.) * m12 * vC_ufCOM / COM_v2
+                     + gamma2_COM * COM_gamma)

--- a/fbpic/particles/elementary_process/collisions/cuda_methods.py
+++ b/fbpic/particles/elementary_process/collisions/cuda_methods.py
@@ -1,0 +1,321 @@
+# Copyright 2017, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines cuda methods that are used in Compton scattering (on GPU).
+"""
+import math as m
+from numba import cuda
+from scipy.constants import c, k, h, epsilon_0
+from fbpic.utils.cuda import cuda_installed
+if cuda_installed:
+    from fbpic.utils.cuda import compile_cupy
+from numba.cuda.random import xoroshiro128p_uniform_float64
+
+
+@compile_cupy
+def pairs_per_cell_cuda(N_batch, array_in1, array_in2, array_out):
+    """
+    Calculate the number of pairs per cell
+    """
+    i = cuda.grid(1)
+    if i < N_batch:
+        if array_in1[i] == 0 or array_in2[i] == 0:
+            array_out[i] = 0
+        else:
+            if array_in1[i] > array_in2[i]:
+                array_out[i] = array_in1[i]
+            else:
+                array_out[i] = array_in2[i]
+
+
+@compile_cupy
+def density_per_cell_cuda(N_batch, density, weights, npart,
+                          prefix_sum, d_invvol, Nz):
+    """
+    Calculate density of species per cell
+    """
+    i = cuda.grid(1)
+    if i < N_batch:
+        sum = 0.
+        if i > 0:
+            i_min = int(prefix_sum[i-1])
+        else:
+            i_min = 0
+        for j in range(int(npart[i])):
+            sum += weights[i_min + j]
+        invvol = d_invvol[int(i / Nz)]
+        density[i] = sum * invvol
+
+
+@compile_cupy
+def n12_per_cell_cuda(N_batch, n12, w1, w2,
+                      npart1, prefix_sum1, prefix_sum2):
+    """
+    Calculate n12 of species per cell
+	n12 is the sum of minimum species weights
+    """
+    i = cuda.grid(1)
+    if i < N_batch:
+        if npart1[i] == 0:
+            n12[i] = 0.
+        else:
+            if i > 0:
+                i_min1 = int(prefix_sum1[i-1])
+                i_min2 = int(prefix_sum2[i-1])
+            else:
+                i_min1 = 0
+                i_min2 = 0
+            sum = 0.
+            for j in range(int(npart1[i])):
+                if w1[i_min1+j] < w2[i_min2+j]:
+                    sum += w1[i_min1+j]
+                else:
+                    sum += w2[i_min2+j]
+                n12[i] = sum
+
+
+@compile_cupy
+def temperature_per_cell_cuda(N_batch, T, npart,
+                              prefix_sum, mass,
+                              ux, uy, uz):
+    """
+    Calculate temperature of species in cell
+    """
+    i = cuda.grid(1)
+    if i < N_batch:
+        if npart[i] == 0:
+            T[i] = 0.
+        else:
+            if i > 0:
+                i_min = int(prefix_sum[i-1])
+            else:
+                i_min = 0
+
+            ux_mean = 0.
+            uy_mean = 0.
+            uz_mean = 0.
+            v2 = 0.
+            for j in range(int(npart[i])):
+                ux_mean += ux[i_min + j]
+                uy_mean += uy[i_min + j]
+                uz_mean += uz[i_min + j]
+
+                v2 += ux[i_min + j]**2 + uy[i_min + j]**2 + uz[i_min + j]**2
+
+            invNp = (1. / npart[i])
+            v2 *= invNp
+            ux_mean *= invNp
+            uy_mean *= invNp
+            uz_mean *= invNp
+            u_mean2 = ux_mean**2 + uy_mean**2 + uz_mean**2
+            T[i] = (mass / (3. * k)) * (v2 - u_mean2)
+
+
+@compile_cupy
+def get_cell_idx_per_pair(N_batch, cell_idx, npair, prefix_sum_pair):
+    """
+    Get the cell index of each pair.
+    The cell index is 1d and calculated by:
+    prefix sum of pairs
+
+    Parameters
+    ----------
+    cell_idx : 1darray of integers
+            	The cell index of the pair
+
+    npair : 1darray of integers
+            	The particle pair array
+
+	prefix_sum_pair : 1darray of integers
+				Cumulative prefix sum of
+				the particle pair array		
+    """
+    i = cuda.grid(1)
+    if i < N_batch:
+        if i > 0:
+            s = prefix_sum_pair[i-1]
+        else:
+            s = 0
+        p = npair[i]
+        k = 0
+        while k < p:
+            cell_idx[s+k] = i
+            k += 1
+
+
+@cuda.jit
+def perform_collisions_cuda(prefix_sum1, prefix_sum2,
+                            cell_idx, npart1, npart2, npairs_tot,
+                            n1, n2, n12, m1, m2,
+                            q1, q2, w1, w2,
+                            ux1, uy1, uz1,
+                            ux2, uy2, uz2,
+                            dt, coulomb_log,
+                            T1, T2,
+                            random_states):
+    """
+    Perform collisions between all pairs in each cell
+    """
+    # Loop over cells
+    i = cuda.grid(1)
+    # Loop over shuffled pairs and perform collision
+    if i < npairs_tot:
+        cell = cell_idx[i]
+
+		# Note: currently this code does not perform a non-repetitive
+		# shuffle of the particle pairs. This means that certain particles
+		# will be randomly chosen multiple times for collisions. This can be
+		# improved by performing the shuffling separately (prior) to ensure
+		# that no particles are repeated. 
+        if cell > 0:
+            si1 = int(round(xoroshiro128p_uniform_float64(random_states, i)
+                            * (npart1[cell] - 1)) + prefix_sum1[cell-1])
+            si2 = int(round(xoroshiro128p_uniform_float64(random_states, i)
+                            * (npart2[cell] - 1)) + prefix_sum2[cell-1])
+        else:
+            si1 = int(round(xoroshiro128p_uniform_float64(
+                random_states, i) * (npart1[cell] - 1)))
+            si2 = int(round(xoroshiro128p_uniform_float64(
+                random_states, i) * (npart2[cell] - 1)))
+
+        # Effective time interval for the collisions
+        corr_dt = dt * n12[cell] / n1[cell]
+
+        # Calculate Lorentz factor
+        gamma1 = 1. / m.sqrt(1. - (ux1[si1]**2
+                                   + uy1[si1]**2 + uz1[si1]**2) / c**2)
+        gamma2 = 1. / m.sqrt(1. - (ux2[si2]**2
+                                   + uy2[si2]**2 + uz2[si2]**2) / c**2)
+
+        gamma_a12 = m1 * gamma1 + m2 * gamma2
+        invgamma_a12 = 1. / gamma_a12
+        gamma12 = m1 * gamma1 * m2 * gamma2
+        invgamma12 = 1. / gamma12
+
+        # Center of mass (COM) velocity
+        COM_vx = (m1 * ux1[si1] + m2 * ux2[si2]) * invgamma_a12
+        COM_vy = (m1 * uy1[si1] + m2 * uy2[si2]) * invgamma_a12
+        COM_vz = (m1 * uz1[si1] + m2 * uz2[si2]) * invgamma_a12
+
+        vCdotu1 = (COM_vx * ux1[si1]
+                   + COM_vy * uy1[si1]
+                   + COM_vz * uz1[si1])
+        vCdotu2 = (COM_vx * ux2[si2]
+                   + COM_vy * uy2[si2]
+                   + COM_vz * uz2[si2])
+
+        vC2 = COM_vx**2 + COM_vy**2 + COM_vz**2
+        gammaC = 1. / m.sqrt(1. - vC2 / c**2)
+
+        # momenta in COM
+        px_COM = m1 * ux1[si1] + ((gammaC - 1.) * vCdotu1 / vC2
+                                  - gammaC) * m1 * gamma1 * COM_vx
+        py_COM = m1 * uy1[si1] + ((gammaC - 1.) * vCdotu1 / vC2
+                                  - gammaC) * m1 * gamma1 * COM_vy
+        pz_COM = m1 * uz1[si1] + ((gammaC - 1.) * vCdotu1 / vC2
+                                  - gammaC) * m1 * gamma1 * COM_vz
+
+        p_COM = m.sqrt(px_COM**2 + py_COM**2 + pz_COM**2)
+        invp_COM = 1. / p_COM
+        invp_COM2 = 1. / p_COM**2
+
+        # Lorentz transforms
+        gamma1_COM = (1 - vCdotu1 / c**2) * gammaC * gamma1
+        gamma2_COM = (1 - vCdotu2 / c**2) * gammaC * gamma2
+
+        # Calculate coulomb log if not user-defined
+        qq = q1 * q2
+        qq2 = qq**2
+        if coulomb_log <= 0.:
+            b0 = (qq / (4 * m.pi * epsilon_0 * c**2)) * gammaC * invgamma_a12 * \
+                (m1 * gamma1_COM * m2 * gamma2_COM * invp_COM2 * c**2 + 1.)**2
+            bmin = max(0.5 * h * invp_COM, b0)
+            Debye2 = k * T1[cell] / (4. * m.pi * n1[cell] * q1 * q1) + \
+                k * T2[cell] / (4. * m.pi * n2[cell] * q2 * q2)
+            coulomb_log = 0.5 * m.log(1. + Debye2 / bmin**2)
+            if coulomb_log < 2.:
+                coulomb_log = 2.
+
+        term1 = n1[cell] * n2[cell] / n12[cell]
+        term2 = corr_dt * coulomb_log * qq2 * \
+            invgamma12 / (4. * m.pi * epsilon_0**2 * c**4)
+        term3 = gammaC * p_COM * invgamma_a12 * \
+            (m1 * gamma1_COM * m2 * gamma2_COM * invp_COM2 * c**2 + 1.)**2
+
+        # Calculate the collision parameter s12
+        s12 = term1 * term2 * term3
+
+        # Low temperature correction
+        v_rel = m.sqrt((ux1[si1] - ux2[si2])**2
+                       + (uy1[si1] - uy2[si2])**2
+                       + (uz1[si1] - uz2[si2])**2)
+        s_prime = (4.*m.pi/3)**(1/3) * term1 * corr_dt * \
+            ((m1 + m2) / max(m1 * n1[cell]**(2/3), m2 * n2[cell]**(2/3))) * \
+            v_rel
+
+        s = min(s12, s_prime)
+
+        # Random azimuthal angle
+        phi = xoroshiro128p_uniform_float64(random_states, i) * 2.0 * m.pi
+
+        # Calculate the deflection angle
+        U = xoroshiro128p_uniform_float64(
+            random_states, i)    # random float [0,1]
+        if s12 < 4:
+            a = 0.37 * s - 0.005 * s**2 - 0.0064 * s**3
+            sin2X2 = a * U / m.sqrt(1 - U + a**2 * U)
+            cosX = 1. - 2. * sin2X2
+            sinX = 2. * m.sqrt(sin2X2 * (1.-sin2X2))
+        else:
+            cosX = 2. * U - 1.
+            sinX = m.sqrt(1. - cosX * cosX)
+        sinXcosPhi = sinX * m.cos(phi)
+        sinXsinPhi = sinX * m.sin(phi)
+
+        p_perp_COM = m.sqrt(px_COM**2 + py_COM**2)
+        invp = 1. / p_perp_COM
+
+        # Resulting momentum in COM frame
+        if (p_perp_COM > 1.e-10 * p_COM):
+            pxf1_COM = (px_COM * pz_COM * invp * sinXcosPhi
+                        - py_COM * p_COM * invp * sinXsinPhi
+                        + px_COM * cosX)
+            pyf1_COM = (py_COM * pz_COM * invp * sinXcosPhi
+                        + px_COM * p_COM * invp * sinXsinPhi
+                        + py_COM * cosX)
+            pzf1_COM = (-p_perp_COM * sinXcosPhi
+                        + pz_COM * cosX)
+        else:
+            pxf1_COM = p_COM * sinXcosPhi
+            pyf1_COM = p_COM * sinXsinPhi
+            pzf1_COM = p_COM * cosX
+
+        vC_pfCOM = (COM_vx * pxf1_COM
+                    + COM_vy * pyf1_COM
+                    + COM_vz * pzf1_COM)
+
+        # Resulting momentum in lab frame
+        pxf1 = pxf1_COM + COM_vx * \
+            ((gammaC - 1.) * vC_pfCOM / vC2 + m1 * gamma1_COM * gammaC)
+        pyf1 = pyf1_COM + COM_vy * \
+            ((gammaC - 1.) * vC_pfCOM / vC2 + m1 * gamma1_COM * gammaC)
+        pzf1 = pzf1_COM + COM_vz * \
+            ((gammaC - 1.) * vC_pfCOM / vC2 + m1 * gamma1_COM * gammaC)
+
+        U1 = xoroshiro128p_uniform_float64(
+            random_states, i)    # random float [0,1]
+        if U1 * w1[si1] < w2[si2]:
+            # Deflect particle 1
+            invm1 = 1. / m1
+            ux1[si1] = pxf1 * invm1
+            uy1[si1] = pyf1 * invm1
+            uz1[si1] = pzf1 * invm1
+
+        if U1 * w2[si2] < w1[si1]:
+            # Deflect particle 2 (pf2 = -pf1)
+            invm2 = 1. / m2
+            ux2[si2] = -pxf1 * invm2
+            uy2[si2] = -pyf1 * invm2
+            uz2[si2] = -pzf1 * invm2

--- a/fbpic/particles/elementary_process/collisions/cuda_methods.py
+++ b/fbpic/particles/elementary_process/collisions/cuda_methods.py
@@ -238,8 +238,6 @@ def perform_collisions_cuda(N_batch, batch_size, npairs_tot,
 			#if distance < m.sqrt(Debye2):
 			if distance < 1.e-4:	
 			#if distance < 0.1:
-				# Effective time interval for the collisions
-				corr_dt = dt * n12[cell] / n1[cell]
 
 				# Calculate Lorentz factor
 				gamma1 = m.sqrt(1. + (ux1[si1]**2 + uy1[si1]**2 + uz1[si1]**2))
@@ -272,9 +270,10 @@ def perform_collisions_cuda(N_batch, batch_size, npairs_tot,
 				pz_COM = uz1[si1] + ((COM_gamma - 1.) * COM_v_u1 / COM_v2
 										- COM_gamma * gamma1) * COM_vz
 
-				p_COM = m.sqrt(px_COM**2 + py_COM**2 + pz_COM**2)
+				p2_COM = px_COM**2 + py_COM**2 + pz_COM**2
+				p_COM = m.sqrt(p2_COM)
 				invp_COM = 1. / p_COM
-				invp_COM2 = 1. / p_COM**2
+				invp_COM2 = 1. / p2_COM
 
 				# Lorentz transforms
 				gamma1_COM = (gamma1 - COM_v_u1) * COM_gamma
@@ -293,7 +292,7 @@ def perform_collisions_cuda(N_batch, batch_size, npairs_tot,
 						coulomb_log = 2.
 
 				coeff1 = 1. / (4. * m.pi * epsilon_0**2 * c**3)
-				term1 = n1[cell] * n2[cell] / n12[cell]
+				term1 = n1[cell] * n2[cell] * dt / n12[cell]
 				term2 = coeff1 * qqm2 * invgamma12
 				term3 = COM_gamma * inv_g12 * p_COM
 				term4 = (gamma1_COM * gamma2_COM * invp_COM2  + m12)
@@ -310,8 +309,6 @@ def perform_collisions_cuda(N_batch, batch_size, npairs_tot,
 					v_rel
 
 				s = min(s12, s_prime)
-
-				s = s * corr_dt
 
 				# Random azimuthal angle
 				phi = xoroshiro128p_uniform_float64(random_states, i) * 2.0 * m.pi

--- a/fbpic/particles/elementary_process/collisions/cuda_methods.py
+++ b/fbpic/particles/elementary_process/collisions/cuda_methods.py
@@ -388,14 +388,16 @@ def perform_collisions_cuda(N_batch, batch_size, npairs_tot,
                         + COM_vz * uzf1_COM)
 
             U1 = xoroshiro128p_uniform_float64(random_states, i)    # random float [0,1]
-            if w2[si2] > U1 * max(w1[si1], w2[si2]):
+            maxW = max(w1[si1], w2[si2])
+            if w2[si2] > U1 * maxW:
                 # Deflect particle 1
                 term0 = (COM_gamma - 1.) * vC_ufCOM / COM_v2 + gamma1_COM * COM_gamma
                 ux1[si1] = uxf1_COM + COM_vx * term0
                 uy1[si1] = uyf1_COM + COM_vy * term0
                 uz1[si1] = uzf1_COM + COM_vz * term0
 
-            if w1[si2] > U1 * max(w1[si1], w2[si2]):
+            U2 = xoroshiro128p_uniform_float64(random_states, i)    # random float [0,1]
+            if w1[si1] > U2 * maxW:
                 # Deflect particle 2 (pf2 = -pf1)
                 term0 = -(COM_gamma - 1.) * m12 * vC_ufCOM / COM_v2 + gamma2_COM * COM_gamma
                 ux2[si2] = -uxf1_COM * m12 + COM_vx * term0

--- a/fbpic/particles/elementary_process/collisions/cuda_methods.py
+++ b/fbpic/particles/elementary_process/collisions/cuda_methods.py
@@ -59,7 +59,8 @@ def density_per_cell_cuda(N_batch, density, weights, npart,
 @compile_cupy
 def n12_per_cell_cuda(N_batch, n12, w1, w2,
                       npairs, shuffled_idx1, shuffled_idx2,
-                      prefix_sum_pair, prefix_sum1, prefix_sum2):
+                      prefix_sum_pair, prefix_sum1, prefix_sum2,
+                      d_invvol, Nz):
     """
     Calculate n12 of species per cell
     n12 is the sum of minimum species weights
@@ -85,7 +86,8 @@ def n12_per_cell_cuda(N_batch, n12, w1, w2,
                 sum += w1[i_min1+si1]
             else:
                 sum += w2[i_min2+si2]
-        n12[i] = sum
+        invvol = d_invvol[int(i / Nz)]
+        n12[i] = sum * invvol
 
 
 @compile_cupy

--- a/fbpic/particles/elementary_process/collisions/cuda_methods.py
+++ b/fbpic/particles/elementary_process/collisions/cuda_methods.py
@@ -125,7 +125,11 @@ def temperature_per_cell_cuda(N_batch, T, npart,
             vy_mean *= invNp
             vz_mean *= invNp
             u_mean2 = vx_mean**2 + vy_mean**2 + vz_mean**2
-            T[i] = m.fabs((mass / (3. * k)) * (v2 - u_mean2))
+            udiff = (v2 - u_mean2)
+            if udiff < 0.:
+                T[i] = 0.
+            else:
+                T[i] = (mass / (3. * k)) * udiff
 
 
 @compile_cupy
@@ -241,7 +245,7 @@ def perform_collisions_cuda(N_batch, batch_size, npairs_tot,
                             ux1, uy1, uz1,
                             ux2, uy2, uz2,
                             dt, coulomb_log,
-                            random_states, debug,
+                            random_states, period, debug,
                             param_s, param_logL):
     """
     Perform collisions between all pairs in each cell
@@ -307,39 +311,43 @@ def perform_collisions_cuda(N_batch, batch_size, npairs_tot,
             # Calculate coulomb log if not user-defined
             qqm = q1 * q2 / m1
             qqm2 = qqm**2
-            if coulomb_log <= 0.:
+            logL = coulomb_log
+            if logL <= 0.:
                 coeff = 1. / (4. * m.pi * epsilon_0 * c**2)
                 b0 = abs(coeff * qqm * COM_gamma * inv_g12 *
                             (gamma1_COM * gamma2_COM * invu_COM2 + m12))
                 bmin = max(0.5 * h / (m1 * c * u_COM), b0)
-                Debye2 = (epsilon_0 * k / e**2) / \
-                    (n1[cell] / T1[cell] + n2[cell] / T2[cell])
-                coulomb_log = 0.5 * m.log(1. + Debye2 / bmin**2)
-                if coulomb_log < 2.:
-                    coulomb_log = 2.
+                if T1[cell] == 0 or T1[cell] == 0:
+                    logL = 0.
+                else:
+                    Debye2 = (epsilon_0 * k / e**2) / \
+                        (n1[cell] / T1[cell] + n2[cell] / T2[cell])
+                    logL = 0.5 * m.log(1. + Debye2 / bmin**2)
+                    if logL < 2.:
+                        logL = 2.
 
             coeff1 = 1. / (4. * m.pi * epsilon_0**2 * c**3)
-            term1 = n1[cell] * n2[cell] * dt / n12[cell]
+            term1 = n1[cell] * n2[cell] * period * dt / n12[cell]
             term2 = coeff1 * qqm2 / (gamma1 * gamma2)
             term3 = COM_gamma * inv_g12 * u_COM
             term4 = (gamma1_COM * gamma2_COM * invu_COM2 + m12)
 
             # Calculate the collision parameter s12
-            s12 = coulomb_log * term1 * term2 * term3 * term4 * term4
+            s12 = logL * term1 * term2 * term3 * term4 * term4
 
             # Low temperature correction
-            v_rel = m.sqrt((ux1[si1] - ux2[si2])**2
-                            + (uy1[si1] - uy2[si2])**2
-                            + (uz1[si1] - uz2[si2])**2)
+            v_rel = abs(g12 * u_COM * c / ( COM_gamma * gamma1_COM * gamma2_COM ))
             s_prime = (4.*m.pi/3)**(1/3) * term1 * \
                 ((m1 + m2) / max(m1 * n1[cell]**(2/3), m2 * n2[cell]**(2/3))) * \
                 v_rel
-
-            s = min(s12, s_prime)
+            if s12 < 0 or s_prime < 0:
+                s = 0.
+            else:
+                s = min(s12, s_prime)
 
             if debug:
                 param_s[ip] = s
-                param_logL[ip] = coulomb_log
+                param_logL[ip] = logL
 
             # Random azimuthal angle
             phi = xoroshiro128p_uniform_float64(random_states, i) * 2.0 * m.pi

--- a/fbpic/particles/elementary_process/collisions/cuda_methods.py
+++ b/fbpic/particles/elementary_process/collisions/cuda_methods.py
@@ -287,27 +287,27 @@ def perform_collisions_cuda(N_batch, batch_size, npairs_tot,
             COM_vy = (m12 * uy1[si1] + uy2[si2]) * inv_g12
             COM_vz = (m12 * uz1[si1] + uz2[si2]) * inv_g12
 
-            COM_v_u1 = (COM_vx * ux1[si1] + COM_vy *
+            COM_v_u1g1 = (COM_vx * ux1[si1] + COM_vy *
                         uy1[si1] + COM_vz * uz1[si1])
-            COM_v_u2 = (COM_vx * ux2[si2] + COM_vy *
+            COM_v_u2g2 = (COM_vx * ux2[si2] + COM_vy *
                         uy2[si2] + COM_vz * uz2[si2])
 
             COM_v2 = COM_vx**2 + COM_vy**2 + COM_vz**2
             COM_gamma = 1. / m.sqrt(1. - COM_v2)
 
             # momenta in COM
-            term0 = (COM_gamma - 1.) * COM_v_u1 / COM_v2 - COM_gamma * gamma1
+            term0 = (COM_gamma - 1.) * COM_v_u1g1 / COM_v2 - COM_gamma * gamma1
             ux_COM = ux1[si1] + COM_vx * term0
             uy_COM = uy1[si1] + COM_vy * term0
             uz_COM = uz1[si1] + COM_vz * term0
 
-            u2_COM = ux_COM**2 + uy_COM**2 + uz_COM**2
-            u_COM = m.sqrt(u2_COM)
-            invu_COM2 = 1. / u2_COM
+            u_COM2 = ux_COM**2 + uy_COM**2 + uz_COM**2
+            u_COM = m.sqrt(u_COM2)
+            invu_COM2 = 1. / u_COM2
 
             # Lorentz transforms
-            gamma1_COM = (gamma1 - COM_v_u1) * COM_gamma
-            gamma2_COM = (gamma2 - COM_v_u2) * COM_gamma
+            gamma1_COM = (gamma1 - COM_v_u1g1) * COM_gamma
+            gamma2_COM = (gamma2 - COM_v_u2g2) * COM_gamma
 
             # Calculate coulomb log if not user-defined
             qqm = q1 * q2 / m1
@@ -395,9 +395,7 @@ def perform_collisions_cuda(N_batch, batch_size, npairs_tot,
                 uy1[si1] = uyf1_COM + COM_vy * term0
                 uz1[si1] = uzf1_COM + COM_vz * term0
 
-            
-            U2 = xoroshiro128p_uniform_float64(random_states, i)    # random float [0,1]
-            if w1[si2] > U2 * max(w1[si1], w2[si2]):
+            if w1[si2] > U1 * max(w1[si1], w2[si2]):
                 # Deflect particle 2 (pf2 = -pf1)
                 term0 = -(COM_gamma - 1.) * m12 * vC_ufCOM / COM_v2 + gamma2_COM * COM_gamma
                 ux2[si2] = -uxf1_COM * m12 + COM_vx * term0

--- a/fbpic/particles/elementary_process/collisions/numba_methods.py
+++ b/fbpic/particles/elementary_process/collisions/numba_methods.py
@@ -1,0 +1,372 @@
+# Copyright 2017, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file is part of the Fourier-Bessel Particle-In-Cell code (FB-PIC)
+It defines cuda methods that are used in Compton scattering (on GPU).
+"""
+import random
+import math as m
+from scipy.constants import c, k, h, epsilon_0, e
+from fbpic.utils.threading import njit_parallel, prange
+
+
+@njit_parallel
+def pairs_per_cell_numba(N_batch, array_in1, array_in2, array_out, intra):
+	"""
+	Calculate the number of pairs per cell
+	"""
+	for i in prange(N_batch):
+		if array_in1[i] == 0 or array_in2[i] == 0:
+			array_out[i] = 0
+		else:
+			if intra:
+				if array_in1[i] < 2: 
+					array_out[i] = 0
+				else:
+					array_out[i] = array_in1[i] / 2 \
+						if array_in1[i] % 2 else (array_in1[i] + 1) / 2
+			else:
+				if array_in1[i] > array_in2[i]:
+					array_out[i] = array_in1[i]
+				else:
+					array_out[i] = array_in2[i]
+
+
+@njit_parallel
+def density_per_cell_numba(N_batch, density, weights, npart,
+                          prefix_sum, d_invvol, Nz):
+    """
+    Calculate density of species per cell
+    """
+    for i in prange(N_batch):
+        sum = 0.
+        if i > 0:
+            i_min = int(prefix_sum[i-1])
+        else:
+            i_min = 0
+        for j in range(int(npart[i])):
+            sum += weights[i_min + j]
+        invvol = d_invvol[int(i / Nz)]
+        density[i] = sum * invvol
+
+
+@njit_parallel
+def n12_per_cell_numba(N_batch, n12, w1, w2,
+                      npairs, shuffled_idx1, shuffled_idx2,
+                      prefix_sum_pair, prefix_sum1, prefix_sum2,
+                      d_invvol, Nz):
+    """
+    Calculate n12 of species per cell
+    n12 is the sum of minimum species weights
+    """
+    # Loop over cells
+    # Loop over batch of particle pairs and perform collision
+    for i in prange(N_batch):
+        # Loop through the batch
+        if i > 0:
+            i_min1 = int(prefix_sum1[i-1])
+            i_min2 = int(prefix_sum2[i-1])
+            p_min = int(prefix_sum_pair[i-1])
+        else:
+            i_min1 = 0
+            i_min2 = 0
+            p_min = 0
+        sum = 0.
+        for j in range(int(npairs[i])):
+            si1 = shuffled_idx1[p_min + j]
+            si2 = shuffled_idx2[p_min + j]
+            if w1[i_min1+si1] < w2[i_min2+si2]:
+                sum += w1[i_min1+si1]
+            else:
+                sum += w2[i_min2+si2]
+        invvol = d_invvol[int(i / Nz)]
+        n12[i] = sum * invvol
+
+
+@njit_parallel
+def temperature_per_cell_numba(N_batch, T, npart,
+                              prefix_sum, mass,
+                              ux, uy, uz):
+    """
+    Calculate temperature of species in cell
+    """
+    for i in prange(N_batch):
+        if npart[i] == 0:
+            T[i] = 0.
+        else:
+            if i > 0:
+                i_min = int(prefix_sum[i-1])
+            else:
+                i_min = 0
+
+            vx_mean = 0.
+            vy_mean = 0.
+            vz_mean = 0.
+            v2 = 0.
+            for j in range(int(npart[i])):
+                vx_mean += ux[i_min + j] * c
+                vy_mean += uy[i_min + j] * c
+                vz_mean += uz[i_min + j] * c
+
+                v2 += (ux[i_min + j]**2 + uy[i_min + j]
+                       ** 2 + uz[i_min + j]**2) * c**2
+
+            invNp = (1. / npart[i])
+            v2 *= invNp
+            vx_mean *= invNp
+            vy_mean *= invNp
+            vz_mean *= invNp
+            u_mean2 = vx_mean**2 + vy_mean**2 + vz_mean**2
+            udiff = (v2 - u_mean2)
+            if udiff < 0.:
+                T[i] = 0.
+            else:
+                T[i] = (mass / (3. * k)) * udiff
+
+
+@njit_parallel
+def get_cell_idx_per_pair_numba(N_batch, cell_idx, npair, prefix_sum_pair):
+    """
+    Get the cell index of each pair.
+    The cell index is 1d and calculated by:
+    prefix sum of pairs
+
+    Parameters
+    ----------
+    cell_idx : 1darray of integers
+                The cell index of the pair
+
+    npair : 1darray of integers
+                The particle pair array
+
+    prefix_sum_pair : 1darray of integers
+                Cumulative prefix sum of
+                the particle pair array		
+    """
+    for i in prange(N_batch):
+        if i > 0:
+            s = prefix_sum_pair[i-1]
+        else:
+            s = 0
+        p = npair[i]
+        k = 0
+        while k < p:
+            cell_idx[s+k] = i
+            k += 1
+
+
+@njit_parallel
+def get_shuffled_idx_per_particle_numba(N_batch, shuffled_idx, npart,
+                            			npair, prefix_sum_pair,
+										intra, species):
+    """
+    Get the shuffled index of each particle in the array of pairs.
+    The particles are shuffled with a linear congruential generator
+    that is cyclic and non-repeating.
+
+    Parameters
+    ----------
+    shuffled_idx : 1darray of integers
+            The shuffled particle index of the particle
+
+    npart : 1darray of integers
+            The particle array
+
+    npair : 1darray of integers
+            The particle pair array
+
+    prefix_sum_pair : 1darray of integers
+            Cumulative prefix sum of
+            the pair array	
+
+    random_states : random states of the random generator
+
+    intra : boolean
+            True: like-particle collisions
+            False: unlike-particle collisions
+
+    species : int
+            species number: 1 or 2
+    """
+    for i in prange(N_batch):
+        if i > 0:
+            s = prefix_sum_pair[i-1]
+        else:
+            s = 0
+        
+        start = 0
+        stop = npart[i]
+        if intra and species == 1:
+            stop = npair[i]
+        if intra and species == 2:
+            start = npair[i]
+
+        p = range(start, stop)
+        
+        random.shuffle(p)
+
+        shuffled_idx[s+start:s+stop] = p
+
+
+@njit_parallel
+def perform_collisions_numba(N_batch, prefix_sum1, prefix_sum2,
+                            shuffled_idx1, shuffled_idx2, cell_idx,
+                            n1, n2, T1, T2,
+                            n12, m1, m2,
+                            q1, q2, w1, w2,
+                            ux1, uy1, uz1,
+                            ux2, uy2, uz2,
+                            dt, coulomb_log,
+                            period, debug,
+                            param_s, param_logL):
+    """
+    Perform collisions between all pairs in each cell
+    """
+    # Loop over cells
+    # Loop over batch of particle pairs and perform collision
+    for ip in prange(N_batch):
+        # The particles are randomly paired in each cell
+        # with a linear congruential generator which
+        # shuffles the particles in a non-repeating manner.
+        # Note: plasma heating due to collisions can
+        # be reduced in certain cases with a 'nearest neighbor'
+        # (NN) pairing and/or low-pass filter. NN can be 
+        # achieved with a finer grid in the particle sorting.
+        cell = cell_idx[ip]
+        if cell > 0:
+            si1 = int(shuffled_idx1[ip] + prefix_sum1[cell-1])
+            si2 = int(shuffled_idx2[ip] + prefix_sum2[cell-1])
+        else:
+            si1 = int(shuffled_idx1[ip])
+            si2 = int(shuffled_idx2[ip])
+
+        # Calculate Lorentz factor
+        gamma1 = m.sqrt(1. + (ux1[si1]**2 + uy1[si1]**2 + uz1[si1]**2))
+        gamma2 = m.sqrt(1. + (ux2[si2]**2 + uy2[si2]**2 + uz2[si2]**2))
+
+        m12 = m1 / m2
+
+        g12 = m12 * gamma1 + gamma2
+        inv_g12 = 1. / g12
+
+        # Center of mass (COM) velocity
+        COM_vx = (m12 * ux1[si1] + ux2[si2]) * inv_g12
+        COM_vy = (m12 * uy1[si1] + uy2[si2]) * inv_g12
+        COM_vz = (m12 * uz1[si1] + uz2[si2]) * inv_g12
+
+        COM_v_u1 = (COM_vx * ux1[si1] + COM_vy *
+                    uy1[si1] + COM_vz * uz1[si1])
+        COM_v_u2 = (COM_vx * ux2[si2] + COM_vy *
+                    uy2[si2] + COM_vz * uz2[si2])
+
+        COM_v2 = COM_vx**2 + COM_vy**2 + COM_vz**2
+        COM_gamma = 1. / m.sqrt(1. - COM_v2)
+
+        # momenta in COM
+        term0 = (COM_gamma - 1.) * COM_v_u1 / COM_v2 - COM_gamma * gamma1
+        ux_COM = ux1[si1] + COM_vx * term0
+        uy_COM = uy1[si1] + COM_vy * term0
+        uz_COM = uz1[si1] + COM_vz * term0
+
+        u2_COM = ux_COM**2 + uy_COM**2 + uz_COM**2
+        u_COM = m.sqrt(u2_COM)
+        invu_COM2 = 1. / u2_COM
+
+        # Lorentz transforms
+        gamma1_COM = (gamma1 - COM_v_u1) * COM_gamma
+        gamma2_COM = (gamma2 - COM_v_u2) * COM_gamma
+
+        # Calculate coulomb log if not user-defined
+        qqm = q1 * q2 / m1
+        qqm2 = qqm**2
+        logL = coulomb_log
+        if logL <= 0.:
+            coeff = 1. / (4. * m.pi * epsilon_0 * c**2)
+            b0 = abs(coeff * qqm * COM_gamma * inv_g12 *
+                        (gamma1_COM * gamma2_COM * invu_COM2 + m12))
+            bmin = max(0.5 * h / (m1 * c * u_COM), b0)
+            if T1[cell] == 0 or T1[cell] == 0:
+                logL = 0.
+            else:
+                Debye2 = (epsilon_0 * k / e**2) / \
+                    (n1[cell] / T1[cell] + n2[cell] / T2[cell])
+                logL = 0.5 * m.log(1. + Debye2 / bmin**2)
+                if logL < 2.:
+                    logL = 2.
+
+        coeff1 = 1. / (4. * m.pi * epsilon_0**2 * c**3)
+        term1 = n1[cell] * n2[cell] * period * dt / n12[cell]
+        term2 = coeff1 * qqm2 / (gamma1 * gamma2)
+        term3 = COM_gamma * inv_g12 * u_COM
+        term4 = (gamma1_COM * gamma2_COM * invu_COM2 + m12)
+
+        # Calculate the collision parameter s12
+        s12 = logL * term1 * term2 * term3 * term4 * term4
+
+        # Low temperature correction
+        v_rel = abs(g12 * u_COM * c / ( COM_gamma * gamma1_COM * gamma2_COM ))
+        s_prime = (4.*m.pi/3)**(1/3) * term1 * \
+            ((m1 + m2) / max(m1 * n1[cell]**(2/3), m2 * n2[cell]**(2/3))) * \
+            v_rel
+        if s12 < 0 or s_prime < 0:
+            s = 0.
+        else:
+            s = min(s12, s_prime)
+
+        if debug:
+            param_s[ip] = s
+            param_logL[ip] = logL
+
+        # Random azimuthal angle
+        phi = random.random()* 2.0 * m.pi
+
+        # Calculate the deflection angle
+        U = random.random()    # random float [0,1]
+        if s12 < 4:
+            a = 0.37 * s - 0.005 * s**2 - 0.0064 * s**3
+            sin2X2 = a * U / m.sqrt(1 - U + a**2 * U)
+            cosX = 1. - 2. * sin2X2
+            sinX = 2. * m.sqrt(sin2X2 * (1. - sin2X2))
+        else:
+            cosX = 2. * U - 1.
+            sinX = m.sqrt(1. - cosX * cosX)
+        sinXcosPhi = sinX * m.cos(phi)
+        sinXsinPhi = sinX * m.sin(phi)
+
+        u_perp_COM = m.sqrt(ux_COM**2 + uy_COM**2)
+        invu = 1. / u_perp_COM
+
+        # Resulting momentum in COM frame
+        if (u_perp_COM > 1.e-10 * u_COM):
+            uxf1_COM = (ux_COM * uz_COM * invu * sinXcosPhi
+                        - uy_COM * u_COM * invu * sinXsinPhi
+                        + ux_COM * cosX)
+            uyf1_COM = (uy_COM * uz_COM * invu * sinXcosPhi
+                        + ux_COM * u_COM * invu * sinXsinPhi
+                        + uy_COM * cosX)
+            uzf1_COM = (-u_perp_COM * sinXcosPhi
+                        + uz_COM * cosX)
+        else:
+            uxf1_COM = u_COM * sinXcosPhi
+            uyf1_COM = u_COM * sinXsinPhi
+            uzf1_COM = u_COM * cosX
+
+        vC_ufCOM = (COM_vx * uxf1_COM
+                    + COM_vy * uyf1_COM
+                    + COM_vz * uzf1_COM)
+
+        U1 = random.random()   # random float [0,1]
+        if U1 * w1[si1] < w2[si2]:
+            # Deflect particle 1
+            term0 = (COM_gamma - 1.) * vC_ufCOM / COM_v2 + gamma1_COM * COM_gamma
+            ux1[si1] = uxf1_COM + COM_vx * term0
+            uy1[si1] = uyf1_COM + COM_vy * term0
+            uz1[si1] = uzf1_COM + COM_vz * term0
+
+        if U1 * w2[si2] < w1[si1]:
+            # Deflect particle 2 (pf2 = -pf1)
+            term0 = -(COM_gamma - 1.) * m12 * vC_ufCOM / COM_v2 + gamma2_COM * COM_gamma
+            ux2[si2] = -uxf1_COM * m12 + COM_vx * term0
+            uy2[si2] = -uyf1_COM * m12 + COM_vy * term0
+            uz2[si2] = -uzf1_COM * m12 + COM_vz * term0

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -249,8 +249,8 @@ class Particles(object) :
             self.sorted = False
 
             # Allocate arrays for cell quantities, e.g. density and temperature
-            self.density = cupy.empty( Nz*Nr, dtype=np.float64)
-            self.temperature = cupy.empty( Nz*Nr, dtype=np.float64)
+            self.density = cupy.empty( Nz*(Nr+1), dtype=np.float64)
+            self.temperature = cupy.empty( Nz*(Nr+1), dtype=np.float64)
             # Register boolean that records if the cell quantities have
             # been previously calculated
             self.calc = False

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -24,6 +24,9 @@ from .gathering.threading_methods_one_mode import erase_eb_numba, \
 from .deposition.threading_methods import \
         deposit_rho_numba_linear, deposit_rho_numba_cubic, \
         deposit_J_numba_linear, deposit_J_numba_cubic
+from .boundaries.numba_methods import reflect_particles_left_numba, \
+    reflect_particles_right_numba, stop_particles_left_numba, \
+    stop_particles_right_numba \
 
 # Check if threading is enabled
 from fbpic.utils.threading import nthreads, get_chunk_indices
@@ -47,6 +50,9 @@ if cuda_installed:
     from .utilities.cuda_sorting import write_sorting_buffer, \
         get_cell_idx_per_particle, sort_particles_per_cell, \
         prefill_prefix_sum, incl_prefix_sum
+    from .boundaries.cuda_methods import reflect_particles_left, \
+        reflect_particles_right, stop_particles_left, \
+        stop_particles_right
 
 class Particles(object) :
     """
@@ -67,7 +73,8 @@ class Particles(object) :
                     ux_th=0., uy_th=0., uz_th=0.,
                     dens_func=None, continuous_injection=True,
                     grid_shape=None, particle_shape='linear',
-                    use_cuda=False, dz_particles=None ):
+                    use_cuda=False, dz_particles=None,
+                    particle_boundaries={'zmin':'open', 'zmax':'open'}):
         """
         Initialize a uniform set of particles
 
@@ -100,10 +107,10 @@ class Particles(object) :
         dt : float (in seconds)
            The timestep for the particle pusher
 
-        ux_m, uy_m, uz_m: floats (dimensionless), optional
+        ux_m, uy_m, uz_m : floats (dimensionless), optional
            Normalized mean momenta of the injected particles in each direction
 
-        ux_th, uy_th, uz_th: floats (dimensionless), optional
+        ux_th, uy_th, uz_th : floats (dimensionless), optional
            Normalized thermal momenta in each direction
 
         dens_func : callable, optional
@@ -119,13 +126,13 @@ class Particles(object) :
            Whether to continuously inject the particles,
            in the case of a moving window
 
-        grid_shape: tuple, optional
+        grid_shape : tuple, optional
             Needed when running on the GPU
             The shape of the local grid (including guard cells), i.e.
             a tuple of the form (Nz, Nr). This is needed in order
             to initialize the sorting of the particles per cell.
 
-        particle_shape: str, optional
+        particle_shape : str, optional
             Set the particle shape for the charge/current deposition.
             Possible values are 'linear' and 'cubic' for first and third
             order particle shape factors.
@@ -133,12 +140,22 @@ class Particles(object) :
         use_cuda : bool, optional
             Wether to use the GPU or not.
 
-        dz_particles: float (in meter), optional
+        dz_particles : float (in meter), optional
             The spacing between particles in `z` (for continuous injection)
             In most cases, the spacing between particles can be inferred
             from the arguments `zmin`, `zmax` and `Npz`. However, when
             there are no particles in the initial box (`Npz = 0`),
             `dz_particles` needs to be explicitly passed.
+
+        particle_boundaries : dict, optional
+            A dictionary with 'zmin' and 'zmax' as keys, and strings as values.
+            This specifies the particle boundary in the longitudinal (z) direction.
+            Boundaries can be either `'open'`, `'reflective'`, or `'stop'`.
+              - `'open'` particles that leave the domain will be removed.
+              - `'reflective'` particles reflect at the domain boundary.
+              - `'stop'` particle momenta are set to 0.
+            If the EM-boundaries are periodic then the particles will be
+            perodic as well.
         """
         # Define whether or not to use the GPU
         self.use_cuda = use_cuda
@@ -148,6 +165,10 @@ class Particles(object) :
                 'Performing the particle operations on the CPU.')
             self.use_cuda = False
         self.data_is_on_gpu = False # Data is initialized on the CPU
+
+        self.zmin = zmin
+        self.zmax = zmax
+        self.particle_boundaries = particle_boundaries
 
         # Generate evenly-spaced particles
         Ntot, x, y, z, ux, uy, uz, inv_gamma, w = generate_evenly_spaced(
@@ -197,6 +218,7 @@ class Particles(object) :
         # (see method make_ionizable and activate_compton)
         self.ionizer = None
         self.compton_scatterer = None
+        self.collisions = None
         # Total number of quantities (necessary in MPI communications)
         self.n_integer_quantities = 0
         self.n_float_quantities = 8 # x, y, z, ux, uy, uz, inv_gamma, w
@@ -226,7 +248,7 @@ class Particles(object) :
             # (because they are swapped with these arrays during sorting)
             self.sorting_buffer = np.empty( Ntot, dtype=np.float64)
 
-            # Register integer thta records shift in the indices,
+            # Register integer that records shift in the indices,
             # induced by the moving window
             self.prefix_sum_shift = 0
             # Register boolean that records if the particles are sorted or not
@@ -503,6 +525,51 @@ class Particles(object) :
             self.compton_scatterer.handle_scattering( self, t )
 
 
+    def handle_particle_boundaries( self ):
+        """
+        Handle particle boundary conditions
+        """
+        if self.particle_boundaries['zmin'] == 'reflective' \
+            or self.particle_boundaries['zmin'] == 'stop':
+            if self.use_cuda:
+                dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( self.Ntot )
+                if self.particle_boundaries['zmin'] == 'reflective':
+                    reflect_particles_left[dim_grid_1d, dim_block_1d](
+                        self.zmin, self.z, self.uz)
+                
+                if self.particle_boundaries['zmin'] == 'stop':
+                    stop_particles_left[dim_grid_1d, dim_block_1d](
+                        self.zmin, self.z, self.ux, self.uy, self.uz)
+            else:
+                if self.particle_boundaries['zmin'] == 'reflective':
+                    reflect_particles_left_numba(self.zmin, self.z, 
+                        self.uz, self.Ntot)
+                
+                if self.particle_boundaries['zmin'] == 'stop':
+                    stop_particles_left_numba(self.zmin, self.z, 
+                        self.ux, self.uy, self.uz, self.Ntot)
+
+        if self.particle_boundaries['zmax'] == 'reflective' \
+            or self.particle_boundaries['zmax'] == 'stop':
+            if self.use_cuda:
+                dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( self.Ntot )
+                if self.particle_boundaries['zmax'] == 'reflective':
+                    reflect_particles_right[dim_grid_1d, dim_block_1d](
+                        self.zmax, self.z, self.uz)
+                
+                if self.particle_boundaries['zmax'] == 'stop':
+                    stop_particles_right[dim_grid_1d, dim_block_1d](
+                        self.zmax, self.z, self.ux, self.uy, self.uz)
+            else:
+                if self.particle_boundaries['zmax'] == 'reflective':
+                    reflect_particles_right_numba(self.zmax, self.z,
+                        self.uz, self.Ntot)
+                
+                if self.particle_boundaries['zmax'] == 'stop':
+                    stop_particles_right_numba(self.zmax, self.z,
+                        self.ux, self.uy, self.uz, self.Ntot)
+
+
     def rearrange_particle_arrays( self ):
         """
         Rearranges the particle data arrays to match with the sorted
@@ -549,6 +616,7 @@ class Particles(object) :
             setattr( attr[0], attr[1], self.int_sorting_buffer)
             # Assign the old particle data array to the particle buffer
             self.int_sorting_buffer = particle_array
+
 
     def push_p( self, t ) :
         """
@@ -665,6 +733,7 @@ class Particles(object) :
                 self.ux, self.uy, self.uz,
                 self.inv_gamma, self.Ntot,
                 dt, x_push, y_push, z_push )
+
 
     def gather( self, grid, comm ) :
         """
@@ -831,6 +900,7 @@ class Particles(object) :
                 raise ValueError("`particle_shape` should be either \
                                   'linear' or 'cubic' \
                                    but is `%s`" % self.particle_shape)
+
 
     def deposit( self, fld, fieldtype ) :
         """
@@ -1045,7 +1115,7 @@ class Particles(object) :
     def sort_particles(self, fld):
         """
         Sort the particles by performing the following steps:
-        1. Get fied cell index
+        1. Get field cell index
         2. Sort field cell index
         3. Parallel prefix sum
         4. Rearrange particle arrays

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -248,13 +248,6 @@ class Particles(object) :
             # Register boolean that records if the particles are sorted or not
             self.sorted = False
 
-            # Allocate arrays for cell quantities, e.g. density and temperature
-            self.density = cupy.empty( Nz*(Nr+1), dtype=np.float64)
-            self.temperature = cupy.empty( Nz*(Nr+1), dtype=np.float64)
-            # Register boolean that records if the cell quantities have
-            # been previously calculated
-            self.calc = False
-
             # Define optimal number of CUDA threads per block for deposition
             # and gathering kernels (determined empirically)
             if particle_shape == "cubic":

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -253,6 +253,14 @@ class Particles(object) :
             self.prefix_sum_shift = 0
             # Register boolean that records if the particles are sorted or not
             self.sorted = False
+
+            # Allocate arrays for cell quantities, e.g. density and temperature
+            self.density = cupy.empty( Nz*Nr, dtype=np.float64)
+            self.temperature = cupy.empty( Nz*Nr, dtype=np.float64)
+            # Register boolean that records if the cell quantities have
+            # been previously calculated
+            self.calc = False
+
             # Define optimal number of CUDA threads per block for deposition
             # and gathering kernels (determined empirically)
             if particle_shape == "cubic":

--- a/tests/test_thermalization.py
+++ b/tests/test_thermalization.py
@@ -1,0 +1,190 @@
+# Copyright 2017, FBPIC contributors
+# Authors: Kristoffer Lindvall
+# License: 3-Clause-BSD-LBNL
+"""
+Thermalization test
+"""
+
+# -------
+# Imports
+# -------
+import shutil, math
+import numpy as np
+from scipy.constants import c, m_e, e, k
+# Import the relevant structures in FBPIC
+from fbpic.main import Simulation
+from fbpic.openpmd_diag import ParticleDiagnostic
+from fbpic.fields.smoothing import BinomialSmoother
+from fbpic.particles.elementary_process.collisions import MCCollisions
+# Import openPMD-viewer for checking output files
+from openpmd_viewer import OpenPMDTimeSeries
+
+# ----------
+# Parameters
+# ----------
+use_cuda = True
+
+def run_simulation():
+    """
+    Run a simulation with a uniform plasma that undergoes
+    electron-ion collisions
+    """
+    # The simulation box
+    zmax = 1.e-3      # Length of the box along z (meters)
+    zmin = 0.e-6
+    rmax = 5.e-4      # Length of the box along r (meters)
+    Nr = 50           # Number of gridpoints along z
+    Nz = 100          # Number of gridpoints along r
+    
+    Nm = 1            # Number of modes used
+
+    # Plasma properties
+    n_i = 1e28
+    n_e = 1e28
+    Te  = 100
+    Ti  = 90
+
+    m_i = 10*m_e
+
+    uth_i = math.sqrt(e * Ti / (m_i * c**2))  # Normalized thermal momenta
+    uth_e = math.sqrt(e * Te / (m_e * c**2))
+
+    p_nz = 20         # Number of particles per cell along z
+    p_nr = 20         # Number of particles per cell along r
+    p_nt = 1          # Number of particles per cell along theta
+
+    # Collision parameters
+    coulomb_log = 5.
+    collision_period = 1
+    start_collision = 1
+
+    # Number of timesteps
+    N_step = 250
+
+    # Simulation time
+    Time = 6e-14
+    dt = Time / N_step
+
+    # The diagnostics
+    diag_period = 20 # Period of the diagnostics in number of timesteps
+
+    # Initialize the simulation object, with the neutralizing electrons
+    # No particles are created because we do not pass the density
+    sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
+        boundaries={'z':'open', 'r':'reflective'}, use_cuda=use_cuda,
+        smoother=BinomialSmoother(5, False))
+
+    # Add the charge-neutralizing electrons
+    elec = sim.add_new_species( q=-e, m=m_e, n=n_e,
+                        ux_th=uth_e, uy_th=uth_e, uz_th=uth_e,
+                        p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
+                        continuous_injection=False )
+    # Add the N atoms
+    ions = sim.add_new_species( q=+e, m=m_i, n=n_i,
+                        ux_th=uth_i, uy_th=uth_i, uz_th=uth_i,
+                        p_nz=p_nz, p_nr=p_nr, p_nt=p_nt,
+                        continuous_injection=False )
+
+    sim.collisions = [
+        MCCollisions(elec, ions, use_cuda,
+                coulomb_log = 5.,
+                start = start_collision,
+                period = collision_period,
+                debug = False)
+    ]
+
+    # Add a particle diagnostic
+    sim.diags = [ ParticleDiagnostic( diag_period, {"elec":elec, "ions":ions},
+        write_dir='tests/diags', comm=sim.comm) ]
+
+    # Run the simulation
+    sim.step( N_step, move_positions=False )
+
+
+    # Check consistency in the regular openPMD diagnostics
+    ts = OpenPMDTimeSeries('./tests/diags/hdf5/')
+
+    import matplotlib.pyplot as plt
+    Tmi = np.zeros(len(ts.iterations))
+    Tme = np.zeros(len(ts.iterations))
+    l = 0
+
+    for i in ts.iterations:
+        ux_i = ts.get_particle(['ux'], species='ions', iteration=i)
+        ux_e = ts.get_particle(['ux'], species='elec', iteration=i)
+
+        uy_i = ts.get_particle(['uy'], species='ions', iteration=i)
+        uy_e = ts.get_particle(['uy'], species='elec', iteration=i)
+
+        uz_i = ts.get_particle(['uz'], species='ions', iteration=i)
+        uz_e = ts.get_particle(['uz'], species='elec', iteration=i)
+
+
+        Tmi[l] = calculate_temperature(m_i, ux_i[0], uy_i[0], uz_i[0])
+        Tme[l] = calculate_temperature(m_e, ux_e[0], uy_e[0], uz_e[0])
+        l+=1
+
+    # NRL relaxation	
+    T_e = Te
+    T_i = Ti
+    t_points = 1000
+    Te_theory = np.zeros(t_points)
+    Ti_theory = np.zeros(t_points)
+    Time_plot = ts.iterations[-1] * dt
+    dtp = Time_plot / t_points
+    t_array = np.linspace(0, Time_plot, t_points, endpoint=True)
+    coeff = 1.8e-19 
+    Zi = 1
+    Ze = -1
+    n_i_cgs = n_i / 1000
+    m_e_cgs = 9.1094e-28
+    m_i_cgs = 10*m_e_cgs
+    
+    for i in range(t_points):
+        Te_theory[i] = T_e
+        Ti_theory[i] = T_i
+        nu0 = coeff * Zi**2 * Ze**2 * n_i_cgs * coulomb_log * \
+            np.sqrt(m_e_cgs * m_i_cgs) / ((m_e_cgs*T_i + m_i_cgs*T_e)**(3/2)) / 1000
+        T_e += nu0 * (T_i - T_e) * dtp
+        T_i += nu0 * (T_e - T_i) * dtp
+
+    plt.plot(ts.iterations * dt * 1.e15, Tmi * (k/e))
+    plt.plot(ts.iterations * dt * 1.e15, Tme * (k/e))
+    plt.plot(t_array * 1.e15, Ti_theory, 'k')
+    plt.plot(t_array * 1.e15, Te_theory, 'k')
+    plt.legend(["i+", "e-"])
+    plt.xlabel( 't [fs]' )
+    plt.ylabel( 'T [eV]' )
+    plt.title( 'Temperature of i+, e-, and NRL formula (black lines)' )
+    plt.show()
+
+    # Remove openPMD files
+    shutil.rmtree('./tests/diags/')
+
+def calculate_temperature( mass, ux, uy, uz ):
+    Np = int(len(ux))
+
+    vx_mean = np.sum(ux)*c
+    vy_mean = np.sum(uy)*c
+    vz_mean = np.sum(uz)*c
+
+    v2 = np.sum(ux**2 + uy**2 + uz**2)*c**2
+
+    invNp = (1. / Np)
+    v2 *= invNp
+    vx_mean *= invNp
+    vy_mean *= invNp
+    vz_mean *= invNp
+    u_mean2 = vx_mean**2 + vy_mean**2 + vz_mean**2
+    udiff = (v2 - u_mean2)
+    if udiff < 0.:
+        return 0.
+    else:
+        return (mass / (3. * k)) * udiff
+
+def test_collision_thermalization():
+    run_simulation()
+
+# Run the tests
+if __name__ == '__main__':
+    test_collision_thermalization()


### PR DESCRIPTION
The collision scheme:
1. Particles are grouped into random pairs
3. Particles are duplicated and weights are split
4. The particle momenta are transformed to the
Center of Mass (COM) frame
5. Calculate coulomb logarithm and deflection angle
6. Perform collisions in COM and transform back to
lab frame

    This work implements the collision scheme proposed
    in [Phys. Plasmas 19, 083104 (2012)] and [J. Comput. Phys. 413, 109450 (2020)]
    It also implements the improvements proposed by the Smilei team, i.e. the deflection angle
    has been modified for better accuracy.

How to implement in input deck:

sim.collisions = [
MCCollisions(elec, prot, use_cuda, coulomb_log = coulomb_log)
]
This code needs a review since the thermalization test is still failing. See the figure that compares the numerical results to an analytical formula.
![image](https://user-images.githubusercontent.com/107398873/189137055-60faa666-8569-46d4-8484-17ffdf8686bc.png)
