### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ pip install fbpic
 interface, you can instead use `pip install fbpic[picmi]`.)
 
 - **Optional:** in order to run on GPU, install the additional package
-`cudatoolkit` and `cupy`.
+`cupy` -- e.g. using CUDA version 11.8. (The command below also automatically installs `cudatoolkit` which is also needed by FBPIC.)
 ```
-conda install cudatoolkit cupy
+conda install cupy cuda-version=11.8
 ```
 (In the above command, you should choose a CUDA version that is compatible with your GPU driver ; see [this table](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#major-components__table-cuda-toolkit-driver-versions) for more info.)
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,9 @@ pip install fbpic
 interface, you can instead use `pip install fbpic[picmi]`.)
 
 - **Optional:** in order to run on GPU, install the additional package
-`cudatoolkit` and `cupy` -- e.g. using CUDA version 10.0.
+`cudatoolkit` and `cupy`.
 ```
-conda install cudatoolkit=10.0
-pip install cupy-cuda100
+conda install cudatoolkit cupy
 ```
 (In the above command, you should choose a CUDA version that is compatible with your GPU driver ; see [this table](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#major-components__table-cuda-toolkit-driver-versions) for more info.)
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -39,12 +39,12 @@ Python. If Anaconda is not your default Python distribution, download and instal
        A shortcut for this is: ``python3 -m pip install git+https://github.com/fbpic/fbpic.git``.
 
 -  **Optional:** In order to be able to run the code on a GPU,
-   install the additional package ``cudatoolkit`` and ``cupy``.
+   install the additional package ``cupy``.
 
    ::
 
 
-       conda install -c conda-forge cudatoolkit cupy
+       conda install -c conda-forge cupy
 
    .. warning::
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -39,14 +39,12 @@ Python. If Anaconda is not your default Python distribution, download and instal
        A shortcut for this is: ``python3 -m pip install git+https://github.com/fbpic/fbpic.git``.
 
 -  **Optional:** In order to be able to run the code on a GPU,
-   install the additional package ``cudatoolkit`` and ``cupy`` --
-   e.g. using CUDA version 11.0:
+   install the additional package ``cudatoolkit`` and ``cupy``.
 
    ::
 
 
-       conda install -c conda-forge cudatoolkit=11.0
-       pip install cupy-cuda110
+       conda install -c conda-forge cudatoolkit cupy
 
    .. warning::
 


### PR DESCRIPTION
It seems that installing compatible version of `cudatookit` and `cupy` is now much simpler. (At least it works on my machine.) I updated the installation instructions accordingly.

https://docs.cupy.dev/en/stable/install.html#installing-cupy-from-conda-forge