### PR TITLE
Better check of the lasy version

### DIFF
--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -906,15 +906,16 @@ class FromLasyFileLaser( LaserProfile ):
 
         # Check lasy version
         valid_version = False
-        if ('softwareVersion' in f.attrs):
+        if ('software' in f.attrs) and ('softwareVersion' in f.attrs):
+            software = f.attrs['software'].decode()
             version_string = f.attrs['softwareVersion'].decode()
             version_list = tuple(int(number) for number in version_string.split('.'))
-            if version_list >= (0,3,0):
+            if (software == "lasy") and (version_list >= (0,3,0)):
                 valid_version = True
         if not valid_version:
             raise RuntimeError(
                 "The `lasy` version that was used to create the file %s "
-                "is obsolete and not supported by FBPIC. Please upgrade your lasy "
+                "is obsolete and not supported by FBPIC.\nPlease upgrade your lasy "
                 "version to at least 0.3.0 (e.g. with `pip install --upgrade lasy`) "
                 "and re-create the file %s." %(filename, filename) )
 


### PR DESCRIPTION
In version of `lasy` before 0.2.0, the `'software'` metadata stored in the openPMD file is actually `'openPMD-api'` and the version is usually higher than `0.14`. This implies that the current check in FBPIC (which attempts to verify that the file has been created with `lasy` version 0.3.0 or higher) is not working as intended. This PR fixes the issue.