### PR TITLE
Remove \\ from math formulas

### DIFF
--- a/fbpic/lpa_utils/laser/laser.py
+++ b/fbpic/lpa_utils/laser/laser.py
@@ -123,11 +123,11 @@ def add_laser( sim, a0, w0, ctau, z0, zf=None, lambda0=0.8e-6,
 
     .. math::
 
-        E(\\boldsymbol{x},t) = a_0\\times E_0\,
-        \exp\left( -\\frac{r^2}{w_0^2} - \\frac{(z-z_0-ct)^2}{c^2\\tau^2} \\right)
+        E(\boldsymbol{x},t) = a_0\times E_0\,
+        \exp\left( -\frac{r^2}{w_0^2} - \frac{(z-z_0-ct)^2}{c^2\tau^2} \right)
         \cos[ k_0( z - z_0 - ct ) - \phi_{cep} ]
 
-    where :math:`k_0 = 2\pi/\\lambda_0` is the wavevector and where
+    where :math:`k_0 = 2\pi/\lambda_0` is the wavevector and where
     :math:`E_0 = m_e c^2 k_0 / q_e` is the field amplitude for :math:`a_0=1`.
 
     .. note::
@@ -156,7 +156,7 @@ def add_laser( sim, a0, w0, ctau, z0, zf=None, lambda0=0.8e-6,
 
     ctau: float (in meter)
         The duration of the laser (in the lab frame),
-        defined as :math:`c\\tau` in the above formula.
+        defined as :math:`c\tau` in the above formula.
 
     z0: float (in meter)
         The initial position of the centroid of the laser
@@ -172,7 +172,7 @@ def add_laser( sim, a0, w0, ctau, z0, zf=None, lambda0=0.8e-6,
 
     lambda0: float (in meter), optional
         The wavelength of the laser (in the lab frame), defined as
-        :math:`\\lambda_0` in the above formula.
+        :math:`\lambda_0` in the above formula.
 
     cep_phase: float (in radian), optional
         The Carrier Enveloppe Phase (CEP), defined as :math:`\phi_{cep}`

--- a/fbpic/lpa_utils/laser/laser_profiles.py
+++ b/fbpic/lpa_utils/laser/laser_profiles.py
@@ -190,11 +190,11 @@ class GaussianLaser( LaserProfile ):
 
         .. math::
 
-            E(\\boldsymbol{x},t) = a_0\\times E_0\,
-            \exp\left( -\\frac{r^2}{w_0^2} - \\frac{(z-z_0-ct)^2}{c^2\\tau^2} \\right)
+            E(\boldsymbol{x},t) = a_0\times E_0\,
+            \exp\left( -\frac{r^2}{w_0^2} - \frac{(z-z_0-ct)^2}{c^2\tau^2} \right)
             \cos[ k_0( z - z_0 - ct ) - \phi_{cep} ]
 
-        where :math:`k_0 = 2\pi/\\lambda_0` is the wavevector and where
+        where :math:`k_0 = 2\pi/\lambda_0` is the wavevector and where
         :math:`E_0 = m_e c^2 k_0 / q_e` is the field amplitude for :math:`a_0=1`.
 
         .. note::
@@ -217,7 +217,7 @@ class GaussianLaser( LaserProfile ):
 
         tau: float (in second)
             The duration of the laser (in the lab frame),
-            defined as :math:`\\tau` in the above formula.
+            defined as :math:`\tau` in the above formula.
 
         z0: float (in meter)
             The initial position of the centroid of the laser
@@ -233,7 +233,7 @@ class GaussianLaser( LaserProfile ):
 
         lambda0: float (in meter), optional
             The wavelength of the laser (in the lab frame), defined as
-            :math:`\\lambda_0` in the above formula.
+            :math:`\lambda_0` in the above formula.
             Default: 0.8 microns (Ti:Sapph laser).
 
         cep_phase: float (in radian), optional
@@ -312,18 +312,18 @@ class LaguerreGaussLaser( LaserProfile ):
 
         .. math::
 
-            E(\\boldsymbol{x},t) = a_0\\times E_0 \, f(r, \\theta) \,
-            \exp\left( -\\frac{r^2}{w_0^2} - \\frac{(z-z_0-ct)^2}{c^2\\tau^2}
-            \\right) \cos[ k_0( z - z_0 - ct ) - \phi_{cep} ]
+            E(\boldsymbol{x},t) = a_0\times E_0 \, f(r, \theta) \,
+            \exp\left( -\frac{r^2}{w_0^2} - \frac{(z-z_0-ct)^2}{c^2\tau^2}
+            \right) \cos[ k_0( z - z_0 - ct ) - \phi_{cep} ]
 
-            \mathrm{with} \qquad f(r, \\theta) =
-            \sqrt{\\frac{p!(2-\delta_{m,0})}{(m+p)!}}
-            \\left( \\frac{\sqrt{2}r}{w_0} \\right)^m
-            L^m_p\\left( \\frac{2 r^2}{w_0^2} \\right)
-            \cos[ m(\\theta - \\theta_0)]
+            \mathrm{with} \qquad f(r, \theta) =
+            \sqrt{\frac{p!(2-\delta_{m,0})}{(m+p)!}}
+            \left( \frac{\sqrt{2}r}{w_0} \right)^m
+            L^m_p\left( \frac{2 r^2}{w_0^2} \right)
+            \cos[ m(\theta - \theta_0)]
 
         where :math:`L^m_p` is a Laguerre polynomial,
-        :math:`k_0 = 2\pi/\\lambda_0` is the wavevector and where
+        :math:`k_0 = 2\pi/\lambda_0` is the wavevector and where
         :math:`E_0 = m_e c^2 k_0 / q_e`.
 
         (For more info, see
@@ -358,12 +358,12 @@ class LaguerreGaussLaser( LaserProfile ):
         m: int (positive)
             The azimuthal order of the pulse.
             (In the transverse plane, the field of the pulse varies as
-            :math:`\cos[m(\\theta-\\theta_0)]`.)
+            :math:`\cos[m(\theta-\theta_0)]`.)
 
         a0: float (dimensionless)
             The amplitude of the pulse, defined so that the total
             energy of the pulse is the same as that of a Gaussian pulse
-            with the same :math:`a_0`, :math:`w_0` and :math:`\\tau`.
+            with the same :math:`a_0`, :math:`w_0` and :math:`\tau`.
             (i.e. The energy of the pulse is independent of ``p`` and ``m``.)
 
         waist: float (in meter)
@@ -372,7 +372,7 @@ class LaguerreGaussLaser( LaserProfile ):
 
         tau: float (in second)
             The duration of the laser (in the lab frame),
-            defined as :math:`\\tau` in the above formula.
+            defined as :math:`\tau` in the above formula.
 
         z0: float (in meter)
             The initial position of the centroid of the laser
@@ -388,7 +388,7 @@ class LaguerreGaussLaser( LaserProfile ):
 
         lambda0: float (in meter), optional
             The wavelength of the laser (in the lab frame), defined as
-            :math:`\\lambda_0` in the above formula.
+            :math:`\lambda_0` in the above formula.
             Default: 0.8 microns (Ti:Sapph laser).
 
         cep_phase: float (in radian), optional
@@ -400,7 +400,7 @@ class LaguerreGaussLaser( LaserProfile ):
             The azimuthal position of (one of) the maxima of intensity, in the
             transverse plane.
             (In the transverse plane, the field of the pulse varies as
-            :math:`\cos[m(\\theta-\\theta_0)]`.)
+            :math:`\cos[m(\theta-\theta_0)]`.)
 
         propagation_direction: int, optional
             Indicates in which direction the laser propagates.
@@ -455,25 +455,25 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
 
         Unlike the :any:`LaguerreGaussLaser` profile, this
         profile has a phase which depends on the azimuthal angle
-        :math:`\\theta` (cork-screw pattern), and an intensity profile which
-        is independent on :math:`\\theta` (donut-like).
+        :math:`\theta` (cork-screw pattern), and an intensity profile which
+        is independent on :math:`\theta` (donut-like).
 
         More precisely, the electric field **near the focal plane**
         is given by:
 
         .. math::
 
-            E(\\boldsymbol{x},t) = a_0\\times E_0 \, f(r) \,
-            \exp\left( -\\frac{r^2}{w_0^2} - \\frac{(z-z_0-ct)^2}{c^2\\tau^2}
-            \\right) \cos[ k_0( z - z_0 - ct ) - m\\theta - \phi_{cep} ]
+            E(\boldsymbol{x},t) = a_0\times E_0 \, f(r) \,
+            \exp\left( -\frac{r^2}{w_0^2} - \frac{(z-z_0-ct)^2}{c^2\tau^2}
+            \right) \cos[ k_0( z - z_0 - ct ) - m\theta - \phi_{cep} ]
 
             \mathrm{with} \qquad f(r) =
-            \sqrt{\\frac{p!}{(|m|+p)!}}
-            \\left( \\frac{\sqrt{2}r}{w_0} \\right)^{|m|}
-            L^{|m|}_p\\left( \\frac{2 r^2}{w_0^2} \\right)
+            \sqrt{\frac{p!}{(|m|+p)!}}
+            \left( \frac{\sqrt{2}r}{w_0} \right)^{|m|}
+            L^{|m|}_p\left( \frac{2 r^2}{w_0^2} \right)
 
         where :math:`L^m_p` is a Laguerre polynomial,
-        :math:`k_0 = 2\pi/\\lambda_0` is the wavevector and where
+        :math:`k_0 = 2\pi/\lambda_0` is the wavevector and where
         :math:`E_0 = m_e c^2 k_0 / q_e`.
 
         (For more info, see
@@ -503,12 +503,12 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
 
         m: int (positive or negative)
             The azimuthal order of the pulse. The laser phase in a given
-            transverse plane varies as :math:`m \\theta`.
+            transverse plane varies as :math:`m \theta`.
 
         a0: float (dimensionless)
             The amplitude of the pulse, defined so that the total
             energy of the pulse is the same as that of a Gaussian pulse
-            with the same :math:`a_0`, :math:`w_0` and :math:`\\tau`.
+            with the same :math:`a_0`, :math:`w_0` and :math:`\tau`.
             (i.e. The energy of the pulse is independent of ``p`` and ``m``.)
 
         waist: float (in meter)
@@ -517,7 +517,7 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
 
         tau: float (in second)
             The duration of the laser (in the lab frame),
-            defined as :math:`\\tau` in the above formula.
+            defined as :math:`\tau` in the above formula.
 
         z0: float (in meter)
             The initial position of the centroid of the laser
@@ -533,7 +533,7 @@ class DonutLikeLaguerreGaussLaser( LaserProfile ):
 
         lambda0: float (in meter), optional
             The wavelength of the laser (in the lab frame), defined as
-            :math:`\\lambda_0` in the above formula.
+            :math:`\lambda_0` in the above formula.
             Default: 0.8 microns (Ti:Sapph laser).
 
         cep_phase: float (in radian), optional
@@ -604,29 +604,29 @@ class FlattenedGaussianLaser( LaserProfile ):
 
         .. math::
 
-            E(\\boldsymbol{x},t)\propto
-            \exp\\left(-\\frac{r^2}{(N+1)w_0^2}\\right)
-            \sum_{n=0}^N c'_n L^0_n\\left(\\frac{2\,r^2}{(N+1)w_0^2}\\right)
+            E(\boldsymbol{x},t)\propto
+            \exp\left(-\frac{r^2}{(N+1)w_0^2}\right)
+            \sum_{n=0}^N c'_n L^0_n\left(\frac{2\,r^2}{(N+1)w_0^2}\right)
 
-            \mathrm{with} \qquad c'_n = \sum_{m=n}^{N}\\frac{1}{2^m}\\binom{m}{n}
+            \mathrm{with} \qquad c'_n = \sum_{m=n}^{N}\frac{1}{2^m}\binom{m}{n}
 
-        - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\\left(-\\frac{r^2}{w_0^2}\\right)`.
+        - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\left(-\frac{r^2}{w_0^2}\right)`.
 
-        - For :math:`N\\rightarrow\infty`, this is a Jinc profile: :math:`E\propto \\frac{J_1(r/w_0)}{r/w_0}`.
+        - For :math:`N\rightarrow\infty`, this is a Jinc profile: :math:`E\propto \frac{J_1(r/w_0)}{r/w_0}`.
 
         The expression **far from focus** is
 
         .. math::
 
-            E(\\boldsymbol{x},t)\propto
-            \exp\\left(-\\frac{(N+1)r^2}{w(z)^2}\\right)
-            \sum_{n=0}^N \\frac{1}{n!}\left(\\frac{(N+1)\,r^2}{w(z)^2}\\right)^n
+            E(\boldsymbol{x},t)\propto
+            \exp\left(-\frac{(N+1)r^2}{w(z)^2}\right)
+            \sum_{n=0}^N \frac{1}{n!}\left(\frac{(N+1)\,r^2}{w(z)^2}\right)^n
 
-            \mathrm{with} \qquad w(z) = \\frac{\lambda_0}{\pi w_0}|z-z_{foc}|
+            \mathrm{with} \qquad w(z) = \frac{\lambda_0}{\pi w_0}|z-z_{foc}|
 
-        - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\\left(-\\frac{r^2}{w_(z)^2}\\right)`.
+        - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\left(-\frac{r^2}{w_(z)^2}\right)`.
 
-        - For :math:`N\\rightarrow\infty`, this is a flat profile: :math:`E\propto \\Theta(w(z)-r)`.
+        - For :math:`N\rightarrow\infty`, this is a flat profile: :math:`E\propto \Theta(w(z)-r)`.
 
         Parameters
         ----------
@@ -720,7 +720,7 @@ class FewCycleLaser( LaserProfile ):
         the standard Gaussian profile :any:`GaussianLaser` is not well-adapted.
         This is because :any:`GaussianLaser` neglects the fact that different
         frequencies focus in different ways. In particular, when initializing
-        a :any:`GaussianLaser` (with a short duration :math:`\\tau`) out of
+        a :any:`GaussianLaser` (with a short duration :math:`\tau`) out of
         focus, the profile at focus will not be the expected one.
 
         Instead, the :any:`FewCycleLaser` profile overcomes this limitation.
@@ -730,12 +730,12 @@ class FewCycleLaser( LaserProfile ):
 
         .. math::
 
-            E(\\boldsymbol{x},t) = Re\\left[ a_0\\times E_0\,
-            e^{i\phi_{cep}} \\frac{i Z_R}{q(z)}
-            \\left( 1 + \\frac{ik_0}{s}\\left(z-z_0-ct+
-            \\frac{r^2}{2q(z)}\\right)\\right)^{-(s+1)} \\right]
+            E(\boldsymbol{x},t) = Re\left[ a_0\times E_0\,
+            e^{i\phi_{cep}} \frac{i Z_R}{q(z)}
+            \left( 1 + \frac{ik_0}{s}\left(z-z_0-ct+
+            \frac{r^2}{2q(z)}\right)\right)^{-(s+1)} \right]
 
-        where :math:`k_0 = 2\pi/\\lambda_0` is the wavevector,
+        where :math:`k_0 = 2\pi/\lambda_0` is the wavevector,
         :math:`E_0 = m_e c^2 k_0 / q_e` is the field amplitude for :math:`a_0=1`,
         :math:`Z_R = k_0 w_0^2/2` is the Rayleigh length,
         :math:`q(z) = z-z_f + iZ_R`, and where :math:`s`
@@ -743,15 +743,15 @@ class FewCycleLaser( LaserProfile ):
 
         .. math::
 
-            \omega_0 \\tau_{FWHM} = s\\sqrt{2(4^{1/(s+1)}-1)}
+            \omega_0 \tau_{FWHM} = s\sqrt{2(4^{1/(s+1)}-1)}
 
         .. note::
 
-            In the case of :math:`\omega_0 \\tau_{FWHM} \gg 1` (i.e. many
+            In the case of :math:`\omega_0 \tau_{FWHM} \gg 1` (i.e. many
             laser cycles within the envelope), the above expression approaches
             that of a standard Gaussian laser pulse, and thus the :any:`FewCycleLaser`
             profile becomes equivalent to the :any:`GaussianLaser` profile
-            (with :math:`\\tau_{FWHM} = \\sqrt{2\\log(2)}\\tau`).
+            (with :math:`\tau_{FWHM} = \sqrt{2\log(2)}\tau`).
 
         Parameters
         ----------
@@ -766,7 +766,7 @@ class FewCycleLaser( LaserProfile ):
 
         tau_FWHM: float (in second)
             The full-width half-maximum duration of the **envelope intensity** (in
-            the lab frame), defined as :math:`\\tau_{FWHM}` in the above formula.
+            the lab frame), defined as :math:`\tau_{FWHM}` in the above formula.
 
         z0: float (in meter)
             The initial position of the centroid of the laser
@@ -782,7 +782,7 @@ class FewCycleLaser( LaserProfile ):
 
         lambda0: float (in meter), optional
             The wavelength of the laser (in the lab frame), defined as
-            :math:`\\lambda_0` in the above formula.
+            :math:`\lambda_0` in the above formula.
             Default: 0.8 microns (Ti:Sapph laser).
 
         cep_phase: float (in radian), optional

--- a/fbpic/lpa_utils/laser/longitudinal_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/longitudinal_laser_profiles.py
@@ -78,7 +78,7 @@ class LaserLongitudinalProfile(object):
 
         .. math::
 
-            \\int_{-\\infty}^\\infty \,dz|f(z)|^2
+            \int_{-\infty}^\infty \,dz|f(z)|^2
 
         Returns:
         --------
@@ -104,10 +104,10 @@ class GaussianChirpedLongitudinalProfile(LaserLongitudinalProfile):
 
         .. math::
 
-            E(z,t) \propto \exp\left( \\frac{(z-z_0-ct)^2}{c^2\\tau^2} \\right)
+            E(z,t) \propto \exp\left( \frac{(z-z_0-ct)^2}{c^2\tau^2} \right)
             \cos[ k_0( z - z_0 - ct ) - \phi_{cep} ]
 
-        where :math:`k_0 = 2\pi/\\lambda_0` is the wavevector, :math:`\\tau`
+        where :math:`k_0 = 2\pi/\lambda_0` is the wavevector, :math:`\tau`
         is the laser duration, :math:`\phi_{cep}` is the CEP phase.
 
         Note that, for a transform-limited pulse, the peak field amplitude of
@@ -118,7 +118,7 @@ class GaussianChirpedLongitudinalProfile(LaserLongitudinalProfile):
         ----------
         tau: float (in second)
             The duration of the laser (in the lab frame),
-            defined as :math:`\\tau` in the above formula.
+            defined as :math:`\tau` in the above formula.
 
         z0: float (in meter)
             The initial position of the centroid of the laser
@@ -126,7 +126,7 @@ class GaussianChirpedLongitudinalProfile(LaserLongitudinalProfile):
 
         lambda0: float (in meter), optional
             The wavelength of the laser (in the lab frame), defined as
-            :math:`\\lambda_0` in the above formula.
+            :math:`\lambda_0` in the above formula.
             Default: 0.8 microns (Ti:Sapph laser).
 
         cep_phase: float (in radian), optional
@@ -214,7 +214,7 @@ class CustomSpectrumLongitudinalProfile(LaserLongitudinalProfile):
         spectral intensity provided in the csv file (as a function of the
         wavelength :math:`\lambda=2\pi/k`). (The fact that the integrand
         is multiplied by :math:`k` in the above formula is because
-        the csv file provides the intensity distribution over wavelengths 
+        the csv file provides the intensity distribution over wavelengths
         :math:`\lambda`, instead of over wavevectors :math:`k`.)
 
         Parameters:

--- a/fbpic/lpa_utils/laser/transverse_laser_profiles.py
+++ b/fbpic/lpa_utils/laser/transverse_laser_profiles.py
@@ -74,7 +74,7 @@ class LaserTransverseProfile(object):
 
         .. math::
 
-            \\int_0^{2\\pi} d\\theta \\int_0^\\infty r \,dr|f(r, \\theta)|^2
+            \int_0^{2\pi} d\theta \int_0^\infty r \,dr|f(r, \theta)|^2
 
         Returns:
         --------
@@ -100,7 +100,7 @@ class GaussianTransverseProfile(LaserTransverseProfile):
 
         .. math::
 
-            E(x,y,z=z_f) \propto \exp\left( -\\frac{r^2}{w_0^2} \\right)
+            E(x,y,z=z_f) \propto \exp\left( -\frac{r^2}{w_0^2} \right)
 
         where :math:`w_0` is the laser waist and :math:`r = \sqrt{x^2 + y^2}`.
 
@@ -119,7 +119,7 @@ class GaussianTransverseProfile(LaserTransverseProfile):
 
         lambda0: float (in meter), optional
             The wavelength of the laser (in the lab frame), defined as
-            :math:`\\lambda_0` in the above formula.
+            :math:`\lambda_0` in the above formula.
             Default: 0.8 microns (Ti:Sapph laser).
 
         propagation_direction: int, optional
@@ -184,20 +184,20 @@ class LaguerreGaussTransverseProfile( LaserTransverseProfile ):
 
         .. math::
 
-            E(x,y,z=zf) \propto \, f(r, \\theta) \,
-            \exp\left( -\\frac{r^2}{w_0^2} )
+            E(x,y,z=zf) \propto \, f(r, \theta) \,
+            \exp\left( -\frac{r^2}{w_0^2} )
 
-            \mathrm{with} \qquad f(r, \\theta) =
-            \sqrt{\\frac{p!(2-\delta_{m,0})}{(m+p)!}}
-            \\left( \\frac{\sqrt{2}r}{w_0} \\right)^m
-            L^m_p\\left( \\frac{2 r^2}{w_0^2} \\right)
-            \cos[ m(\\theta - \\theta_0)]
+            \mathrm{with} \qquad f(r, \theta) =
+            \sqrt{\frac{p!(2-\delta_{m,0})}{(m+p)!}}
+            \left( \frac{\sqrt{2}r}{w_0} \right)^m
+            L^m_p\left( \frac{2 r^2}{w_0^2} \right)
+            \cos[ m(\theta - \theta_0)]
 
         where :math:`L^m_p` is a Laguerre polynomial and :math:`w_0` is the
         laser waist.
 
         Note that, for :math:`p=m=0`, the profile reduces to a Gaussian and the
-        peak field amplitude is unity. For :math:`m \\neq 0`, the peak
+        peak field amplitude is unity. For :math:`m \neq 0`, the peak
         amplitude is reduced, such that the energy of the pulse is independent
         of ``p`` and ``m``.
 
@@ -226,7 +226,7 @@ class LaguerreGaussTransverseProfile( LaserTransverseProfile ):
         m: int (positive)
             The azimuthal order of the pulse.
             (In the transverse plane, the field of the pulse varies as
-            :math:`\cos[m(\\theta-\\theta_0)]`.)
+            :math:`\cos[m(\theta-\theta_0)]`.)
 
         waist: float (in meter)
             Laser waist at the focal plane, defined as :math:`w_0` in the
@@ -238,14 +238,14 @@ class LaguerreGaussTransverseProfile( LaserTransverseProfile ):
 
         lambda0: float (in meter), optional
             The wavelength of the laser (in the lab frame), defined as
-            :math:`\\lambda_0` in the above formula.
+            :math:`\lambda_0` in the above formula.
             Default: 0.8 microns (Ti:Sapph laser).
 
         theta0: float (in radian), optional
             The azimuthal position of (one of) the maxima of intensity, in the
             transverse plane.
             (In the transverse plane, the field of the pulse varies as
-            :math:`\cos[m(\\theta-\\theta_0)]`.)
+            :math:`\cos[m(\theta-\theta_0)]`.)
 
         propagation_direction: int, optional
             Indicates in which direction the laser propagates.
@@ -321,8 +321,8 @@ class DonutLikeLaguerreGaussTransverseProfile( LaserTransverseProfile ):
 
         Unlike the :any:`LaguerreGaussLaser` profile, this
         profile has a phase which depends on the azimuthal angle
-        :math:`\\theta` (cork-screw pattern), and an intensity profile which
-        is independent on :math:`\\theta` (donut-like).
+        :math:`\theta` (cork-screw pattern), and an intensity profile which
+        is independent on :math:`\theta` (donut-like).
 
         **In the focal plane** (:math:`z=z_f`), the profile translates to a
         laser with a transverse electric field:
@@ -330,13 +330,13 @@ class DonutLikeLaguerreGaussTransverseProfile( LaserTransverseProfile ):
         .. math::
 
             E(x,y,z=zf) \propto \, \, f(r) \,
-            \exp\left( -\\frac{r^2}{w_0^2} \\right) \,
-            \exp\left( -i m\\theta \\right)
+            \exp\left( -\frac{r^2}{w_0^2} \right) \,
+            \exp\left( -i m\theta \right)
 
             \mathrm{with} \qquad f(r) =
-            \sqrt{\\frac{p!}{(|m|+p)!}}
-            \\left( \\frac{\sqrt{2}r}{w_0} \\right)^{|m|}
-            L^{|m|}_p\\left( \\frac{2 r^2}{w_0^2} \\right)
+            \sqrt{\frac{p!}{(|m|+p)!}}
+            \left( \frac{\sqrt{2}r}{w_0} \right)^{|m|}
+            L^{|m|}_p\left( \frac{2 r^2}{w_0^2} \right)
 
         where :math:`L^m_p` is a Laguerre polynomial and :math:`w_0` is the
         laser waist.
@@ -361,7 +361,7 @@ class DonutLikeLaguerreGaussTransverseProfile( LaserTransverseProfile ):
 
         m: int (positive or negative)
             The azimuthal order of the pulse. The laser phase in a given
-            transverse plane varies as :math:`m \\theta`.
+            transverse plane varies as :math:`m \theta`.
 
         waist: float (in meter)
             Laser waist at the focal plane, defined as :math:`w_0` in the
@@ -373,7 +373,7 @@ class DonutLikeLaguerreGaussTransverseProfile( LaserTransverseProfile ):
 
         lambda0: float (in meter), optional
             The wavelength of the laser (in the lab frame), defined as
-            :math:`\\lambda_0` in the above formula.
+            :math:`\lambda_0` in the above formula.
             Default: 0.8 microns (Ti:Sapph laser).
 
         propagation_direction: int, optional
@@ -453,29 +453,29 @@ class FlattenedGaussianTransverseProfile( LaserTransverseProfile ):
         .. math::
 
             E(x,y,z=zf) \propto
-            \exp\\left(-\\frac{r^2}{(N+1)w_0^2}\\right)
-            \sum_{n=0}^N c'_n L^0_n\\left(\\frac{2\,r^2}{(N+1)w_0^2}\\right)
+            \exp\left(-\frac{r^2}{(N+1)w_0^2}\right)
+            \sum_{n=0}^N c'_n L^0_n\left(\frac{2\,r^2}{(N+1)w_0^2}\right)
 
             \mathrm{with} Laguerre polynomials :math:`L^0_n` and
-            \qquad c'_n = \sum_{m=n}^{N}\\frac{1}{2^m}\\binom{m}{n}
+            \qquad c'_n = \sum_{m=n}^{N}\frac{1}{2^m}\binom{m}{n}
 
-        - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\\left(-\\frac{r^2}{w_0^2}\\right)`.
+        - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\left(-\frac{r^2}{w_0^2}\right)`.
 
-        - For :math:`N\\rightarrow\infty`, this is a Jinc profile: :math:`E\propto \\frac{J_1(r/w_0)}{r/w_0}`.
+        - For :math:`N\rightarrow\infty`, this is a Jinc profile: :math:`E\propto \frac{J_1(r/w_0)}{r/w_0}`.
 
         The equivalent expression **far from focus** is
 
         .. math::
 
             E(x,y,z=\infty) \propto
-            \exp\\left(-\\frac{(N+1)r^2}{w(z)^2}\\right)
-            \sum_{n=0}^N \\frac{1}{n!}\left(\\frac{(N+1)\,r^2}{w(z)^2}\\right)^n
+            \exp\left(-\frac{(N+1)r^2}{w(z)^2}\right)
+            \sum_{n=0}^N \frac{1}{n!}\left(\frac{(N+1)\,r^2}{w(z)^2}\right)^n
 
-            \mathrm{with} \qquad w(z) = \\frac{\lambda_0}{\pi w_0}|z-z_{foc}|
+            \mathrm{with} \qquad w(z) = \frac{\lambda_0}{\pi w_0}|z-z_{foc}|
 
-        - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\\left(-\\frac{r^2}{w_(z)^2}\\right)`.
+        - For :math:`N=0`, this is a Gaussian profile: :math:`E\propto\exp\left(-\frac{r^2}{w_(z)^2}\right)`.
 
-        - For :math:`N\\rightarrow\infty`, this is a flat profile: :math:`E\propto \\Theta(w(z)-r)`.
+        - For :math:`N\rightarrow\infty`, this is a flat profile: :math:`E\propto \Theta(w(z)-r)`.
 
         Parameters
         ----------

--- a/fbpic/particles/particles.py
+++ b/fbpic/particles/particles.py
@@ -563,29 +563,29 @@ class Particles(object) :
         vector throughout the simulation.
 
         .. math::
-            \\frac{d\\boldsymbol{s}}{dt} = (\\boldsymbol{\\Omega}_T +
-             \\boldsymbol{\\Omega}_a) \\times \\boldsymbol{s}
+            \frac{d\boldsymbol{s}}{dt} = (\boldsymbol{\Omega}_T +
+             \boldsymbol{\Omega}_a) \times \boldsymbol{s}
 
         where
 
         .. math::
-            \\boldsymbol{\\Omega}_T = \\frac{q}{m}\\left(
-                 \\frac{\\boldsymbol{B}}{\\gamma} -
-                 \\frac{\\boldsymbol{B}}{1+\\gamma}
-                 \\times \\frac{\\boldsymbol{E}}{c} \\right)
+            \boldsymbol{\Omega}_T = \frac{q}{m}\left(
+                 \frac{\boldsymbol{B}}{\gamma} -
+                 \frac{\boldsymbol{B}}{1+\gamma}
+                 \times \frac{\boldsymbol{E}}{c} \right)
 
         and
 
         .. math::
-            \\boldsymbol{\\Omega}_a = a_e \\frac{q}{m}\\left(
-                 \\boldsymbol{B} -
-                 \\frac{\\gamma}{1+\\gamma}\\boldsymbol{\\beta}
-                 (\\boldsymbol{\\beta}\\cdot\\boldsymbol{B}) -
-                 \\boldsymbol{\\beta} \\times \\frac{\\boldsymbol{E}}{c} \\right)
+            \boldsymbol{\Omega}_a = a_e \frac{q}{m}\left(
+                 \boldsymbol{B} -
+                 \frac{\gamma}{1+\gamma}\boldsymbol{\beta}
+                 (\boldsymbol{\beta}\cdot\boldsymbol{B}) -
+                 \boldsymbol{\beta} \times \frac{\boldsymbol{E}}{c} \right)
 
         Here, :math:`a_e` is the anomalous magnetic moment of the particle,
-        :math:`\\gamma` is the Lorentz factor of the particle,
-        :math:`\\boldsymbol{\\beta}=\\boldsymbol{v}/c` is the normalised velocity
+        :math:`\gamma` is the Lorentz factor of the particle,
+        :math:`\boldsymbol{\beta}=\boldsymbol{v}/c` is the normalised velocity
 
         The implementation of the push algorithm is detailed in
         https://arxiv.org/abs/2303.16966.

--- a/fbpic/particles/spin/spin_tracker.py
+++ b/fbpic/particles/spin/spin_tracker.py
@@ -35,29 +35,29 @@ class SpinTracker(object):
         axis specified by the user (see spin_distr below).
 
         .. math::
-            \\frac{d\\boldsymbol{s}}{dt} = (\\boldsymbol{\\Omega}_T +
-             \\boldsymbol{\\Omega}_a) \\times \\boldsymbol{s}
+            \frac{d\boldsymbol{s}}{dt} = (\boldsymbol{\Omega}_T +
+             \boldsymbol{\Omega}_a) \times \boldsymbol{s}
 
         where
 
         .. math::
-            \\boldsymbol{\\Omega}_T = \\frac{q}{m}\\left(
-                 \\frac{\\boldsymbol{B}}{\\gamma} -
-                 \\frac{\\boldsymbol{B}}{1+\\gamma}
-                 \\times \\frac{\\boldsymbol{E}}{c} \\right)
+            \boldsymbol{\Omega}_T = \frac{q}{m}\left(
+                 \frac{\boldsymbol{B}}{\gamma} -
+                 \frac{\boldsymbol{B}}{1+\gamma}
+                 \times \frac{\boldsymbol{E}}{c} \right)
 
         and
 
         .. math::
-            \\boldsymbol{\\Omega}_a = a_e \\frac{q}{m}\\left(
-                 \\boldsymbol{B} -
-                 \\frac{\\gamma}{1+\\gamma}\\boldsymbol{\\beta}
-                 (\\boldsymbol{\\beta}\\cdot\\boldsymbol{B}) -
-                 \\boldsymbol{\\beta} \\times \\frac{\\boldsymbol{E}}{c} \\right)
+            \boldsymbol{\Omega}_a = a_e \frac{q}{m}\left(
+                 \boldsymbol{B} -
+                 \frac{\gamma}{1+\gamma}\boldsymbol{\beta}
+                 (\boldsymbol{\beta}\cdot\boldsymbol{B}) -
+                 \boldsymbol{\beta} \times \frac{\boldsymbol{E}}{c} \right)
 
         Here, :math:`a_e` is the anomalous magnetic moment of the particle,
-        :math:`\\gamma` is the Lorentz factor of the particle,
-        :math:`\\boldsymbol{\\beta}=\\boldsymbol{v}/c` is the normalised velocity
+        :math:`\gamma` is the Lorentz factor of the particle,
+        :math:`\boldsymbol{\beta}=\boldsymbol{v}/c` is the normalised velocity
 
         The implementation of the push algorithm is detailed in
         https://arxiv.org/abs/2303.16966.
@@ -138,7 +138,7 @@ class SpinTracker(object):
         """
         Store the momenta at the previous half timestep, ie at
         t = (n-1/2) dt
-        
+
         Parameters
         ----------
         species: an fbpic.Species object
@@ -167,7 +167,7 @@ class SpinTracker(object):
         self.Bx, self.By, self.Bz,                          n
         self.x, self.y, self.z                              n
         self.ux, self.uy, self.uz                           n+1/2
-        
+
         Parameters
         ----------
         species: an fbpic.Species object


### PR DESCRIPTION
I think that the character `\\` was added because of some formatting error in the past, but this no longer seems needed, and in fact it interferes with Sphinx as noted by @hightower8083 