### PR TITLE
Remove obsolete "python setup.py test" command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ git pull git@github.com:fbpic/fbpic.git dev
   ```
   python setup.py install
   pip install matplotlib openPMD-viewer
-  python setup.py test
+  python -m pytest tests --ignore=tests/unautomated
   ```
   (Be patient: the tests can take approx. 5 min.)
 

--- a/tests/test_boosted.py
+++ b/tests/test_boosted.py
@@ -18,8 +18,6 @@ $ python tests/test_boosted.py
 
 In order to let Python check the agreement
 $ py.test -q tests/test_boosted.py
-or
-$ python setup.py test
 """
 
 # -------

--- a/tests/test_charge_cylinder.py
+++ b/tests/test_charge_cylinder.py
@@ -52,7 +52,7 @@ scales = [1.0, 0.5, 0.25, 0.1, 0.05, 0.025, 0.01]
 # -------------
 
 def test_charge_cylinder(show=False):
-    "Function that is run by py.test, when doing `python setup.py test`"
+    "Function that is run by py.test"
     for shape in ['linear', 'cubic']:
         charge_cylinder( shape, show )
 

--- a/tests/test_example_docs_scripts.py
+++ b/tests/test_example_docs_scripts.py
@@ -16,7 +16,6 @@ This file is meant to be run from the top directory of fbpic,
 by any of the following commands
 $ python tests/test_example_docs_scripts.py
 $ py.test -q tests/test_example_docs_scripts.py
-$ python setup.py test
 """
 import time
 import os

--- a/tests/test_external_fields.py
+++ b/tests/test_external_fields.py
@@ -157,11 +157,11 @@ def laser_func( F, x, y, z, t, amplitude, length_scale ):
     return( F + amplitude*math.cos( 2*np.pi*(z-c*t)/length_scale ) )
 
 def test_external_fields_lab(show=False):
-    "Function that is run by py.test, when doing `python setup.py test`"
+    "Function that is run by py.test"
     run_external_laser_field_simulation( show, None )
 
 def test_external_fields_boost(show=False):
-    "Function that is run by py.test, when doing `python setup.py test`"
+    "Function that is run by py.test"
     run_external_laser_field_simulation( show, gamma_boost=10 )
 
 if __name__ == '__main__' :

--- a/tests/test_fewcycle_laser.py
+++ b/tests/test_fewcycle_laser.py
@@ -17,7 +17,7 @@ $ python tests/test_fewcycle_laser.py
 In order to let Python check the agreement automatically
 $ py.test -q tests/test_fewcycle_laser.py
 or
-$ python setup.py test
+$
 """
 import numpy as np
 from scipy.constants import c
@@ -103,7 +103,7 @@ def compare_fields( grid, t, profile, show ):
 
 def test_laser_periodic(show=False):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the propagation of a laser in a periodic box.
     """
     # Propagate the pulse in a single step

--- a/tests/test_flattenedgauss_laser.py
+++ b/tests/test_flattenedgauss_laser.py
@@ -18,8 +18,6 @@ $ python tests/test_flattenedgauss_laser.py
 In order to let Python check the agreement between the curve without
 having to look at the plots
 $ py.test -q tests/test_flattenedgauss_laser.py
-or
-$ python setup.py test
 """
 import numpy as np
 from scipy.special import factorial
@@ -68,7 +66,7 @@ def flat_gauss(x, N):
 
 def test_laser_periodic(show=False):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the propagation of a laser in a periodic box.
     """
     # Propagate the pulse in a single step
@@ -79,7 +77,7 @@ def test_laser_periodic(show=False):
                 n_order=n_order, zmin=zmin, boundaries={'z':'periodic', 'r':'reflective'} )
 
     # Initialize the laser fields
-    profile = FlattenedGaussianLaser(a0=a0, w0=w0, N=N, 
+    profile = FlattenedGaussianLaser(a0=a0, w0=w0, N=N,
                                      tau=ctau/c, z0=0, zf=zfoc)
     add_laser_pulse( sim, profile )
 

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -31,8 +31,6 @@ $ python tests/test_laser.py
 In order to let Python check the agreement between the curve without
 having to look at the plots
 $ py.test -q tests/test_fields.py
-or
-$ python setup.py test
 """
 import numpy as np
 from scipy.constants import c, m_e, e
@@ -73,7 +71,7 @@ rtol = 1.e-4
 
 def test_laser_periodic(show=False):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the propagation of a laser in a periodic box.
     """
     # Choose a very long timestep to check the absence of Courant limit
@@ -92,7 +90,7 @@ def test_laser_periodic(show=False):
 
 def test_laser_moving_window(show=False):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the propagation of a laser in a moving window
     """
     # Choose the regular timestep (required by moving window)
@@ -111,7 +109,7 @@ def test_laser_moving_window(show=False):
 
 def test_laser_galilean(show=False):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the propagation of a laser with a galilean change of frame
     """
     # Choose the regular timestep (required by moving window)

--- a/tests/test_laser_antenna.py
+++ b/tests/test_laser_antenna.py
@@ -22,8 +22,6 @@ $ python tests/test_laser_antenna.py
 In order to let Python check the agreement between the curve without
 having to look at the plots
 $ py.test -q tests/test_laser_antenna.py
-or
-$ python setup.py test
 """
 import numpy as np
 from scipy.optimize import curve_fit
@@ -63,14 +61,14 @@ gamma_boost = 10.
 
 def test_antenna_labframe(show=False, write_files=False):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the emission of a laser by an antenna, in the lab frame
     """
     run_and_check_laser_antenna(None, show, write_files, z0=z0_antenna-ctau)
 
 def test_antenna_labframe_moving( show=False, write_files=False ):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the emission of a laser by a moving antenna, in the lab frame
     """
     run_and_check_laser_antenna( None, show, write_files, z0=z0_antenna+ctau,
@@ -78,7 +76,7 @@ def test_antenna_labframe_moving( show=False, write_files=False ):
 
 def test_antenna_boostedframe(show=False, write_files=False):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the emission of a laser by an antenna, in the boosted frame
     """
     run_and_check_laser_antenna(gamma_boost, show, write_files,

--- a/tests/test_parax_approx_laser.py
+++ b/tests/test_parax_approx_laser.py
@@ -17,8 +17,6 @@ In order to let Python check the agreement:
 $ python tests/test_parax_approx_laser.py
 or
 $ py.test -q tests/test_parax_approx_laser.py
-or
-$ python setup.py test
 """
 import numpy as np
 from scipy.constants import c, epsilon_0, m_e, e
@@ -70,7 +68,7 @@ def retrieve_pulse_energy(Er, r, dr, dz):
 
 def test_laser_periodic(case='gaussian'):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the propagation of a laser in a periodic box.
     """
     # Propagate the pulse in a single step

--- a/tests/test_periodic_plasma_wave.py
+++ b/tests/test_periodic_plasma_wave.py
@@ -21,8 +21,6 @@ $ mpirun -np 2 python tests/test_periodic_plasma_wave.py # Two-proc simulation
 In order to let Python check the agreement between the curve without
 having to look at the plots
 $ py.test -q tests/test_periodic_plasma_wave.py
-or
-$ python setup.py test
 
 Theory:
 -------
@@ -171,11 +169,11 @@ N_step = int( 2*np.pi/(wp*dt)*0.75 )
 # -------------
 
 def test_periodic_plasma_wave_linear_shape( show=False ):
-    "Function that is run by py.test, when doing `python setup.py test"
+    "Function that is run by py.test"
     simulate_periodic_plasma_wave( 'linear', show=show )
 
 def test_periodic_plasma_wave_cubic_shape( show=False ):
-    "Function that is run by py.test, when doing `python setup.py test"
+    "Function that is run by py.test"
     simulate_periodic_plasma_wave( 'cubic', show=show )
 
 def simulate_periodic_plasma_wave( particle_shape, show=False ):

--- a/tests/test_pml.py
+++ b/tests/test_pml.py
@@ -52,14 +52,14 @@ z0 = 0.
 
 def test_laser_periodic(show=False):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the propagation of a laser in a periodic box.
     """
     run_parallel( show=show, z_boundary='periodic', use_galilean=False )
 
 def test_laser_galilean(show=False):
     """
-    Function that is run by py.test, when doing `python setup.py test`
+    Function that is run by py.test
     Test the propagation of a laser with a galilean change of frame
     """
     run_parallel( show=show, z_boundary='open', use_galilean=True )

--- a/tests/test_space_charge.py
+++ b/tests/test_space_charge.py
@@ -12,7 +12,6 @@ This file is meant to be run from the top directory of fbpic,
 by any of the following commands
 $ python tests/test_space_charge.py
 $ py.test -q tests/test_space_charge.py
-$ python setup.py test
 """
 import os
 import shutil

--- a/tests/test_uniform_rho_deposition.py
+++ b/tests/test_uniform_rho_deposition.py
@@ -46,7 +46,7 @@ frac_shift = 0.01
 # -------------
 
 def test_uniform_electron_plasma(show=False):
-    "Function that is run by py.test, when doing `python setup.py test`"
+    "Function that is run by py.test"
     for shape in ['linear', 'cubic']:
         uniform_electron_plasma( shape, show )
 
@@ -92,7 +92,7 @@ def uniform_electron_plasma(shape, show=False):
         plt.show()
 
 def test_neutral_plasma_shifted(show=False):
-    "Function that is run by py.test, when doing `python setup.py test`"
+    "Function that is run by py.test"
     for shape in ['linear', 'cubic']:
         neutral_plasma_shifted( shape, show )
 

--- a/tests/unautomated/test_picmi.py
+++ b/tests/unautomated/test_picmi.py
@@ -13,7 +13,6 @@ This file is meant to be run from the top directory of fbpic,
 by any of the following commands
 $ python tests/test_picmi.py
 $ py.test -q tests/test_picmi.py
-$ python setup.py test
 """
 import os
 import re

--- a/tests/unautomated/test_pml.py
+++ b/tests/unautomated/test_pml.py
@@ -20,8 +20,6 @@ $ python tests/test_pml.py
 In order to let Python check the agreement between the curve without
 having to look at the plots
 $ py.test -q tests/test_pml.py
-or
-$ python setup.py test
 """
 import numpy as np
 from scipy.constants import c


### PR DESCRIPTION
The command `python setup.py test` is obsolete and should be replaced by `python -m pytest tests --ignore=tests/unautomated` (See https://github.com/fbpic/fbpic/pull/646).

This PR updates various comments and docstrings, to remove the obsolete command.