### PR TITLE
add info on mkl issue with apple silicon

### DIFF
--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -77,6 +77,13 @@ MPI-related error, try installing ``mpi4py`` using MacPorts and
    sudo port select --set mpi openmpi-gcc48-fortran
    pip install mpi4py
 
+If you are running on an Apple Silicon machine, `mkl` is not available via `conda`. You can use `brew` instead:
+
+::
+
+   brew install onednn
+
+
 Running simulations
 -------------------
 


### PR DESCRIPTION
The `mkl` library is not available for M1/M2 Apple Silicon chips via conda. 
`brew`'s https://formulae.brew.sh/formula/onednn could be an alternative. 
At least for me (no MPI, M1 pro), fbpic ran. 