### PR TITLE
Improve installation instructions for non-Intel environments

### DIFF
--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -10,11 +10,11 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
 **Installation steps**:
 
-- Install the dependencies of FBPIC:
+-  Install the dependencies of FBPIC:
 
-  ::
+   ::
 
-     conda install -c conda-forge numba scipy pyfftw mkl mpi4py
+      conda install -c conda-forge numba scipy pyfftw mkl mpi4py
 
    .. note::
 
@@ -25,21 +25,21 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
          conda install -c conda-forge mkl
 
--  Install ``fbpic``
+-  Install ``fbpic``:
 
    ::
 
-       pip install fbpic
+      pip install fbpic
 
    .. note::
 
-       If you want to run FBPIC through the
-       `PICMI interface <https://picmi-standard.github.io/>`__, you can instead
-       use
+      If you want to run FBPIC through the
+      `PICMI interface <https://picmi-standard.github.io/>`__, you can instead
+      use
 
-       ::
+      ::
 
-           pip install fbpic[picmi]
+         pip install fbpic[picmi]
 
    .. note::
        Instead of using a release, you can also install FBPIC from the sources,

--- a/docs/source/install/install_local.rst
+++ b/docs/source/install/install_local.rst
@@ -14,7 +14,16 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
   ::
 
-     conda install -c conda-forge numba scipy h5py mkl mpi4py
+     conda install -c conda-forge numba scipy pyfftw mkl mpi4py
+
+   .. note::
+
+      If you want to run FBPIC on an Intel CPU (not applicable if you want to run on
+      a Macbook with Apple Silicon, or on a GPU), you can additionally install ``mkl`` for better performance.
+
+      ::
+
+         conda install -c conda-forge mkl
 
 -  Install ``fbpic``
 
@@ -49,7 +58,7 @@ Python. If Anaconda is not your default Python distribution, download and instal
 
    For CUDA 12+ which no longer provides the ``cudatoolkit`` package, explicit installation of ``cuda-nvcc`` and ``cuda-nvrtc`` is required
 
-   :: 
+   ::
 
       conda install -c conda-forge cupy cuda-version=12.0 cuda-nvcc cuda-nvrtc
 
@@ -59,13 +68,6 @@ Python. If Anaconda is not your default Python distribution, download and instal
        with your GPU driver**. You can see the version of your GPU driver by typing
        the command ``nvidia-smi``. You can then find the compatible CUDA
        versions using `this table <https://docs.nvidia.com/deploy/cuda-compatibility/index.html#use-the-right-compat-package>`__.
-
--  **Optional:** In order to run on a CPU which is **not** an Intel model, you need to install `pyfftw`, in order to replace the MKL FFT:
-
-   ::
-
-      conda install -c conda-forge pyfftw
-
 
 Potential issues
 ----------------


### PR DESCRIPTION
The default installation instructions assumed that the CPU used is an Intel CPU. However, this has become less common recently. Thus, the default installation instructions here are modified to ensure that they work also on a non-Intel CPU.