### PR TITLE
Fix SyntaxWarnings for invalid escape sequences in strings

### DIFF
--- a/fbpic/fields/spectral_transform/hankel.py
+++ b/fbpic/fields/spectral_transform/hankel.py
@@ -1,7 +1,7 @@
 # Copyright 2016, FBPIC contributors
 # Authors: Remi Lehe, Manuel Kirchen
 # License: 3-Clause-BSD-LBNL
-"""
+r"""
 This file is part of FBPIC (Fourier-Bessel Particle-In-Cell code).
 It defines the class that performs the Hankel transform.
 

--- a/fbpic/fields/utility_methods.py
+++ b/fbpic/fields/utility_methods.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy.constants import c
 
 def get_modified_k(k, n_order, dz):
-    """
+    r"""
     Calculate the modified k that corresponds to a finite-order stencil
 
     The modified k are given by the formula

--- a/fbpic/lpa_utils/laser/antenna_injection.py
+++ b/fbpic/lpa_utils/laser/antenna_injection.py
@@ -22,7 +22,7 @@ if cuda_installed:
         deposit_rho_gpu_unsorted, deposit_J_gpu_unsorted
 
 class LaserAntenna( object ):
-    """
+    r"""
     Class that implements the emission of a laser by an antenna
 
     The antenna produces a current on the grid (in a thin slice along z), which

--- a/fbpic/lpa_utils/laser/laser.py
+++ b/fbpic/lpa_utils/laser/laser.py
@@ -115,7 +115,7 @@ def add_laser( sim, a0, w0, ctau, z0, zf=None, lambda0=0.8e-6,
                gamma_boost=None, method='direct',
                fw_propagating=True, update_spectral=True,
                z0_antenna=None, v_antenna=0. ):
-    """
+    r"""
     Introduce a linearly-polarized, Gaussian laser in the simulation.
 
     More precisely, the electric field **near the focal plane**

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -182,7 +182,7 @@ class GaussianLaser( LaserProfile ):
     def __init__( self, a0, waist, tau, z0, zf=None, theta_pol=0.,
                     lambda0=0.8e-6, cep_phase=0., phi2_chirp=0.,
                     propagation_direction=1 ):
-        """
+        r"""
         Define a linearly-polarized Gaussian laser profile.
 
         More precisely, the electric field **near the focal plane**
@@ -299,7 +299,7 @@ class LaguerreGaussLaser( LaserProfile ):
     def __init__( self, p, m, a0, waist, tau, z0, zf=None, theta_pol=0.,
                     lambda0=0.8e-6, cep_phase=0., theta0=0.,
                     propagation_direction=1 ):
-        """
+        r"""
         Define a linearly-polarized Laguerre-Gauss laser profile.
 
         Unlike the :any:`DonutLikeLaguerreGaussLaser` profile, this
@@ -450,7 +450,7 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
 
     def __init__( self, p, m, a0, waist, tau, z0, zf=None, theta_pol=0.,
                     lambda0=0.8e-6, cep_phase=0., propagation_direction=1 ):
-        """
+        r"""
         Define a linearly-polarized donut-like Laguerre-Gauss laser profile.
 
         Unlike the :any:`LaguerreGaussLaser` profile, this
@@ -589,7 +589,7 @@ class FlattenedGaussianLaser( LaserProfile ):
 
     def __init__( self, a0, w0, tau, z0, N=6, zf=None, theta_pol=0.,
                     lambda0=0.8e-6, cep_phase=0., propagation_direction=1 ):
-        """
+        r"""
         Define a linearly-polarized laser such that the transverse intensity
         profile is a flattened Gaussian **far from focus**, and a distribution
         with rings **in the focal plane**. (See `Santarsiero et al., J.
@@ -715,7 +715,7 @@ class FewCycleLaser( LaserProfile ):
 
     def __init__( self, a0, waist, tau_fwhm, z0, zf=None, theta_pol=0.,
                     lambda0=0.8e-6, cep_phase=0., propagation_direction=1 ):
-        """
+        r"""
         When a laser pulse is so short that it contains **only a few laser cycles**,
         the standard Gaussian profile :any:`GaussianLaser` is not well-adapted.
         This is because :any:`GaussianLaser` neglects the fact that different

--- a/fbpic/lpa_utils/laser/longitudinal_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/longitudinal_laser_profiles.py
@@ -72,7 +72,7 @@ class LaserLongitudinalProfile(object):
         return np.zeros_like(z, dtype='complex')
 
     def squared_profile_integral(self):
-        """
+        r"""
         Return the integral of the square of the absolute value of
         of the (complex) laser profile along the `z` axis:
 
@@ -96,7 +96,7 @@ class GaussianChirpedLongitudinalProfile(LaserLongitudinalProfile):
 
     def __init__(self, tau, z0, lambda0=0.8e-6, cep_phase=0.,
                  phi2_chirp=0., propagation_direction=1):
-        """
+        r"""
         Define the complex longitudinal profile of a Gaussian laser pulse.
 
         At the focus and for zero chirp, this translates to a laser with an
@@ -195,7 +195,7 @@ class CustomSpectrumLongitudinalProfile(LaserLongitudinalProfile):
                  phi2_chirp=0., phi3_chirp=0., phi4_chirp=0.,
                  subtract_linear_phase=False,
                  propagation_direction=1):
-        """
+        r"""
         Define the complex longitudinal profile of the laser pulse,
         from the spectrum provided in `spectrum_file`.
 

--- a/fbpic/lpa_utils/laser/transverse_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/transverse_laser_profiles.py
@@ -68,7 +68,7 @@ class LaserTransverseProfile(object):
         return np.zeros_like(x, dtype='complex')
 
     def squared_profile_integral(self):
-        """
+        r"""
         Return the integral of the square of the absolute value of
         of the (complex) laser profile in the transverse plane:
 
@@ -92,7 +92,7 @@ class GaussianTransverseProfile(LaserTransverseProfile):
     """Class that calculates a Gaussian transverse laser profile."""
 
     def __init__(self, waist, zf=0., lambda0=0.8e-6, propagation_direction=1):
-        """
+        r"""
         Define the complex transverse profile of a Gaussian laser.
 
         **In the focal plane** (:math:`z=z_f`), the profile translates to a
@@ -171,7 +171,7 @@ class LaguerreGaussTransverseProfile( LaserTransverseProfile ):
 
     def __init__( self, p, m, waist, zf=0., lambda0=0.8e-6, theta0=0.,
                   propagation_direction=1 ):
-        """
+        r"""
         Define the complex transverse profile of a Laguerre-Gauss laser.
 
         Unlike the :any:`DonutLikeLaguerreGaussLaser` profile, this
@@ -315,7 +315,7 @@ class DonutLikeLaguerreGaussTransverseProfile( LaserTransverseProfile ):
 
     def __init__( self, p, m, waist, zf=0., lambda0=0.8e-6,
                   propagation_direction=1 ):
-        """
+        r"""
         Define the complex transverse profile of a donut-like Laguerre-Gauss
         laser.
 
@@ -437,7 +437,7 @@ class FlattenedGaussianTransverseProfile( LaserTransverseProfile ):
 
     def __init__( self, w0, N=6, zf=0., lambda0=0.8e-6,
                   propagation_direction=1 ):
-        """
+        r"""
         Define a complex transverse profile with a flattened Gaussian intensity
         distribution **far from focus** that transform into a distribution
         with rings **in the focal plane**. (See `Santarsiero et al., J.

--- a/fbpic/openpmd_diag/boosted_field_diag.py
+++ b/fbpic/openpmd_diag/boosted_field_diag.py
@@ -692,7 +692,7 @@ class SliceHandler:
         return( output_array )
 
     def transform_fields_to_lab_frame( self, fields ):
-        """
+        r"""
         Modifies the array `fields` in place, to transform the field values
         from the boosted frame to the lab frame.
 

--- a/fbpic/openpmd_diag/checkpoint_restart.py
+++ b/fbpic/openpmd_diag/checkpoint_restart.py
@@ -203,7 +203,7 @@ def check_restart( sim, iteration, checkpoint_dir ):
     # Infer the number of processors that were used for the checkpoint
     # and check that it is the same as the current number of processors
     nproc = 0
-    regex_matcher = re.compile('proc\d+')
+    regex_matcher = re.compile(r'proc\d+')
     for directory in os.listdir(checkpoint_dir):
         if regex_matcher.match(directory) is not None:
             nproc += 1

--- a/fbpic/particles/elementary_process/ionization/read_atomic_data.py
+++ b/fbpic/particles/elementary_process/ionization/read_atomic_data.py
@@ -71,7 +71,7 @@ def read_ionization_energies( element ):
     # - the ionization level (represented as the second (\d+))
     # - the ionization energy (represented as (\d+\.*\d*))
     regex_command = \
-        '\n\s+(\d+)\s+\|\s+%s\s+\w+\s+\|\s+\+*(\d+)\s+\|\s+\(*\[*(\d+\.*\d*)' \
+        r'\n\s+(\d+)\s+\|\s+%s\s+\w+\s+\|\s+\+*(\d+)\s+\|\s+\(*\[*(\d+\.*\d*)' \
         %element
     list_of_tuples = re.findall( regex_command, text_data )
     # Return None if the requested element was not found


### PR DESCRIPTION
This PR addresses numerous SyntaxWarnings related to invalid escape sequences (e.g., `\s`, `\d`, `\f`, `\b`, `\p`, `\,`) found within standard string literals.

**Issue:**

These warnings occurred in two main places:

Regular expression patterns passed to the re module.
Multi-line docstrings containing LaTeX/math markup for documentation generation.

These warnings might not have been consistently visible because Python's bytecode caching (`__pycache__` directories) suppresses warnings on subsequent runs if the source `.py` file hasn't changed, so they are only visible when you run `fbpic` for the _first time_ or when you _clear existing bytecode cache_ before running.

**Steps to Reproduce**

1. Ensure you are in the root directory of the `fbpic` repository.
2. Set up your Python environment and clear any existing Python bytecode cache:
```bash
find fbpic/ -name "__pycache__" -type d -exec rm -rf {} +
```
3. Run an example script that imports the affected modules:
```bash
python docs/source/example_input/lwfa_script.py
```
4. Output:
```
SyntaxWarning: /home/berceanu/Development/fbpic/fbpic/particles/elementary_process/ionization/read_atomic_data.py:74:
invalid escape sequence '\s'

SyntaxWarning: /home/berceanu/Development/fbpic/fbpic/fields/utility_methods.py:12:
invalid escape sequence '\s'

SyntaxWarning: /home/berceanu/Development/fbpic/fbpic/fields/spectral_transform/hankel.py:4:
invalid escape sequence '\p'

SyntaxWarning: /home/berceanu/Development/fbpic/fbpic/lpa_utils/laser/laser.py:118:
invalid escape sequence '\,'

SyntaxWarning: /home/berceanu/Development/fbpic/fbpic/lpa_utils/laser/laser_profiles.py:185:
invalid escape sequence '\,'

[truncated]
```

**Fix**

The fix applied is to convert all affected string literals into raw strings by prefixing them with r (e.g., `r'...'`, `r"""..."""`).

Note: used `Python 3.12` and the following package versions:

```
Package         Version     Editable project location
--------------- ----------- --------------------------------
cupy-cuda12x    13.4.1
fastrlock       0.8.3
fbpic           0.26.1      ~/Development/fbpic
h5py            3.13.0
llvmlite        0.44.0
mpi4py          4.0.3
numba           0.61.0
numpy           2.1.3
pyfftw          0.15.0
python-dateutil 2.9.0.post0
scipy           1.15.2
setuptools      78.1.0
six             1.17.0
```