### PR TITLE
Fix version of numexpr to avoid error message in CI

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -50,7 +50,7 @@ jobs:
     - shell: bash -eo pipefail -l {0}
       name: PICMI test
       run: |
-        pip install wget picmistandard numexpr periodictable
+        pip install wget picmistandard numexpr<2.8.5 periodictable
         cd tests/unautomated
         curl https://raw.githubusercontent.com/picmi-standard/picmi/master/Examples/laser_acceleration/laser_acceleration_PICMI.py -o fbpic_script.py
         python test_picmi.py

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -50,7 +50,7 @@ jobs:
     - shell: bash -eo pipefail -l {0}
       name: PICMI test
       run: |
-        pip install wget picmistandard numexpr<2.8.5 periodictable
+        pip install wget picmistandard numexpr==2.8.4 periodictable
         cd tests/unautomated
         curl https://raw.githubusercontent.com/picmi-standard/picmi/master/Examples/laser_acceleration/laser_acceleration_PICMI.py -o fbpic_script.py
         python test_picmi.py


### PR DESCRIPTION
It seems that `numexpr 2.8.5` has some breaking changes that result in errors when certain floating point notations. For instance:
```
numexpr.evaluate('1.e24')
```
results in 
```
Expression 1.e24 has forbidden control characters.
```

For now, I will fix the version of `numexpr` to avoid this issue.