### PR TITLE
Fix pyflakes error

### DIFF
--- a/fbpic/main.py
+++ b/fbpic/main.py
@@ -944,11 +944,9 @@ class Simulation(object):
                     coef = self.boost.gamma0*(1 - beta_m_lab*self.boost.beta0)
                     args = _check_dens_func_arguments( dens_func )
                     if args == ['z', 'r']:
-                        def new_dens_func( z, r ):
-                            return dens_func( coef*z, r )
+                        new_dens_func = lambda z, r: dens_func( coef*z, r )
                     elif args == ['x', 'y', 'z']:
-                        def new_dens_func( x, y, z ):
-                            return dens_func( x, y, coef*z )
+                        new_dens_func = lambda x, y, z: dens_func( x, y, coef*z )
 
             # Modify input particle bounds, in order to only initialize the
             # particles in the local sub-domain


### PR DESCRIPTION
With recent versions of `pyflakes`, it seems that the file `main.py` raises the following error:
```
fbpic/main.py:947:25: redefinition of unused 'new_dens_func' from line 897
```
This PR fixes the issue with a minor change in syntax.