### PR TITLE
Add option to symmetrize Gaussian beam

### DIFF
--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -265,6 +265,7 @@ def add_particle_bunch_gaussian(sim, q, m, sig_r, sig_z, n_emit, gamma0,
 
     # Add 4-fold copies of the beam by rotating particles by pi/2, pi and -pi/2
     if symmetrize:
+        w *= 0.25
         x, y, z, ux, uy, uz, w = map( np.concatenate, zip(
                                     [ x, y, z, ux, uy, uz, w],
                                     [-y, x, z,-uy, ux, uz, w],

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -617,7 +617,8 @@ def add_elec_bunch( sim, gamma0, n_e, p_zmin, p_zmax, p_rmin, p_rmax,
 
 def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0,
                         sig_gamma, Q, N, tf=0., zf=0., boost=None,
-                        save_beam=None, z_injection_plane=None ):
+                        save_beam=None, z_injection_plane=None,
+                        symmetrize=False ):
     """
     Introduce a relativistic Gaussian electron bunch in the simulation,
     along with its space charge field.
@@ -673,6 +674,12 @@ def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0,
         motion for z<z_injection_plane. This is sometimes useful in
         boosted-frame simulations.
         `z_injection_plane` is always given in the lab frame.
+
+    symmetrize: bool, optional
+       Whether to symmetrize the beam with 4-fold rotational symmetry.
+       (Meaning that, for every macroparticle, 3 other macroparticles
+       that are rotated by +pi/2, +pi, -pi/2 in the transverse plane)
+       This ensures that the beam has exactly 0 initial offset in x and y
     """
     # Generate Gaussian gamma distribution of the beam
     n_physical_particles = Q/e
@@ -680,7 +687,8 @@ def add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0,
                                 n_emit, gamma0, sig_gamma,
                                 n_physical_particles, N, tf=tf,
                                 zf=zf, boost=boost, save_beam=save_beam,
-                                z_injection_plane=z_injection_plane)
+                                z_injection_plane=z_injection_plane,
+                                symmetrize=symmetrize)
     return elec_bunch
 
 

--- a/fbpic/lpa_utils/bunch.py
+++ b/fbpic/lpa_utils/bunch.py
@@ -127,7 +127,8 @@ def add_particle_bunch_gaussian(sim, q, m, sig_r, sig_z, n_emit, gamma0,
                                 sig_gamma, n_physical_particles,
                                 n_macroparticles, tf=0., zf=0., boost=None,
                                 save_beam=None, z_injection_plane=None,
-                                initialize_self_field=True):
+                                initialize_self_field=True,
+                                symmetrize=False):
     """
     Introduce a relativistic Gaussian particle bunch in the simulation,
     along with its space charge field.
@@ -192,7 +193,18 @@ def add_particle_bunch_gaussian(sim, q, m, sig_r, sig_z, n_emit, gamma0,
     initialize_self_field: bool, optional
        Whether to calculate the initial space charge fields of the bunch
        and add these fields to the fields on the grid (Default: True)
+
+    symmetrize: bool, optional
+       Whether to symmetrize the beam with 4-fold rotational symmetry.
+       (Meaning that, for every macroparticle, 3 other macroparticles
+       that are rotated by +pi/2, +pi, -pi/2 in the transverse plane)
+       This ensures that the beam has exactly 0 initial offset in x and y
     """
+    if symmetrize:
+        assert n_macroparticles%4 == 0, \
+            "When using symmetrize, `n_macroparticles` must be a multiple of 4."
+        n_macroparticles = n_macroparticles//4
+
     # Generate Gaussian gamma distribution of the beam
     if sig_gamma > 0.:
         gamma = np.random.normal(gamma0, sig_gamma, n_macroparticles)
@@ -250,6 +262,14 @@ def add_particle_bunch_gaussian(sim, q, m, sig_r, sig_z, n_emit, gamma0,
         x = x - ux * inv_gamma * c * tf
         y = y - uy * inv_gamma * c * tf
         z = z - uz * inv_gamma * c * tf
+
+    # Add 4-fold copies of the beam by rotating particles by pi/2, pi and -pi/2
+    if symmetrize:
+        x, y, z, ux, uy, uz, w = map( np.concatenate, zip(
+                                    [ x, y, z, ux, uy, uz, w],
+                                    [-y, x, z,-uy, ux, uz, w],
+                                    [-x,-y, z,-ux,-uy, uz, w],
+                                    [ y,-x, z, uy,-ux, uz, w] ) )
 
     # Save beam distribution to an .npz file
     if save_beam is not None:

--- a/tests/test_space_charge.py
+++ b/tests/test_space_charge.py
@@ -116,6 +116,12 @@ def check_theory_gaussian():
     assert np.allclose( Ex, Eth, atol=0.1*Eth.max() )
     assert np.allclose( By, Bth, atol=0.1*Bth.max() )
 
+    # In addition, test that the mean of the transverse position
+    # is close to 0 (thanks to the symmetrize option)
+    transverse_quantities = ts.get_particle(['x', 'y', 'ux', 'uy'], iteration=0)
+    for q in transverse_quantities:
+        assert q.mean() < 1.e-10*q.std()
+
 def test_bunch_from_file():
     run_sim_serial_and_parallel( 'test_space_charge_file.py',
                                 'test_space_charge_file_data.txt')

--- a/tests/unautomated/test_space_charge_gaussian.py
+++ b/tests/unautomated/test_space_charge_gaussian.py
@@ -12,7 +12,7 @@ from scipy.constants import c
 import numpy as np
 # Import the relevant structures in FBPIC
 from fbpic.main import Simulation
-from fbpic.openpmd_diag import FieldDiagnostic
+from fbpic.openpmd_diag import FieldDiagnostic, ParticleDiagnostic
 from fbpic.lpa_utils.bunch import add_elec_bunch_gaussian
 
 # Set the seed since the gaussian is drawn randomly
@@ -49,9 +49,10 @@ sim = Simulation( Nz, zmax, Nr, rmax, Nm, dt,
 sim.set_moving_window( v=c )
 # Suppress the particles that were intialized by default and add the bunch
 sim.ptcl = [ ]
-add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0, sig_gamma,
+elec = add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0, sig_gamma,
                          Q, N, tf, zf, symmetrize=True )
 # Set the diagnostics
-sim.diags = [ FieldDiagnostic(10, sim.fld, comm=sim.comm) ]
+sim.diags = [ FieldDiagnostic(10, sim.fld, comm=sim.comm),
+            ParticleDiagnostic(10, species={'elec':elec}, comm=sim.comm) ]
 # Perform one simulation step (essentially in order to write the diags)
 sim.step(1)

--- a/tests/unautomated/test_space_charge_gaussian.py
+++ b/tests/unautomated/test_space_charge_gaussian.py
@@ -50,7 +50,7 @@ sim.set_moving_window( v=c )
 # Suppress the particles that were intialized by default and add the bunch
 sim.ptcl = [ ]
 add_elec_bunch_gaussian( sim, sig_r, sig_z, n_emit, gamma0, sig_gamma,
-                         Q, N, tf, zf )
+                         Q, N, tf, zf, symmetrize=True )
 # Set the diagnostics
 sim.diags = [ FieldDiagnostic(10, sim.fld, comm=sim.comm) ]
 # Perform one simulation step (essentially in order to write the diags)


### PR DESCRIPTION
This option avoids small random transverse offsets from statistical fluctuations in the beam initialization, so as to avoid e.g. seeding the hosing instability.