### PR TITLE
Make the install of MKL more flexible for Windows

### DIFF
--- a/fbpic/fields/spectral_transform/mkl_fft.py
+++ b/fbpic/fields/spectral_transform/mkl_fft.py
@@ -31,7 +31,10 @@ elif sys.platform == 'darwin':
     except OSError:
         mkl = ctypes.CDLL('libmkl_rt.1.dylib')
 elif sys.platform == 'win32':
-    mkl = ctypes.CDLL('mkl_rt.dll')
+    try:
+        mkl = ctypes.CDLL('mkl_rt.dll')
+    except OSError:
+        mkl = ctypes.CDLL('mkl_rt.1.dll')
 else:
     raise ValueError('Unrecognized plateform: %s' %sys.platform)
 


### PR DESCRIPTION
MKL numbers libraries now. Anaconda seems to have them numbered with '1'. Implemented in the same manner as it is done for Linux.