### PR TITLE
Add script to automatically publish releases to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,35 @@
+name: Publish package to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-n-publish:
+    name: Build and publish package to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python3 -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish package distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,14 +37,4 @@ username: <yourPypiUsername>
 
 ## Uploading the package to PyPI
 
-- Upload the package to [PyPI](https://pypi.python.org/pypi):
-
-```
-rm -rf dist
-python setup.py sdist bdist_wheel
-twine upload dist/* -r pypi
-```
-
-(NB: You can also first test this by uploading the package to
-[test PyPI](https://testpypi.python.org/pypi) ; to do so, simply
-replace `pypi` by `pypitest` in the above set of commands)
+The code will be automatically uploaded to PyPI upon creation of a new release on Github.


### PR DESCRIPTION
This adds a script to automatically publish new FBPIC releases to PyPI (see https://docs.pypi.org/trusted-publishers/)

Inspired by: https://github.com/LASY-org/lasy/pull/159