### PR TITLE
Fix typo sampling of Klein-Nishina formula and repair CI

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         export NUMBA_THREADING_LAYER=omp
         export MKL_NUM_THREADS=2
-        export NUMBA_NUM_THREADS=2
+        export OPENPMD_VERIFY_HOMOGENEOUS_EXTENTS=0
         python -m pytest tests --ignore=tests/unautomated
     - shell: bash -eo pipefail -l {0}
       name: PICMI test

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -32,7 +32,7 @@ jobs:
     - shell: bash -eo pipefail -l {0}
       name: Install dependencies
       run: |
-        conda install --yes -c conda-forge numba scipy h5py mkl mpich mpi4py matplotlib python=${{ matrix.python-version }}
+        conda install --yes -c conda-forge numba scipy h5py mkl mpich mpi4py matplotlib python=${{ matrix.python-version }} pip
         pip install openPMD-viewer pytest pyflakes lasy
         python -m pip install .
 

--- a/fbpic/particles/elementary_process/compton/cuda_methods.py
+++ b/fbpic/particles/elementary_process/compton/cuda_methods.py
@@ -179,7 +179,7 @@ def scatter_photons_electrons_cuda(
                 k = photon_rest_p * INV_MC
                 c0 = 2.*(2.*k**2 + 2.*k + 1.)/(2.*k + 1.)**3
                 b = (2. + c0)/(2. - c0)
-                a = 2.*b - 1.
+                a = 2.*(b - 1.)
                 # Use rejection method to draw x
                 reject = True
                 while reject:

--- a/fbpic/particles/elementary_process/compton/numba_methods.py
+++ b/fbpic/particles/elementary_process/compton/numba_methods.py
@@ -184,7 +184,7 @@ def scatter_photons_electrons_numba(
                 k = photon_rest_p * INV_MC
                 c0 = 2.*(2.*k**2 + 2.*k + 1.)/(2.*k + 1.)**3
                 b = (2. + c0)/(2. - c0)
-                a = 2.*b - 1.
+                a = 2.*(b - 1.)
                 # Use rejection method to draw x
                 reject = True
                 while reject:

--- a/tests/test_spin_restart.py
+++ b/tests/test_spin_restart.py
@@ -205,8 +205,8 @@ def compare_spin_vectors(ts1, ts2, checked_species):
                 # Get the same IDs
                 ids = s1[1] if len(s1[0]) < len(s2[0]) else s2[1]
 
-                s1_common = s1[0][np.in1d(s1[1], ids)]
-                s2_common = s2[0][np.in1d(s2[1], ids)]
+                s1_common = s1[0][np.isin(s1[1], ids)]
+                s2_common = s2[0][np.isin(s2[1], ids)]
                 assert np.allclose(s1_common, s2_common, atol=tolerance)
 
 


### PR DESCRIPTION
The formula published in Ozmutlu, E. N. "Sampling of Angular Distribution in Compton Scattering" Appl. Radiat. Isot. 43, 6, pp. 713-715 (1992) is:
$a(k) = 2[b(k) - 1]$

This affects the efficiency (but not the accuracy) of this rejection sampling method.

<img width="1098" height="796" alt="Screenshot 2026-07-07 at 8 42 37 PM" src="https://github.com/user-attachments/assets/862d2c74-e475-4050-8eae-f42b07716e98" />


(See also https://github.com/BLAST-WarpX/warpx/pull/7029)

This PR also fixes a few CI issues.