### PR TITLE
Check the lasy version when reading lasy files

### DIFF
--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -910,10 +910,10 @@ class FromLasyFileLaser( LaserProfile ):
                 valid_version = True
         if not valid_version:
             raise RuntimeError(
-                "The `lasy` version that was used to create the file %s " %filename
+                "The `lasy` version that was used to create the file %s "
                 "is obsolete and not supported by FBPIC. Please upgrade your lasy "
                 "version to at least 0.3.0 (e.g. with `pip install --upgrade lasy`) "
-                "and re-create the file %s." %filename)
+                "and re-create the file %s." %(filename, filename) )
 
         dset = f['/data/0/meshes/laserEnvelope']
         self.omega = dset.attrs['angularFrequency']

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -845,9 +845,9 @@ class FromLasyFileLaser( LaserProfile ):
         """
         Define a laser whose profile is determined by a
         `lasy <https://lasydoc.readthedocs.io/en/latest/>`_ file.
-        
-        When the laser is initialized by this function, FBPIC forces the beginning of 
-        the time axis in the ``lasy`` file to be zero (irrespective of the metadata for 
+
+        When the laser is initialized by this function, FBPIC forces the beginning of
+        the time axis in the ``lasy`` file to be zero (irrespective of the metadata for
         ``tmin`` that is actually present in the ``lasy`` file). This convention was chosen
         for convenience, because ``tmin`` in ``lasy`` could otherwise result in large delays
         before emitting the laser, especially when using ``lasy``'s ``propagate`` feature.
@@ -860,14 +860,14 @@ class FromLasyFileLaser( LaserProfile ):
         t_start: float (in seconds), optional, default: 0
             Physical time (in the simulation), at which the laser will start being
             emitted. This can be used in order to introduce a time delay that was
-            not originally present in the ``lasy`` file. (As explained above, FBPIC ignores any 
+            not originally present in the ``lasy`` file. (As explained above, FBPIC ignores any
             initial time offset in the ``lasy``. This offset is replaced by `t_start` (or zero if unspecified).
 
         .. warning::
 
             This laser profile can only be emitted with the ``antenna`` method
             (not with the ``direct`` method).
-            
+
     Example
     ---------
     .. code-block:: python
@@ -883,14 +883,14 @@ class FromLasyFileLaser( LaserProfile ):
         laser.write_to_file('lasy_laser', 'h5')
         # Note that, in the lasy file, tmin is now a large, negative number.
         # (The peak of laser intensity still occurs 2.5*pulse_duration after tmin.)
-        # FBPIC ignores tmin when reading the file, and sets the start of 
-        # the lasy time axis to zero instead. So, by default, the peak of 
+        # FBPIC ignores tmin when reading the file, and sets the start of
+        # the lasy time axis to zero instead. So, by default, the peak of
         # the laser intensity would occur at `t= 2.5*pulse_duration` in FBPIC.
         laser_profile = FromLasyFileLaser( 'lasy_laser_00000.h5', t_start=0.5*pulse_duration )
         add_laser_pulse(sim, laser_profile, method='antenna', z0_antenna=0)
-        # Here, modify the `t_start`, which will result in the peak of intensity being 
+        # Here, modify the `t_start`, which will result in the peak of intensity being
         # emitted at `(2.5+0.5)*pulse_duration` instead of `2.5*pulse_duration`.
-        # Since the `z0_antenna` was set to `0` here, this is as if the centroid 
+        # Since the `z0_antenna` was set to `0` here, this is as if the centroid
         # of the laser would have been initialized at `z = -3*c*pulse_duration` at `t=0`
         # (with then ``direct`` method).
         """
@@ -900,6 +900,21 @@ class FromLasyFileLaser( LaserProfile ):
 
         # Open and read the lasy file
         f = h5py.File( filename, mode="r" )
+
+        # Check lasy version
+        valid_version = False
+        if ('softwareVersion' in f.attrs):
+            version_string = f.attrs['softwareVersion'].decode()
+            version_list = tuple(int(number) for number in version_string.split('.'))
+            if version_list >= (0,3,0):
+                valid_version = True
+        if not valid_version:
+            raise RuntimeError(
+                "The `lasy` version that was used to create the file %s " %filename
+                "is obsolete and not supported by FBPIC. Please upgrade your lasy "
+                "version to at least 0.3.0 (e.g. with `pip install --upgrade lasy`) "
+                "and re-create the file %s." %filename)
+
         dset = f['/data/0/meshes/laserEnvelope']
         self.omega = dset.attrs['angularFrequency']
         self.pol = dset.attrs['polarization']


### PR DESCRIPTION
Since the format of `lasy` files has been evolving, we need to check the version number of the file, before attempting to read it.