### PR TITLE
Set `inline=False` for CUDA 13 compatibility

### DIFF
--- a/fbpic/lpa_utils/external_fields.py
+++ b/fbpic/lpa_utils/external_fields.py
@@ -134,7 +134,7 @@ class ExternalField( object ):
         self.cpu_func = cpu_compiler( func )
         if cuda_installed:
             # First create a device inline function
-            inline_func = cuda.jit( func, inline=True, device=True )
+            inline_func = cuda.jit( func, inline=False, device=True )
             # Then create a CUDA kernel and compile it the usual way
             def external_field_kernel( F, x, y, z, t, amplitude, length_scale ):
                 i = cuda.grid(1)

--- a/fbpic/particles/deposition/cuda_methods.py
+++ b/fbpic/particles/deposition/cuda_methods.py
@@ -15,10 +15,10 @@ from fbpic.particles.deposition.particle_shapes import Sz_linear, \
     Sr_linear, Sz_cubic, Sr_cubic
 
 # JIT-compilation of particle shapes
-Sz_linear = cuda.jit(Sz_linear, device=True, inline=True)
-Sr_linear = cuda.jit(Sr_linear, device=True, inline=True)
-Sz_cubic = cuda.jit(Sz_cubic, device=True, inline=True)
-Sr_cubic = cuda.jit(Sr_cubic, device=True, inline=True)
+Sz_linear = cuda.jit(Sz_linear, device=True, inline=False)
+Sr_linear = cuda.jit(Sr_linear, device=True, inline=False)
+Sz_cubic = cuda.jit(Sz_cubic, device=True, inline=False)
+Sr_cubic = cuda.jit(Sr_cubic, device=True, inline=False)
 
 # -------------------------------
 # Field deposition - linear - rho

--- a/fbpic/particles/deposition/cuda_methods_one_mode.py
+++ b/fbpic/particles/deposition/cuda_methods_one_mode.py
@@ -15,10 +15,10 @@ from fbpic.particles.deposition.particle_shapes import Sz_linear, \
     Sr_linear, Sz_cubic, Sr_cubic
 
 # JIT-compilation of particle shapes
-Sz_linear = cuda.jit(Sz_linear, device=True, inline=True)
-Sr_linear = cuda.jit(Sr_linear, device=True, inline=True)
-Sz_cubic = cuda.jit(Sz_cubic, device=True, inline=True)
-Sr_cubic = cuda.jit(Sr_cubic, device=True, inline=True)
+Sz_linear = cuda.jit(Sz_linear, device=True, inline=False)
+Sr_linear = cuda.jit(Sr_linear, device=True, inline=False)
+Sz_cubic = cuda.jit(Sz_cubic, device=True, inline=False)
+Sr_cubic = cuda.jit(Sr_cubic, device=True, inline=False)
 
 # -------------------------------
 # Field deposition - linear - rho

--- a/fbpic/particles/deposition/cuda_methods_unsorted.py
+++ b/fbpic/particles/deposition/cuda_methods_unsorted.py
@@ -12,8 +12,8 @@ from fbpic.particles.deposition.particle_shapes import Sz_linear, \
     Sr_linear
 
 # JIT-compilation of particle shapes
-Sz_linear = cuda.jit(Sz_linear, device=True, inline=True)
-Sr_linear = cuda.jit(Sr_linear, device=True, inline=True)
+Sz_linear = cuda.jit(Sz_linear, device=True, inline=False)
+Sr_linear = cuda.jit(Sr_linear, device=True, inline=False)
 
 @compile_cupy
 def deposit_rho_gpu_unsorted(x, y, z, w, q,

--- a/fbpic/particles/elementary_process/compton/cuda_methods.py
+++ b/fbpic/particles/elementary_process/compton/cuda_methods.py
@@ -13,11 +13,11 @@ from numba.cuda.random import xoroshiro128p_uniform_float64
 from .inline_functions import lorentz_transform, get_scattering_probability, \
     get_photon_density_gaussian, INV_MC
 # Compile the inline functions for GPU
-lorentz_transform = cuda.jit( lorentz_transform, device=True, inline=True )
+lorentz_transform = cuda.jit( lorentz_transform, device=True, inline=False )
 get_scattering_probability = cuda.jit( get_scattering_probability,
-                                            device=True, inline=True )
+                                            device=True, inline=False )
 get_photon_density_gaussian = cuda.jit( get_photon_density_gaussian,
-                                            device=True, inline=True )
+                                            device=True, inline=False )
 
 @compile_cupy
 def get_photon_density_gaussian_cuda( photon_n, elec_Ntot,

--- a/fbpic/particles/elementary_process/ionization/cuda_methods.py
+++ b/fbpic/particles/elementary_process/ionization/cuda_methods.py
@@ -15,11 +15,11 @@ from .inline_functions import get_ionization_probability, \
     get_E_amplitude, copy_ionized_electrons_batch
 # Compile the inline functions for GPU
 get_ionization_probability = cuda.jit( get_ionization_probability,
-                                        device=True, inline=True )
+                                        device=True, inline=False )
 get_E_amplitude = cuda.jit( get_E_amplitude,
-                            device=True, inline=True )
+                            device=True, inline=False )
 copy_ionized_electrons_batch = cuda.jit( copy_ionized_electrons_batch,
-                                            device=True, inline=True )
+                                            device=True, inline=False )
 
 @compile_cupy
 def ionize_ions_cuda( N_batch, batch_size, Ntot,

--- a/fbpic/particles/gathering/cuda_methods.py
+++ b/fbpic/particles/gathering/cuda_methods.py
@@ -14,9 +14,9 @@ from .inline_functions import \
     add_linear_gather_for_mode, add_cubic_gather_for_mode
 # Compile the inline functions for GPU
 add_linear_gather_for_mode = cuda.jit( add_linear_gather_for_mode,
-                                        device=True, inline=True )
+                                        device=True, inline=False )
 add_cubic_gather_for_mode = cuda.jit( add_cubic_gather_for_mode,
-                                        device=True, inline=True )
+                                        device=True, inline=False )
 
 # -----------------------
 # Field gathering linear

--- a/fbpic/particles/gathering/cuda_methods_one_mode.py
+++ b/fbpic/particles/gathering/cuda_methods_one_mode.py
@@ -14,9 +14,9 @@ from .inline_functions import \
     add_linear_gather_for_mode, add_cubic_gather_for_mode
 # Compile the inline functions for GPU
 add_linear_gather_for_mode = cuda.jit( add_linear_gather_for_mode,
-                                        device=True, inline=True )
+                                        device=True, inline=False )
 add_cubic_gather_for_mode = cuda.jit( add_cubic_gather_for_mode,
-                                        device=True, inline=True )
+                                        device=True, inline=False )
 
 @compile_cupy
 def erase_eb_cuda( Ex, Ey, Ez, Bx, By, Bz, Ntot ):

--- a/fbpic/particles/push/cuda_methods.py
+++ b/fbpic/particles/push/cuda_methods.py
@@ -11,7 +11,7 @@ from fbpic.utils.cuda import compile_cupy
 # Import inline function
 from .inline_functions import push_p_vay
 # Compile the inline function for GPU
-push_p_vay = cuda.jit( push_p_vay, device=True, inline=True )
+push_p_vay = cuda.jit( push_p_vay, device=True, inline=False )
 
 @compile_cupy
 def push_x_gpu( x, y, z, ux, uy, uz, inv_gamma, dt,

--- a/fbpic/particles/spin/cuda_methods.py
+++ b/fbpic/particles/spin/cuda_methods.py
@@ -16,12 +16,12 @@ from .inline_functions import push_s_BMT, copy_ionized_electron_spin_batch
 from .cuda_numba_utils import random_point_sphere_gpu
 
 # Compile the inline function for GPU
-push_s_BMT = cuda.jit( push_s_BMT, device=True, inline=True )
+push_s_BMT = cuda.jit( push_s_BMT, device=True, inline=False )
 copy_ionized_electron_spin_batch = \
     cuda.jit(copy_ionized_electron_spin_batch, device=True, 
-             inline=True)
+             inline=False)
 random_point_sphere_gpu = cuda.jit(random_point_sphere_gpu, 
-                                   device=True, inline=True)
+                                   device=True, inline=False)
 
 @compile_cupy
 def push_s_gpu(sx, sy, sz, ux_prev, uy_prev, uz_prev, ux, uy, uz,


### PR DESCRIPTION
This PR implements a workaround by Frank Schlunzen (DESY IT support) to make `FBPIC` compatible with the new CUDA 13 drivers.
Check the issue here: https://github.com/fbpic/fbpic/issues/729
 