### PR TITLE
Make FBPIC compatible with Numpy 2.0

### DIFF
--- a/fbpic/openpmd_diag/field_diag.py
+++ b/fbpic/openpmd_diag/field_diag.py
@@ -316,22 +316,22 @@ class FieldDiagnostic(OpenPMDDiagnostic):
         dset : an h5py.Group object that contains all the mesh quantities
         """
         # Field Solver
-        dset.attrs["fieldSolver"] = np.string_("PSATD")
+        dset.attrs["fieldSolver"] = np.bytes_("PSATD")
         # Field boundary
         dset.attrs["fieldBoundary"] = np.array([
-            np.string_("reflecting"), np.string_("reflecting"),
-            np.string_("reflecting"), np.string_("reflecting") ])
+            np.bytes_("reflecting"), np.bytes_("reflecting"),
+            np.bytes_("reflecting"), np.bytes_("reflecting") ])
         # Particle boundary
         dset.attrs["particleBoundary"] = np.array([
-            np.string_("absorbing"), np.string_("absorbing"),
-            np.string_("absorbing"), np.string_("absorbing") ])
+            np.bytes_("absorbing"), np.bytes_("absorbing"),
+            np.bytes_("absorbing"), np.bytes_("absorbing") ])
         # Current Smoothing
-        dset.attrs["currentSmoothing"] = np.string_("Binomial")
+        dset.attrs["currentSmoothing"] = np.bytes_("Binomial")
         dset.attrs["currentSmoothingParameters"] = \
-          np.string_("period=1;numPasses=1;compensator=false")
+          np.bytes_("period=1;numPasses=1;compensator=false")
         # Charge correction
-        dset.attrs["chargeCorrection"] = np.string_("spectral")
-        dset.attrs["chargeCorrectionParameters"] = np.string_("period=1")
+        dset.attrs["chargeCorrection"] = np.bytes_("spectral")
+        dset.attrs["chargeCorrectionParameters"] = np.bytes_("period=1")
 
     def setup_openpmd_mesh_record( self, dset, quantity, dz, zmin ) :
         """
@@ -354,9 +354,9 @@ class FieldDiagnostic(OpenPMDDiagnostic):
         self.setup_openpmd_record( dset, quantity )
 
         # Geometry parameters
-        dset.attrs['geometry'] = np.string_("thetaMode")
+        dset.attrs['geometry'] = np.bytes_("thetaMode")
         dset.attrs['geometryParameters'] = \
-            np.string_("m={:d};imag=+".format(self.fld.Nm))
+            np.bytes_("m={:d};imag=+".format(self.fld.Nm))
         dset.attrs['gridSpacing'] = np.array([
                 self.fld.interp[0].dr, dz ])
         dset.attrs["gridGlobalOffset"] = np.array([
@@ -364,9 +364,9 @@ class FieldDiagnostic(OpenPMDDiagnostic):
         dset.attrs['axisLabels'] = np.array([ b'r', b'z' ])
 
         # Generic attributes
-        dset.attrs["dataOrder"] = np.string_("C")
+        dset.attrs["dataOrder"] = np.bytes_("C")
         dset.attrs["gridUnitSI"] = 1.
-        dset.attrs["fieldSmoothing"] = np.string_("none")
+        dset.attrs["fieldSmoothing"] = np.bytes_("none")
 
     def setup_openpmd_mesh_component( self, dset, quantity ) :
         """

--- a/fbpic/openpmd_diag/generic_diag.py
+++ b/fbpic/openpmd_diag/generic_diag.py
@@ -183,18 +183,18 @@ class OpenPMDDiagnostic(object) :
         # Set the attributes of the HDF5 file
 
         # General attributes
-        f.attrs["openPMD"] = np.string_("1.0.0")
+        f.attrs["openPMD"] = np.bytes_("1.0.0")
         f.attrs["openPMDextension"] = np.uint32(1)
-        f.attrs["software"] = np.string_("fbpic " + fbpic_version)
-        f.attrs["date"] = np.string_(
+        f.attrs["software"] = np.bytes_("fbpic " + fbpic_version)
+        f.attrs["date"] = np.bytes_(
             datetime.datetime.now(tzlocal()).strftime('%Y-%m-%d %H:%M:%S %z'))
-        f.attrs["meshesPath"] = np.string_("fields/")
-        f.attrs["particlesPath"] = np.string_("particles/")
-        f.attrs["iterationEncoding"] = np.string_("fileBased")
-        f.attrs["iterationFormat"] =  np.string_("data%T.h5")
+        f.attrs["meshesPath"] = np.bytes_("fields/")
+        f.attrs["particlesPath"] = np.bytes_("particles/")
+        f.attrs["iterationEncoding"] = np.bytes_("fileBased")
+        f.attrs["iterationFormat"] =  np.bytes_("data%T.h5")
 
         # Setup the basePath
-        f.attrs["basePath"] = np.string_("/data/%T/")
+        f.attrs["basePath"] = np.bytes_("/data/%T/")
         base_path = "/data/%d/" %iteration
         bp = f.require_group( base_path )
         bp.attrs["time"] = time

--- a/fbpic/openpmd_diag/inputscript_diag.py
+++ b/fbpic/openpmd_diag/inputscript_diag.py
@@ -105,13 +105,13 @@ class InputScriptDiagnostic(OpenPMDDiagnostic):
         f = self.open_file(fullpath)
         # Only the first proc does writing to file
         if f is not None:
-            f.attrs["inputScript"] = np.string_(self._input_script)
+            f.attrs["inputScript"] = np.bytes_(self._input_script)
 
             # Write the extra parameters, if required
             if self.param_dict is not None:
                 for key, val in self.param_dict.items():
                     if isinstance(val, str):
-                        f.attrs[key] = np.string_(val)
+                        f.attrs[key] = np.bytes_(val)
                     elif isinstance(val, (list, tuple)):
                         f.attrs[key] = np.array(val)
                     else: #if isinstance(val, (int, float)):

--- a/fbpic/openpmd_diag/particle_diag.py
+++ b/fbpic/openpmd_diag/particle_diag.py
@@ -147,10 +147,10 @@ class ParticleDiagnostic(OpenPMDDiagnostic) :
         """
         # Generic attributes
         grp.attrs["particleShape"] = 1.
-        grp.attrs["currentDeposition"] = np.string_("directMorseNielson")
-        grp.attrs["particleSmoothing"] = np.string_("none")
-        grp.attrs["particlePush"] = np.string_("Vay")
-        grp.attrs["particleInterpolation"] = np.string_("uniform")
+        grp.attrs["currentDeposition"] = np.bytes_("directMorseNielson")
+        grp.attrs["particleSmoothing"] = np.bytes_("none")
+        grp.attrs["particlePush"] = np.bytes_("Vay")
+        grp.attrs["particleInterpolation"] = np.bytes_("uniform")
 
         # Setup constant datasets (e.g. charge, mass)
         for quantity in constant_quantities:


### PR DESCRIPTION
When using FBPIC with Numpy 2.0, one gets the following error:
```
AttributeError: `np.string_` was removed in the NumPy 2.0 release. Use `np.bytes_` instead.. Did you mean: 'strings'?
```

This PR fixes the issue.