### PR TITLE
Interface for SR diagnostics and documentation fixes

### DIFF
--- a/docs/source/api_reference/lpa_utilities/betatron.rst
+++ b/docs/source/api_reference/lpa_utilities/betatron.rst
@@ -51,6 +51,9 @@ the proper profile.
 Optionally the plugin can deduce the photon momentum from the emitting electron in order to 
 simulate the classical radiation reaction.
 
+.. warning::
+    Currently this plugin only works in the lab-frame simulations.
+
 Plugin is activated for the chosen particle specie (electron) with the following method:
 
 .. automethod:: fbpic.particles.Particles.activate_synchrotron

--- a/docs/source/api_reference/particles.rst
+++ b/docs/source/api_reference/particles.rst
@@ -23,4 +23,4 @@ the list ``Simulation.ptcl``.
    .. automethod:: track
    .. automethod:: make_ionizable
    .. automethod:: activate_spin_tracking
-
+   .. automethod:: activate_synchrotron

--- a/fbpic/openpmd_diag/sr_diag.py
+++ b/fbpic/openpmd_diag/sr_diag.py
@@ -32,8 +32,11 @@ class SRDiagnostic(OpenPMDDiagnostic):
             The period of the diagnostics, in physical time of the simulation.
             Specify either this or `period`
 
-        sr_object : a Synchrotron Radiation object
-            Points to the data that has to be written at each output
+        species: a dictionary of :any:`Particles` objects
+            The object that is written (e.g. elec)
+            is assigned to the particle name of this species.
+            (e.g. {"electrons": elec }). All species must have synchrotron
+            radiation activated with the same specral-angular grids.
 
         comm : an fbpic BoundaryCommunicator object or None
             If this is not None, the data is gathered on the first proc,
@@ -53,25 +56,34 @@ class SRDiagnostic(OpenPMDDiagnostic):
         # Check input
         if len(species) == 0:
             raise ValueError(
-            "`SRDiagnostic` requires the list of the species with active `sr_object`.")
+            "`SRDiagnostic` requires the dictionary with the species.")
 
         # Register the arguments
         self.species = species
         self.species_names = list( species.keys() )
 
+        for species_name in self.species_names:
+            if species[ species_name ].synchrotron_radiator is None:
+                raise ValueError(
+                    f"{species_name} must have synchrotron radiation active")
+
         sr_object = species[ self.species_names[0] ].synchrotron_radiator
 
         self.use_cuda = sr_object.use_cuda
         self.dt_sim = sr_object.dt
-        self.mesh_shape = (sr_object.N_theta_x, sr_object.N_theta_y, sr_object.N_omega)
+        self.mesh_shape = (
+            sr_object.N_theta_x, sr_object.N_theta_y, sr_object.N_omega
+        )
 
         self.mesh_spacing = np.array([
-            sr_object.d_theta_x, sr_object.d_theta_y, sr_object.d_omega * hbar ])
+            sr_object.d_theta_x, sr_object.d_theta_y,
+            sr_object.d_omega * hbar ]
+        )
 
         self.mesh_origin = np.array([
             sr_object.theta_x_min, sr_object.theta_x_min,
-            sr_object.omega_min * hbar ])
-
+            sr_object.omega_min * hbar
+        ])
 
         # General setup
         OpenPMDDiagnostic.__init__(self, period, comm, write_dir,
@@ -92,7 +104,8 @@ class SRDiagnostic(OpenPMDDiagnostic):
         # If needed: Receive data from the GPU
         if self.use_cuda :
             for specie_name in self.species_names:
-                self.species[specie_name].synchrotron_radiator.receive_from_gpu()
+                self.species[specie_name].synchrotron_radiator\
+                    .receive_from_gpu()
 
         # Extract information needed for the openPMD attributes
         time = iteration * self.dt_sim

--- a/fbpic/openpmd_diag/sr_diag.py
+++ b/fbpic/openpmd_diag/sr_diag.py
@@ -49,7 +49,7 @@ class SRDiagnostic(OpenPMDDiagnostic):
             to be written. If none is provided, this will be the path
             of the current working directory
 
-        iteration_min, iteration_max: ints
+        iteration_min, iteration_max: ints, optional
             The iterations between which data should be written
             (`iteration_min` is inclusive, `iteration_max` is exclusive)
         """

--- a/fbpic/openpmd_diag/sr_diag.py
+++ b/fbpic/openpmd_diag/sr_diag.py
@@ -162,7 +162,7 @@ class SRDiagnostic(OpenPMDDiagnostic):
 
     def get_dataset( self, specie ):
         """
-        Copy and dathers radation data on the first proc, in MPI mode
+        Copy and gather radation data on the first proc, in MPI mode
         """
         # Get the data on each individual proc
         data_one_proc = specie.synchrotron_radiator.radiation_data.copy()
@@ -219,45 +219,16 @@ class SRDiagnostic(OpenPMDDiagnostic):
             # Setup the meshes group (contains all the fields)
             field_path = "/data/%d/fields/" %iteration
             field_grp = f.require_group(field_path)
-            self.setup_openpmd_meshes_group(field_grp)
 
             for specie_name in self.species_names:
                 dset = field_grp.require_dataset(
                     f"radiation_{specie_name}", self.mesh_shape, dtype='f8')
-
-                self.setup_openpmd_mesh_component( dset )
-                # Setup the record to which it belongs
-                self.setup_openpmd_mesh_record( dset, "radiation" )
+                # Setup the record and the component to which it belongs
+                self.setup_openpmd_mesh_component_record( dset, "radiation" )
             # Close the file
             f.close()
 
-    def setup_openpmd_meshes_group( self, dset ) :
-        """
-        Set the attributes that are specific to the mesh path
-
-        Parameter
-        ---------
-        dset : an h5py.Group object that contains all the mesh quantities
-        """
-        # Field Solver
-        dset.attrs["fieldSolver"] = np.bytes_("PSATD")
-        # Field boundary
-        dset.attrs["fieldBoundary"] = np.array([
-            np.bytes_("reflecting"), np.bytes_("reflecting"),
-            np.bytes_("reflecting"), np.bytes_("reflecting") ])
-        # Particle boundary
-        dset.attrs["particleBoundary"] = np.array([
-            np.bytes_("absorbing"), np.bytes_("absorbing"),
-            np.bytes_("absorbing"), np.bytes_("absorbing") ])
-        # Current Smoothing
-        dset.attrs["currentSmoothing"] = np.bytes_("Binomial")
-        dset.attrs["currentSmoothingParameters"] = \
-          np.bytes_("period=1;numPasses=1;compensator=false")
-        # Charge correction
-        dset.attrs["chargeCorrection"] = np.bytes_("spectral")
-        dset.attrs["chargeCorrectionParameters"] = np.bytes_("period=1")
-
-    def setup_openpmd_mesh_record( self, dset, quantity ) :
+    def setup_openpmd_mesh_component_record( self, dset, quantity ) :
         """
         Sets the attributes that are specific to a mesh record
 
@@ -282,17 +253,6 @@ class SRDiagnostic(OpenPMDDiagnostic):
         dset.attrs["gridUnitSI"] = 1.
         dset.attrs["fieldSmoothing"] = np.bytes_("none")
 
-    def setup_openpmd_mesh_component( self, dset ) :
-        """
-        Set up the attributes of a mesh component
-
-        Parameter
-        ---------
-        dset : an h5py.Dataset or h5py.Group object
-
-        quantity : string
-            The field that is being written
-        """
         # Generic setup of the component
         self.setup_openpmd_component( dset )
 

--- a/fbpic/openpmd_diag/sr_diag.py
+++ b/fbpic/openpmd_diag/sr_diag.py
@@ -15,7 +15,7 @@ class SRDiagnostic(OpenPMDDiagnostic):
     Class that defines the synchrotron radiation diagnostics to be performed.
     """
 
-    def __init__(self, period=None, dt_period=None, sr_object=None, comm=None,
+    def __init__(self, period=None, dt_period=None, species={}, comm=None,
                  write_dir=None,iteration_min=0, iteration_max=np.inf ):
         """
         Initialize the synchrotron radiation diagnostic
@@ -51,17 +51,33 @@ class SRDiagnostic(OpenPMDDiagnostic):
             (`iteration_min` is inclusive, `iteration_max` is exclusive)
         """
         # Check input
-        if sr_object is None:
+        if len(species) == 0:
             raise ValueError(
-            "You need to pass the argument `sr_object` to `SRDiagnostic`.")
+            "`SRDiagnostic` requires the list of the species with active `sr_object`.")
+
+        # Register the arguments
+        self.species = species
+        self.species_names = list( species.keys() )
+
+        sr_object = species[ self.species_names[0] ].synchrotron_radiator
+
+        self.use_cuda = sr_object.use_cuda
+        self.dt_sim = sr_object.dt
+        self.mesh_shape = (sr_object.N_theta_x, sr_object.N_theta_y, sr_object.N_omega)
+
+        self.mesh_spacing = np.array([
+            sr_object.d_theta_x, sr_object.d_theta_y, sr_object.d_omega * hbar ])
+
+        self.mesh_origin = np.array([
+            sr_object.theta_x_min, sr_object.theta_x_min,
+            sr_object.omega_min * hbar ])
+
 
         # General setup
         OpenPMDDiagnostic.__init__(self, period, comm, write_dir,
                             iteration_min, iteration_max,
-                            dt_period=dt_period, dt_sim=sr_object.dt )
+                            dt_period=dt_period, dt_sim=self.dt_sim )
 
-        # Register the arguments
-        self.fld = sr_object
 
     def write_hdf5( self, iteration ):
         """
@@ -74,12 +90,12 @@ class SRDiagnostic(OpenPMDDiagnostic):
         """
 
         # If needed: Receive data from the GPU
-        if self.fld.use_cuda :
-            self.fld.receive_from_gpu()
+        if self.use_cuda :
+            for specie_name in self.species_names:
+                self.species[specie_name].synchrotron_radiator.receive_from_gpu()
 
         # Extract information needed for the openPMD attributes
-        dt = self.fld.dt
-        time = iteration * dt
+        time = iteration * self.dt_sim
 
         # Create the file with these attributes
         filename = "data%08d.h5" %iteration
@@ -103,8 +119,9 @@ class SRDiagnostic(OpenPMDDiagnostic):
             f.close()
 
         # Send data to the GPU if needed
-        if self.fld.use_cuda :
-            self.fld.send_to_gpu()
+        if self.use_cuda :
+            for specie_name in self.species_names:
+                self.species[specie_name].synchrotron_radiator.send_to_gpu()
 
     # Writing methods
     # ---------------
@@ -120,20 +137,22 @@ class SRDiagnostic(OpenPMDDiagnostic):
         path : string
             The relative path where to write the dataset, in field_grp
         """
-        # Extract the correct dataset
-        data_array = self.get_dataset()
-        if field_grp is not None:
-            dset = field_grp[path]
-            dset[:] =  data_array
-        else:
-            dset = None
 
-    def get_dataset( self ):
+        for specie_name in self.species_names:
+            path_specie = path + '_' + specie_name
+            data_array = self.get_dataset( self.species[specie_name] )
+            if field_grp is not None:
+                dset = field_grp[path_specie]
+                dset[:] =  data_array
+            else:
+                dset = None
+
+    def get_dataset( self, specie ):
         """
         Copy and dathers radation data on the first proc, in MPI mode
         """
         # Get the data on each individual proc
-        data_one_proc = self.fld.radiation_data.copy()
+        data_one_proc = specie.synchrotron_radiator.radiation_data.copy()
 
         # Gather the data
         if self.comm.size>1:
@@ -174,10 +193,6 @@ class SRDiagnostic(OpenPMDDiagnostic):
         time: float (seconds)
             The physical time at this iteration
         """
-        # Determine the shape of the datasets that will be written
-        data_shape = ( self.fld.N_theta_x, self.fld.N_theta_y,
-                       self.fld.N_omega )
-
         # Create the file
         f = self.open_file( fullpath )
 
@@ -186,18 +201,20 @@ class SRDiagnostic(OpenPMDDiagnostic):
         if f is not None:
 
             # Setup the attributes of the top level of the file
-            self.setup_openpmd_file( f, iteration, time, self.fld.dt )
+            self.setup_openpmd_file( f, iteration, time, self.dt_sim )
 
             # Setup the meshes group (contains all the fields)
             field_path = "/data/%d/fields/" %iteration
             field_grp = f.require_group(field_path)
             self.setup_openpmd_meshes_group(field_grp)
 
-            dset = field_grp.require_dataset(
-                "radiation", data_shape, dtype='f8')
-            self.setup_openpmd_mesh_component( dset, "radiation" )
-            # Setup the record to which it belongs
-            self.setup_openpmd_mesh_record( dset, "radiation" )
+            for specie_name in self.species_names:
+                dset = field_grp.require_dataset(
+                    f"radiation_{specie_name}", self.mesh_shape, dtype='f8')
+
+                self.setup_openpmd_mesh_component( dset )
+                # Setup the record to which it belongs
+                self.setup_openpmd_mesh_record( dset, "radiation" )
             # Close the file
             f.close()
 
@@ -244,21 +261,15 @@ class SRDiagnostic(OpenPMDDiagnostic):
         # Geometry parameters
         dset.attrs['geometry'] = np.bytes_("cartesian")
         dset.attrs['axisLabels'] = np.array([ b'x', b'y', b'z' ])
-
-        dset.attrs['gridSpacing'] = np.array([
-                self.fld.d_theta_x, self.fld.d_theta_y,
-                self.fld.d_omega * hbar ])
-
-        dset.attrs["gridGlobalOffset"] = np.array([
-            self.fld.theta_x_min, self.fld.theta_x_min,
-            self.fld.omega_min * hbar ])
+        dset.attrs['gridSpacing'] = self.mesh_spacing
+        dset.attrs["gridGlobalOffset"] = self.mesh_origin
 
         # Generic attributes
         dset.attrs["dataOrder"] = np.bytes_("C")
         dset.attrs["gridUnitSI"] = 1.
         dset.attrs["fieldSmoothing"] = np.bytes_("none")
 
-    def setup_openpmd_mesh_component( self, dset, quantity ) :
+    def setup_openpmd_mesh_component( self, dset ) :
         """
         Set up the attributes of a mesh component
 

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -481,16 +481,16 @@ class Particles(object) :
             `(theta_y_min, theta_y_max, N_theta_y)`, where `theta_y_min`
             and `theta_y_max` are floats in radians and `N_theta_y` is integer
 
-        gamma_cutoff: float (optional)
+        gamma_cutoff: float, optional
             Minimal particle gamma factor for which radiation is calculated
 
         radiation_reaction: bool
             Whether to consider radiation reaction on the electrons
 
-        x_max: float (optional)
+        x_max: float, optional
             Extent of the sampling used for the spectral profile function
 
-        nSamples: integer (optional)
+        nSamples: integer, optional
             number of sampling points for the spectral profile function
         """
         self.synchrotron_radiator = SynchrotronRadiator(

--- a/tests/test_synchrotron.py
+++ b/tests/test_synchrotron.py
@@ -108,7 +108,7 @@ def run_simulation():
     # Add diagnostics
     sim.diags = [
                   SRDiagnostic(period=N_step,
-                    sr_object=bunch.synchrotron_radiator,
+                    species={'bunch': bunch},
                     comm=sim.comm)
                 ]
 
@@ -117,14 +117,14 @@ def run_simulation():
 
 def check_energy():
     ts = OpenPMDTimeSeries('./diags/hdf5/')
-    radiation_fbpic, info = ts.get_field('radiation', t=ts.t[-1], slice_across=None)
+    radiation_fbpic, info = ts.get_field('radiation_bunch', t=ts.t[-1], slice_across=None)
     rad_energy = radiation_fbpic.sum() * info.dx * info.dy * info.dz
     err = np.abs( rad_energy - rad_energy_theory ) / rad_energy
     assert err<0.06
 
 def check_angle():
     ts = OpenPMDTimeSeries('./diags/hdf5/')
-    radiation_fbpic, info = ts.get_field('radiation', t=ts.t[-1], slice_across=None)
+    radiation_fbpic, info = ts.get_field('radiation_bunch', t=ts.t[-1], slice_across=None)
     spot = radiation_fbpic.sum(-1)
     thx = info.x
 
@@ -138,7 +138,7 @@ def check_angle():
 
 def check_spectrum():
     ts = OpenPMDTimeSeries('./diags/hdf5/')
-    radiation_fbpic, info = ts.get_field('radiation', t=ts.t[-1], slice_across=None)
+    radiation_fbpic, info = ts.get_field('radiation_bunch', t=ts.t[-1], slice_across=None)
     spect_1d = radiation_fbpic[
         radiation_fbpic.shape[0]//2, radiation_fbpic.shape[1]//2
     ]


### PR DESCRIPTION
This is as follow-up PR for the merged  #655 that uses a better syntax for synchrotron radiation diagnostics. Similarly to the ParticleDensityDiagnostics it takes dictionary with species with  `activate_synchrotron` plug-in enabled and writes the produced emission field with names derived from species names, i.e. the diagnostics :
```
 SRDiagnostic(period=diag_period, write_dir='diags_radiation',
    species={'electrons_He': electrons_He, 'electrons_N': electrons_N,},
    comm=sim.comm),
```
will produce fields `'radiation_electrons_He'` and `'radiation_electrons_N'`

The grid parameters of radiation (i.e. `photon_energy_axis`,  `theta_x_axis`, `theta_y_axis`) are assumed to be the same for all species per diagnostics.