### PR TITLE
Update format and dependencies of CI test

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -33,7 +33,7 @@ jobs:
       name: Install dependencies
       run: |
         conda install --yes -c conda-forge numba scipy h5py mkl mpich mpi4py matplotlib python=${{ matrix.python-version }};
-        pip install openPMD-viewer pytest pyflakes matplotlib;
+        pip install openPMD-viewer pytest pyflakes;
         python setup.py install
     - shell: bash -l {0}
       name: pyflakes

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -40,7 +40,10 @@ jobs:
       run: python -m pyflakes .
     - shell: bash -l {0}
       name: FBPIC physics tests
-      run: export FBPIC_DISABLE_THREADING=1; python -m pytest tests --ignore=tests/unautomated --durations=10
+      run: |
+        export MKL_NUM_THREADS=1;
+        export NUMBA_NUM_THREADS=1;
+        python -m pytest tests --ignore=tests/unautomated --durations=10
     - shell: bash -l {0}
       name: PICMI test
       run: |

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -41,9 +41,10 @@ jobs:
     - shell: bash -l {0}
       name: FBPIC physics tests
       run: |
+        export NUMBA_THREADING_LAYER=omp;
         export MKL_NUM_THREADS=2;
         export NUMBA_NUM_THREADS=2;
-        python -m pytest tests --ignore=tests/unautomated --durations=10
+        python -m pytest tests --ignore=tests/unautomated
     - shell: bash -l {0}
       name: PICMI test
       run: |

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -32,16 +32,16 @@ jobs:
     - shell: bash -l {0}
       name: Install dependencies
       run: |
-        conda install --yes numba scipy h5py mkl matplotlib python=${{ matrix.python-version }};
+        conda install --yes numba scipy h5py mkl python=${{ matrix.python-version }};
         conda install --yes -c conda-forge mpich mpi4py;
-        pip install openPMD-viewer pytest pyflakes;
+        pip install openPMD-viewer pytest pyflakes matplotlib more-itertools<6.0.0;
         python setup.py install
     - shell: bash -l {0}
       name: pyflakes
       run: python -m pyflakes .
     - shell: bash -l {0}
       name: FBPIC physics tests
-      run: export FBPIC_DISABLE_THREADING=1; python -m pytest tests
+      run: export FBPIC_DISABLE_THREADING=1; python -m pytest tests --ignore=tests/unautomated --durations=10
     - shell: bash -l {0}
       name: PICMI test
       run: |

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.11]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -32,9 +32,8 @@ jobs:
     - shell: bash -l {0}
       name: Install dependencies
       run: |
-        conda install --yes numba scipy h5py mkl python=${{ matrix.python-version }};
-        conda install --yes -c conda-forge mpich mpi4py;
-        pip install openPMD-viewer pytest pyflakes matplotlib more-itertools<6.0.0;
+        conda install --yes -c conda-forge numba scipy h5py mkl mpich mpi4py matplotlib python=${{ matrix.python-version }};
+        pip install openPMD-viewer pytest pyflakes matplotlib;
         python setup.py install
     - shell: bash -l {0}
       name: pyflakes

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -32,7 +32,7 @@ jobs:
     - shell: bash -l {0}
       name: Install dependencies
       run: |
-        conda install --yes "numba<0.49" scipy h5py mkl python=${{ matrix.python-version }};
+        conda install --yes numba scipy h5py mkl python=${{ matrix.python-version }};
         conda install --yes -c conda-forge mpich mpi4py;
         pip install openPMD-viewer pytest pyflakes;
         python setup.py install

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -32,7 +32,7 @@ jobs:
     - shell: bash -l {0}
       name: Install dependencies
       run: |
-        conda install --yes numba scipy h5py mkl python=${{ matrix.python-version }};
+        conda install --yes numba scipy h5py mkl matplotlib python=${{ matrix.python-version }};
         conda install --yes -c conda-forge mpich mpi4py;
         pip install openPMD-viewer pytest pyflakes;
         python setup.py install

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -41,7 +41,7 @@ jobs:
       run: python -m pyflakes .
     - shell: bash -l {0}
       name: FBPIC physics tests
-      run: python setup.py test
+      run: export FBPIC_DISABLE_THREADING=1; python -m pytest tests
     - shell: bash -l {0}
       name: PICMI test
       run: |

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -41,8 +41,8 @@ jobs:
     - shell: bash -l {0}
       name: FBPIC physics tests
       run: |
-        export MKL_NUM_THREADS=1;
-        export NUMBA_NUM_THREADS=1;
+        export MKL_NUM_THREADS=2;
+        export NUMBA_NUM_THREADS=2;
         python -m pytest tests --ignore=tests/unautomated --durations=10
     - shell: bash -l {0}
       name: PICMI test

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,7 @@
 # Copyright 2016, FBPIC contributors
 # Authors: Remi Lehe, Manuel Kirchen, Kevin Peters, Soeren Jalas
 # License: 3-Clause-BSD-LBNL
-import sys
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 import fbpic # In order to extract the version number
 
 # Obtain the long description from README.md

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,6 @@ with open('./README.md') as f:
 with open('requirements.txt') as f:
     install_requires = [ line.strip('\n') for line in f.readlines() ]
 
-# Define a custom class to run the py.test with `python setup.py test`
-class PyTest(TestCommand):
-
-    def run_tests(self):
-        import pytest
-        errcode = pytest.main(['--ignore=tests/unautomated', '--durations=10'])
-        sys.exit(errcode)
-
 setup(
     name='fbpic',
     version=fbpic.__version__,
@@ -33,8 +25,6 @@ setup(
     maintainer_email='remi.lehe@normalesup.org',
     license='BSD-3-Clause-LBNL',
     packages=find_packages('.'),
-    tests_require=['more-itertools<6.0.0', 'pytest', 'openpmd_viewer'],
-    cmdclass={'test': PyTest},
     install_requires=install_requires,
     extras_require = {
         'picmi':  ["picmistandard", "numexpr", "periodictable"],


### PR DESCRIPTION
This updates the CI tests so that it:
- Uses a recent version of Python
- Uses the latest version of `numba`
- Avoids using the deprecated command `python setup.py test`