### PR TITLE
Update CI test for latest lasy version

### DIFF
--- a/tests/test_lasy_laser.py
+++ b/tests/test_lasy_laser.py
@@ -150,7 +150,7 @@ def run_and_check_laser_emission(gamma_b, data_dir, lasy_geometry):
         npoints = (200,200,200)
         laser = Laser(lasy_geometry, lo, hi, npoints, profile)
     laser.propagate(-3 * c * tau)
-    laser.write_to_file("laguerrelaserRZ")
+    laser.write_to_file("laguerrelaserRZ", write_dir='lasy_data')
 
     # Create an FBPIC simulation that reads this lasy file
     # Initialize the simulation object
@@ -172,7 +172,7 @@ def run_and_check_laser_emission(gamma_b, data_dir, lasy_geometry):
     sim.set_moving_window(v=c)
 
     # Add the laser
-    laser_profile = FromLasyFileLaser( 'diags/laguerrelaserRZ_00000.h5' )
+    laser_profile = FromLasyFileLaser( 'lasy_data/laguerrelaserRZ_00000.h5' )
     add_laser_pulse(sim, laser_profile, method='antenna',
                     z0_antenna=0, gamma_boost=gamma_b)
 
@@ -197,7 +197,7 @@ def run_and_check_laser_emission(gamma_b, data_dir, lasy_geometry):
 
     # Remove openPMD and lasy files
     shutil.rmtree(data_dir)
-    os.remove('laguerrelaserRZ_00000.h5')
+    shutil.rmtree('lasy_data') # This folder is created by lasy
     os.chdir('../')
 
 def test_laser_emission_labframe():

--- a/tests/test_lasy_laser.py
+++ b/tests/test_lasy_laser.py
@@ -172,7 +172,7 @@ def run_and_check_laser_emission(gamma_b, data_dir, lasy_geometry):
     sim.set_moving_window(v=c)
 
     # Add the laser
-    laser_profile = FromLasyFileLaser( 'laguerrelaserRZ_00000.h5' )
+    laser_profile = FromLasyFileLaser( 'diags/laguerrelaserRZ_00000.h5' )
     add_laser_pulse(sim, laser_profile, method='antenna',
                     z0_antenna=0, gamma_boost=gamma_b)
 


### PR DESCRIPTION
The latest version of `lasy` (`lasy 0.5.0`) was released 2 days ago. 
With this new release, the files produced by `lasy` are automatically saved in the folder `diags` (see https://github.com/LASY-org/lasy/pull/260). CI tests therefore need to be updated to read files from this folder.