### PR TITLE
Update documentation for CUDA 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,29 +64,34 @@ it from [here](https://www.continuum.io/downloads).
 **Installation steps**:
 
 - Install the dependencies of FBPIC. This can be done in two lines:
-```
-conda install numba scipy h5py mkl
-conda install -c conda-forge mpi4py
-```
+    ```
+    conda install numba scipy h5py mkl
+    conda install -c conda-forge mpi4py
+    ```
 - Download and install FBPIC:
-```
-pip install fbpic
-```
-(If you want to run FBPIC through the [PICMI](https://picmi-standard.github.io/)
-interface, you can instead use `pip install fbpic[picmi]`.)
+    ```
+    pip install fbpic
+    ```
+    (If you want to run FBPIC through the [PICMI](https://picmi-standard.github.io/)
+    interface, you can instead use `pip install fbpic[picmi]`.)
 
 - **Optional:** in order to run on GPU, install the additional package
-`cupy` -- e.g. using CUDA version 11.8. (The command below also automatically installs `cudatoolkit` which is also needed by FBPIC.)
-```
-conda install cupy cuda-version=11.8
-```
-(In the above command, you should choose a CUDA version that is compatible with your GPU driver ; see [this table](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#major-components__table-cuda-toolkit-driver-versions) for more info.)
+    `cupy` — e.g. using CUDA version 11.8. (The command below also automatically installs `cudatoolkit` which is also needed by FBPIC.)
+    ```
+    conda install cupy cuda-version=11.8
+    ```
+    (In the above command, you should choose a CUDA version that is compatible with your GPU driver ; see [this table](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#major-components__table-cuda-toolkit-driver-versions) for more info.)
+
+    If you want to use CUDA version 12+ which no longer comes with the `cudatoolkit` package, explicit installation of `cuda-nvcc` and `cuda-nvrtc` is required
+    ```
+    conda install cupy cuda-version=12.0 cuda-nvcc cuda-nvrtc
+    ```
 
 - **Optional:** in order to run on a CPU which is **not** an Intel model, you
 need to install `pyfftw`, in order to replace the MKL FFT:
-```
-conda install -c conda-forge pyfftw
-```
+    ```
+    conda install -c conda-forge pyfftw
+    ```
 
 ## Running simulations
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -39,19 +39,32 @@ Python. If Anaconda is not your default Python distribution, download and instal
        A shortcut for this is: ``python3 -m pip install git+https://github.com/fbpic/fbpic.git``.
 
 -  **Optional:** In order to be able to run the code on a GPU,
-   install the additional package ``cupy``.
+   install the additional package ``cupy`` as well as dependencies needed to enable GPU support in ``numba``.
 
+   For CUDA versions below 12, install ``cupy`` and ``cuda-version`` (which will automatically install ``cudatoolkit``), for example
    ::
 
 
-       conda install -c conda-forge cupy
+       conda install -c conda-forge cupy cuda-version=11.8
+
+   For CUDA 12+ which no longer provides the ``cudatoolkit`` package, explicit installation of ``cuda-nvcc`` and ``cuda-nvrtc`` is required
+
+   :: 
+
+      conda install -c conda-forge cupy cuda-version=12.0 cuda-nvcc cuda-nvrtc
 
    .. warning::
 
-       In the above command, you should choose a CUDA version that is **compatible
+       In the above commands, you should choose a CUDA version that is **compatible
        with your GPU driver**. You can see the version of your GPU driver by typing
        the command ``nvidia-smi``. You can then find the compatible CUDA
        versions using `this table <https://docs.nvidia.com/deploy/cuda-compatibility/index.html#use-the-right-compat-package>`__.
+
+       To prevent ``conda`` from automatically updating the CUDA packages to incompatible newer versions, pin the ``cuda-version`` package, e.g.
+       
+       ::
+         
+          echo "cuda-version==12.0.*" > $CONDA_PREFIX/conda-meta/pinned
 
 -  **Optional:** In order to run on a CPU which is **not** an Intel model, you need to install `pyfftw`, in order to replace the MKL FFT:
 

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -60,12 +60,6 @@ Python. If Anaconda is not your default Python distribution, download and instal
        the command ``nvidia-smi``. You can then find the compatible CUDA
        versions using `this table <https://docs.nvidia.com/deploy/cuda-compatibility/index.html#use-the-right-compat-package>`__.
 
-       To prevent ``conda`` from automatically updating the CUDA packages to incompatible newer versions, pin the ``cuda-version`` package, e.g.
-       
-       ::
-         
-          echo "cuda-version==12.0.*" > $CONDA_PREFIX/conda-meta/pinned
-
 -  **Optional:** In order to run on a CPU which is **not** an Intel model, you need to install `pyfftw`, in order to replace the MKL FFT:
 
    ::


### PR DESCRIPTION
- For CUDA 12, suggest installing "cuda-nvcc cuda-nvrtc" in the README and the docs
- Add information about pinning packages in conda
- Fix indentation fot the list in the README

For `cupy`, `cuda-version` is a formal dependency, and it is sufficient to make `cupy` running. However, in order to have CUDA 12 support in Numba, `cuda-nvcc cuda-nvrtc` are also needed (see https://github.com/numba/numba/issues/9045, this didn't make it to the latest Numba docs yet).