### PR TITLE
Fix logic for numba version 0.57.0

### DIFF
--- a/fbpic/utils/cuda.py
+++ b/fbpic/utils/cuda.py
@@ -387,7 +387,7 @@ if cuda_installed:
             # numba kernel
             module = cupy.cuda.function.Module()
             if numba_version[1] >= 56:
-                if numba_version[2] == 0:
+                if (numba_version[1] == 56) and (numba_version[2] == 0):
                     raise RuntimeError(
                         'FBPIC is incompatible with numba 0.56.0.\n'
                         'Please install either a later or an earlier version.')


### PR DESCRIPTION
The logic in `cuda.py` was incorrect. This PR fixes it and allows the code to run with numba 0.57.0.